### PR TITLE
Feature/31/add form styles to styled folder

### DIFF
--- a/mrtt-ui/src/components/ProjectDetailsForm.js
+++ b/mrtt-ui/src/components/ProjectDetailsForm.js
@@ -18,7 +18,7 @@ import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider'
 import { MobileDatePicker } from '@mui/x-date-pickers/MobileDatePicker'
 import Autocomplete from '@mui/material/Autocomplete'
 
-import { ProjectDetailsFormDiv, FormGroupDiv } from '../styles/forms'
+import { MainFormDiv, FormQuestionDiv } from '../styles/forms'
 import countries from '../data/countries.json'
 import { questionMapping } from '../data/questionMapping'
 
@@ -79,13 +79,13 @@ const ProjectDetailsForm = () => {
   }
 
   return (
-    <ProjectDetailsFormDiv>
+    <MainFormDiv>
       <Typography variant='h4' sx={{ marginBottom: '0.5em' }}>
         Project Details Form
       </Typography>
       <form onSubmit={handleSubmit(onSubmit)}>
         {/* Has project end date radio group */}
-        <FormGroupDiv>
+        <FormQuestionDiv>
           <FormLabel>1.1a Does the project have an end date?</FormLabel>
           <Controller
             name='hasProjectEndDate'
@@ -101,9 +101,9 @@ const ProjectDetailsForm = () => {
               </RadioGroup>
             )}
           />
-        </FormGroupDiv>
+        </FormQuestionDiv>
         {/* Start Date */}
-        <FormGroupDiv>
+        <FormQuestionDiv>
           <FormLabel>Project Duration</FormLabel>
           <FormLabel>1.1b</FormLabel>
           <Controller
@@ -128,10 +128,10 @@ const ProjectDetailsForm = () => {
           <Typography variant='subtitle' sx={{ color: 'red' }}>
             {errors.projectStartDate?.message}
           </Typography>
-        </FormGroupDiv>
+        </FormQuestionDiv>
         {/* End Date */}
         {watchHasProjectEndDate === 'true' && (
-          <FormGroupDiv>
+          <FormQuestionDiv>
             <FormLabel>1.1c</FormLabel>
             <Controller
               name='projectEndDate'
@@ -154,10 +154,10 @@ const ProjectDetailsForm = () => {
             <Typography variant='subtitle' sx={{ color: 'red' }}>
               {errors.projectEndDate?.message}
             </Typography>
-          </FormGroupDiv>
+          </FormQuestionDiv>
         )}
         {/* Countries selector */}
-        <FormGroupDiv>
+        <FormQuestionDiv>
           <FormLabel>1.2 What country/countries is the site located in?</FormLabel>
           <Controller
             name='countries'
@@ -180,11 +180,11 @@ const ProjectDetailsForm = () => {
           <Typography variant='subtitle' sx={{ color: 'red' }}>
             {errors.countries?.message}
           </Typography>
-        </FormGroupDiv>
+        </FormQuestionDiv>
         {/* Draw Pologon - TO BE INSERTED */}
-        <FormGroupDiv>
+        <FormQuestionDiv>
           <FormLabel>1.3 What is the overall site area?</FormLabel>
-        </FormGroupDiv>
+        </FormQuestionDiv>
         {isError && (
           <Typography variant='subtitle' sx={{ color: 'red' }}>
             Submit failed, please try again
@@ -194,7 +194,7 @@ const ProjectDetailsForm = () => {
           {isSubmitting ? 'Submitting...' : 'Submit'}
         </Button>
       </form>
-    </ProjectDetailsFormDiv>
+    </MainFormDiv>
   )
 }
 

--- a/mrtt-ui/src/components/ProjectDetailsForm.js
+++ b/mrtt-ui/src/components/ProjectDetailsForm.js
@@ -18,7 +18,7 @@ import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider'
 import { MobileDatePicker } from '@mui/x-date-pickers/MobileDatePicker'
 import Autocomplete from '@mui/material/Autocomplete'
 
-import { styled } from '@mui/material/styles'
+import { ProjectDetailsFormDiv, FormGroupDiv } from '../styles/forms'
 import countries from '../data/countries.json'
 import { questionMapping } from '../data/questionMapping'
 
@@ -197,22 +197,5 @@ const ProjectDetailsForm = () => {
     </ProjectDetailsFormDiv>
   )
 }
-
-// Styles
-
-const ProjectDetailsFormDiv = styled('div')(() => ({
-  display: 'flex',
-  flexDirection: 'column',
-  justifyContent: 'center',
-  alignItems: 'center',
-  margin: '1.5em'
-}))
-
-const FormGroupDiv = styled('div')(() => ({
-  display: 'flex',
-  flexDirection: 'column',
-  marginBottom: '1em',
-  marginTop: '2em'
-}))
 
 export default ProjectDetailsForm

--- a/mrtt-ui/src/components/SiteBackgroundForm.js
+++ b/mrtt-ui/src/components/SiteBackgroundForm.js
@@ -1,7 +1,0 @@
-import React from 'react'
-
-const ProjectDetailsForm = () => {
-  return <div className='project-details-form'></div>
-}
-
-export default ProjectDetailsForm

--- a/mrtt-ui/src/components/SiteBackgroundForm.js
+++ b/mrtt-ui/src/components/SiteBackgroundForm.js
@@ -1,0 +1,7 @@
+import React from 'react'
+
+const ProjectDetailsForm = () => {
+  return <div className='project-details-form'></div>
+}
+
+export default ProjectDetailsForm

--- a/mrtt-ui/src/styles/forms.js
+++ b/mrtt-ui/src/styles/forms.js
@@ -1,0 +1,16 @@
+import { styled } from '@mui/material/styles'
+
+export const ProjectDetailsFormDiv = styled('div')(() => ({
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'center',
+  alignItems: 'center',
+  margin: '1.5em'
+}))
+
+export const FormGroupDiv = styled('div')(() => ({
+  display: 'flex',
+  flexDirection: 'column',
+  marginBottom: '1em',
+  marginTop: '2em'
+}))

--- a/mrtt-ui/src/styles/forms.js
+++ b/mrtt-ui/src/styles/forms.js
@@ -1,6 +1,6 @@
 import { styled } from '@mui/material/styles'
 
-export const ProjectDetailsFormDiv = styled('div')(() => ({
+export const MainFormDiv = styled('div')(() => ({
   display: 'flex',
   flexDirection: 'column',
   justifyContent: 'center',
@@ -8,7 +8,7 @@ export const ProjectDetailsFormDiv = styled('div')(() => ({
   margin: '1.5em'
 }))
 
-export const FormGroupDiv = styled('div')(() => ({
+export const FormQuestionDiv = styled('div')(() => ({
   display: 'flex',
   flexDirection: 'column',
   marginBottom: '1em',


### PR DESCRIPTION
# Description

Just a style clean up - should have added this in the previous Style Guidelines PR.

I created a `form.js` file in the styles folder, with two generic divs form form styling to be used in each form. These were also removed from the ProjectDetailsForm, so they can be reused.

Fixes # ([31](https://github.com/globalmangrovewatch/gmw-users/issues/31))

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Instructions

Load page to ensure styling still looks the same/there are no errors

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
