### PR TITLE
[47] feat: submit section 3 form to API, made language file for reuse, made reusable ErrorText component

### DIFF
--- a/mrtt-ui/.eslintrc.js
+++ b/mrtt-ui/.eslintrc.js
@@ -16,6 +16,14 @@ module.exports = {
   plugins: ['react', 'react-hooks'],
   rules: {
     'react/react-in-jsx-scope': 'off',
-    'prettier/prettier': ['error', { jsxSingleQuote: true }]
-  }
+    'prettier/prettier': ['error', { jsxSingleQuote: true }],
+    'no-unused-vars': [
+      'error',
+      {
+        varsIgnorePattern: '^_',
+        argsIgnorePattern: '^_' // ignore unused vars and args that start with _. These vars are unsued, but named for readability/maintainability of code.
+      }
+    ]
+  },
+  settings: { react: { version: 'detect' } }
 }

--- a/mrtt-ui/package.json
+++ b/mrtt-ui/package.json
@@ -34,8 +34,8 @@
     "build": "react-scripts build",
     "test": "react-scripts test  --passWithNoTests",
     "eject": "react-scripts eject",
-    "lint": "eslint ./src/**/*.{js,jsx,tsx,ts}",
-    "lint:fix": "eslint './src/**/*.{js,jsx,tsx,ts}' --fix",
+    "lint": "eslint ./src/**/*.{js,jsx,tsx,ts} --no-error-on-unmatched-pattern",
+    "lint:fix": "eslint './src/**/*.{js,jsx,tsx,ts}' --fix --no-error-on-unmatched-pattern",
     "prettier": "prettier --write './**/*.{js,jsx,ts,tsx,css,md,json}' --config ./.prettierrc"
   },
   "eslintConfig": {

--- a/mrtt-ui/src/App.js
+++ b/mrtt-ui/src/App.js
@@ -1,9 +1,10 @@
-import React from 'react'
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom'
-import Home from './views/Home'
-import ProjectDetailsForm from './components/ProjectDetailsForm'
 import { ThemeProvider } from '@mui/material/styles'
+import Home from './views/Home'
+import React from 'react'
 import theme from './styles/theme'
+import ProjectDetailsForm from './components/ProjectDetailsForm'
+import RestorationAimsForm from './components/RestorationAimsForm/RestorationAimsForm'
 
 function App() {
   return (
@@ -11,12 +12,9 @@ function App() {
       <Router>
         <div className='app'>
           <Routes>
-            <Route
-              path='/'
-              element={[
-                <Home key='1'></Home>,
-                <ProjectDetailsForm key='2'></ProjectDetailsForm>
-              ]}></Route>
+            <Route path='/' element={<Home />} />
+            <Route path='/:siteId/form/project-details' element={<ProjectDetailsForm />} />
+            <Route path='/:siteId/form/restoration-aims' element={<RestorationAimsForm />} />
           </Routes>
         </div>
       </Router>

--- a/mrtt-ui/src/components/ButtonSubmit.js
+++ b/mrtt-ui/src/components/ButtonSubmit.js
@@ -1,0 +1,16 @@
+import { Button } from '@mui/material'
+import PropTypes from 'prop-types'
+
+const ButtonSubmit = ({ isSubmitting }) => {
+  return (
+    <Button sx={{ marginTop: '1em' }} variant='contained' type='submit' disabled={isSubmitting}>
+      {isSubmitting ? 'Submitting...' : 'Submit'}
+    </Button>
+  )
+}
+
+ButtonSubmit.propTypes = {
+  isSubmitting: PropTypes.bool.isRequired
+}
+
+export default ButtonSubmit

--- a/mrtt-ui/src/components/CheckboxGroup.js
+++ b/mrtt-ui/src/components/CheckboxGroup.js
@@ -1,0 +1,61 @@
+import { Checkbox, FormControlLabel, FormGroup } from '@mui/material'
+import PropTypes from 'prop-types'
+import { forwardRef, useEffect, useState } from 'react'
+
+const CheckboxGroup = forwardRef(({ options, value, onChange, onBlur }, ref) => {
+  const [checkboxItems, setCheckboxItems] = useState([])
+
+  const _loadCheckboxItems = useEffect(() => {
+    setCheckboxItems(value)
+  }, [value])
+
+  const handleCheckboxGroupChange = ({ itemValue, event }) => {
+    const updateCheckboxItems = [...checkboxItems]
+    const foundItemIndex = updateCheckboxItems.indexOf(itemValue)
+
+    if (foundItemIndex > -1) {
+      updateCheckboxItems.splice(foundItemIndex, 1)
+    } else {
+      updateCheckboxItems.push(itemValue)
+    }
+
+    setCheckboxItems(updateCheckboxItems)
+    onChange({ selectedItems: updateCheckboxItems, event })
+  }
+
+  const checkboxes = options.map((item) => (
+    <div key={item.value}>
+      <FormControlLabel
+        control={
+          <Checkbox
+            id={item.value}
+            value={item.value}
+            checked={checkboxItems.includes(item.value)}
+            onChange={(event) => handleCheckboxGroupChange({ itemValue: item.value, event })}
+            onBlur={onBlur}
+          />
+        }
+        label={item.label}
+      />
+    </div>
+  ))
+
+  return <FormGroup ref={ref}>{checkboxes}</FormGroup>
+})
+
+CheckboxGroup.displayName = 'Checkbox Group'
+CheckboxGroup.propTypes = {
+  options: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.string,
+      value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+    })
+  ).isRequired,
+  onChange: PropTypes.func.isRequired,
+  onBlur: PropTypes.func,
+  value: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number]))
+}
+
+CheckboxGroup.defaultProps = { onBlur: () => {} }
+
+export default CheckboxGroup

--- a/mrtt-ui/src/components/CheckboxGroupMangroveWithLabel.js
+++ b/mrtt-ui/src/components/CheckboxGroupMangroveWithLabel.js
@@ -1,0 +1,55 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { FormQuestionDiv } from '../styles/forms'
+import { FormLabel } from '@mui/material'
+import { Controller } from 'react-hook-form'
+import CheckboxGroup from './CheckboxGroup'
+
+const CheckboxGroupMangroveWithLabel = ({
+  reactHookFormInstance,
+  options,
+  question,
+  fieldName
+}) => {
+  const { control: formControl, setValue: setFormValue } = reactHookFormInstance
+  const labelId = `${fieldName}-label`
+
+  return (
+    <>
+      <FormQuestionDiv>
+        <FormLabel id={labelId}>{question}</FormLabel>
+      </FormQuestionDiv>
+      <Controller
+        name={fieldName}
+        control={formControl}
+        defaultValue={[]}
+        render={({ field }) => {
+          return (
+            <CheckboxGroup
+              {...field}
+              onChange={({ selectedItems }) => {
+                setFormValue(fieldName, selectedItems)
+              }}
+              options={options}
+              aria-labelledby={labelId}
+            />
+          )
+        }}
+      />
+    </>
+  )
+}
+
+CheckboxGroupMangroveWithLabel.propTypes = {
+  reactHookFormInstance: PropTypes.any.isRequired,
+  question: PropTypes.oneOfType([PropTypes.node, PropTypes.string]).isRequired,
+  options: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.string,
+      value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+    })
+  ).isRequired,
+  fieldName: PropTypes.string.isRequired
+}
+
+export default CheckboxGroupMangroveWithLabel

--- a/mrtt-ui/src/components/FakeSite.js
+++ b/mrtt-ui/src/components/FakeSite.js
@@ -1,0 +1,19 @@
+import { Link, Stack, Typography } from '@mui/material'
+import { Link as LinkReactRouter } from 'react-router-dom'
+import React from 'react'
+
+const FakeSite = () => {
+  return (
+    <Stack>
+      <Typography variant='h4'>Fake Site for Demo</Typography>
+      <Link component={LinkReactRouter} to='/1/form/project-details'>
+        Project Details
+      </Link>
+      <Link component={LinkReactRouter} to='/1/form/restoration-aims'>
+        Restoration Aims
+      </Link>
+    </Stack>
+  )
+}
+
+export default FakeSite

--- a/mrtt-ui/src/components/ProjectDetailsForm.js
+++ b/mrtt-ui/src/components/ProjectDetailsForm.js
@@ -20,7 +20,7 @@ import Autocomplete from '@mui/material/Autocomplete'
 
 import { MainFormDiv, FormQuestionDiv } from '../styles/forms'
 import countries from '../data/countries.json'
-import { questionMapping } from '../data/questionMapping'
+import { mapDataForApi } from '../library/mapDataForApi'
 
 const ProjectDetailsForm = () => {
   // form validation rules
@@ -53,18 +53,12 @@ const ProjectDetailsForm = () => {
   const onSubmit = async (data) => {
     setisSubmitting(true)
     setIsError(false)
-    const preppedData = []
     const url = `${process.env.REACT_APP_API_URL}sites/1/registration_answers`
 
     if (!data) return
 
-    // set up data structure for api
-    for (const [key, value] of Object.entries(data)) {
-      // map question ids with keys
-      if (Object.prototype.hasOwnProperty.call(questionMapping.projectDetails, key)) {
-        preppedData.push({ question_id: questionMapping.projectDetails[key], answer_value: value })
-      }
-    }
+    const preppedData = mapDataForApi('projectDetails', data)
+
     // make axios PUT request
     axios
       .put(url, preppedData)

--- a/mrtt-ui/src/components/ProjectDetailsForm.js
+++ b/mrtt-ui/src/components/ProjectDetailsForm.js
@@ -53,7 +53,7 @@ const ProjectDetailsForm = () => {
   const onSubmit = async (data) => {
     setisSubmitting(true)
     setIsError(false)
-    const url = `${process.env.REACT_APP_API_URL}sites/1/registration_answers`
+    const url = `${process.env.REACT_APP_API_URL}/sites/1/registration_answers`
 
     if (!data) return
 

--- a/mrtt-ui/src/components/ProjectDetailsForm.js
+++ b/mrtt-ui/src/components/ProjectDetailsForm.js
@@ -1,8 +1,3 @@
-import { useState } from 'react'
-import axios from 'axios'
-import { useForm, Controller } from 'react-hook-form'
-import { yupResolver } from '@hookform/resolvers/yup'
-import * as Yup from 'yup'
 import {
   FormControlLabel,
   FormLabel,
@@ -15,12 +10,19 @@ import {
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns'
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider'
 import { MobileDatePicker } from '@mui/x-date-pickers/MobileDatePicker'
+import { useForm, Controller } from 'react-hook-form'
+import { useState } from 'react'
+import { yupResolver } from '@hookform/resolvers/yup'
+import * as Yup from 'yup'
 import Autocomplete from '@mui/material/Autocomplete'
+import axios from 'axios'
 
-import { MainFormDiv, FormQuestionDiv, SectionFormTitle } from '../styles/forms'
 import countries from '../data/countries.json'
 import { mapDataForApi } from '../library/mapDataForApi'
+import { ErrorText } from '../styles/typography'
+import { MainFormDiv, FormQuestionDiv, SectionFormTitle, Form } from '../styles/forms'
 import ButtonSubmit from './ButtonSubmit'
+import language from '../language'
 
 const ProjectDetailsForm = () => {
   // form validation rules
@@ -61,13 +63,14 @@ const ProjectDetailsForm = () => {
 
     // make axios PUT request
     axios
-      .put(url, preppedData)
+      .patch(url, preppedData)
       .then((res) => {
         setIsSubmitting(false)
         console.log(res)
       })
       .catch((error) => {
         setIsError(true)
+        setIsSubmitting(false)
         console.log(error)
       })
   }
@@ -75,7 +78,7 @@ const ProjectDetailsForm = () => {
   return (
     <MainFormDiv>
       <SectionFormTitle>Project Details Form</SectionFormTitle>
-      <form onSubmit={handleSubmit(onSubmit)}>
+      <Form onSubmit={handleSubmit(onSubmit)}>
         {/* Has project end date radio group */}
         <FormQuestionDiv>
           <FormLabel>1.1a Does the project have an end date?</FormLabel>
@@ -177,13 +180,9 @@ const ProjectDetailsForm = () => {
         <FormQuestionDiv>
           <FormLabel>1.3 What is the overall site area?</FormLabel>
         </FormQuestionDiv>
-        {isError && (
-          <Typography variant='subtitle' sx={{ color: 'red' }}>
-            Submit failed, please try again
-          </Typography>
-        )}
+        {isError && <ErrorText>{language.error.submit}</ErrorText>}
         <ButtonSubmit isSubmitting={isSubmitting} />
-      </form>
+      </Form>
     </MainFormDiv>
   )
 }

--- a/mrtt-ui/src/components/ProjectDetailsForm.js
+++ b/mrtt-ui/src/components/ProjectDetailsForm.js
@@ -4,7 +4,6 @@ import { useForm, Controller } from 'react-hook-form'
 import { yupResolver } from '@hookform/resolvers/yup'
 import * as Yup from 'yup'
 import {
-  Button,
   FormControlLabel,
   FormLabel,
   Radio,
@@ -18,9 +17,10 @@ import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider'
 import { MobileDatePicker } from '@mui/x-date-pickers/MobileDatePicker'
 import Autocomplete from '@mui/material/Autocomplete'
 
-import { MainFormDiv, FormQuestionDiv } from '../styles/forms'
+import { MainFormDiv, FormQuestionDiv, SectionFormTitle } from '../styles/forms'
 import countries from '../data/countries.json'
 import { mapDataForApi } from '../library/mapDataForApi'
+import ButtonSubmit from './ButtonSubmit'
 
 const ProjectDetailsForm = () => {
   // form validation rules
@@ -47,11 +47,11 @@ const ProjectDetailsForm = () => {
   const { control, handleSubmit, formState, watch } = useForm(formOptions)
   const { errors } = formState
   const watchHasProjectEndDate = watch('hasProjectEndDate', 'false')
-  const [isSubmitting, setisSubmitting] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
   const [isError, setIsError] = useState(false)
 
   const onSubmit = async (data) => {
-    setisSubmitting(true)
+    setIsSubmitting(true)
     setIsError(false)
     const url = `${process.env.REACT_APP_API_URL}/sites/1/registration_answers`
 
@@ -63,7 +63,7 @@ const ProjectDetailsForm = () => {
     axios
       .put(url, preppedData)
       .then((res) => {
-        setisSubmitting(false)
+        setIsSubmitting(false)
         console.log(res)
       })
       .catch((error) => {
@@ -74,9 +74,7 @@ const ProjectDetailsForm = () => {
 
   return (
     <MainFormDiv>
-      <Typography variant='h4' sx={{ marginBottom: '0.5em' }}>
-        Project Details Form
-      </Typography>
+      <SectionFormTitle>Project Details Form</SectionFormTitle>
       <form onSubmit={handleSubmit(onSubmit)}>
         {/* Has project end date radio group */}
         <FormQuestionDiv>
@@ -184,9 +182,7 @@ const ProjectDetailsForm = () => {
             Submit failed, please try again
           </Typography>
         )}
-        <Button sx={{ marginTop: '1em' }} variant='contained' type='submit' disabled={isSubmitting}>
-          {isSubmitting ? 'Submitting...' : 'Submit'}
-        </Button>
+        <ButtonSubmit isSubmitting={isSubmitting} />
       </form>
     </MainFormDiv>
   )

--- a/mrtt-ui/src/components/RestorationAimsForm/RestorationAimsForm.js
+++ b/mrtt-ui/src/components/RestorationAimsForm/RestorationAimsForm.js
@@ -1,0 +1,66 @@
+import { FormLabel } from '@mui/material'
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { FormQuestionDiv, MainFormDiv, SectionFormTitle } from '../../styles/forms'
+import ButtonSubmit from '../ButtonSubmit'
+import CheckboxGroupMangroveWithLabel from '../CheckboxGroupMangroveWithLabel'
+import restorationAimsQuestionsAndAnswers from './restorationAimsQuestionsAndAnswers'
+
+const RestorationAimsForm = () => {
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const reactHookFormInstance = useForm()
+
+  const { handleSubmit: validateInputs } = reactHookFormInstance
+
+  const handleSubmit = () => {
+    setIsSubmitting(true)
+    // hit api here
+    setIsSubmitting(false)
+  }
+  const generateOptionsObjectFromAnswers = (answers) =>
+    answers.map((answer) => ({
+      label: answer,
+      value: answer
+    }))
+  const ecologicalAimsOptions = generateOptionsObjectFromAnswers(
+    restorationAimsQuestionsAndAnswers[1].answers
+  )
+  const socioEconomicAimsOptions = generateOptionsObjectFromAnswers(
+    restorationAimsQuestionsAndAnswers[2].answers
+  )
+  const otherAimsOptions = generateOptionsObjectFromAnswers(
+    restorationAimsQuestionsAndAnswers[3].answers
+  )
+  return (
+    <MainFormDiv>
+      <SectionFormTitle>Restoration Aims</SectionFormTitle>
+      <form onSubmit={validateInputs(handleSubmit)}>
+        <CheckboxGroupMangroveWithLabel
+          fieldName='ecologicalAims'
+          reactHookFormInstance={reactHookFormInstance}
+          options={ecologicalAimsOptions}
+          question={restorationAimsQuestionsAndAnswers[1].question}
+        />
+        <CheckboxGroupMangroveWithLabel
+          fieldName='socioEconomicAims'
+          reactHookFormInstance={reactHookFormInstance}
+          options={socioEconomicAimsOptions}
+          question={restorationAimsQuestionsAndAnswers[2].question}
+        />
+        <CheckboxGroupMangroveWithLabel
+          fieldName='otherAims'
+          reactHookFormInstance={reactHookFormInstance}
+          options={otherAimsOptions}
+          question={restorationAimsQuestionsAndAnswers[3].question}
+        />
+        <FormQuestionDiv>
+          <FormLabel>{restorationAimsQuestionsAndAnswers[4].question}</FormLabel>
+        </FormQuestionDiv>
+        <div>Question 3.4 is complicated and will be built in a later ticket (#41)</div>
+        <ButtonSubmit isSubmitting={isSubmitting} />
+      </form>
+    </MainFormDiv>
+  )
+}
+
+export default RestorationAimsForm

--- a/mrtt-ui/src/components/RestorationAimsForm/RestorationAimsForm.js
+++ b/mrtt-ui/src/components/RestorationAimsForm/RestorationAimsForm.js
@@ -1,21 +1,46 @@
 import { FormLabel } from '@mui/material'
-import { useState } from 'react'
 import { useForm } from 'react-hook-form'
-import { FormQuestionDiv, MainFormDiv, SectionFormTitle } from '../../styles/forms'
+import { useState } from 'react'
+import axios from 'axios'
+
+import { ErrorText } from '../../styles/typography'
+import { Form, FormQuestionDiv, MainFormDiv, SectionFormTitle } from '../../styles/forms'
 import ButtonSubmit from '../ButtonSubmit'
 import CheckboxGroupMangroveWithLabel from '../CheckboxGroupMangroveWithLabel'
+import language from '../../language'
 import restorationAimsQuestionsAndAnswers from './restorationAimsQuestionsAndAnswers'
 
-const RestorationAimsForm = () => {
-  const [isSubmitting, setIsSubmitting] = useState(false)
-  const reactHookFormInstance = useForm()
+const formatFormDataForApi = (formData) =>
+  Object.entries(formData).map((formField) => {
+    const formAnswers = formField[1].map((formAnswer) => ({ choice: formAnswer }))
 
+    return {
+      question_id: `Q3.${formField[0]}`,
+      answer_value: formAnswers
+    }
+  })
+
+const submitUrl = `${process.env.REACT_APP_API_URL}sites/1/registration_answers`
+
+const RestorationAimsForm = () => {
+  const [isSubmitError, setIsSubmitError] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const reactHookFormInstance = useForm()
   const { handleSubmit: validateInputs } = reactHookFormInstance
 
-  const handleSubmit = () => {
+  const handleSubmit = (formData) => {
     setIsSubmitting(true)
-    // hit api here
-    setIsSubmitting(false)
+    setIsSubmitError(false)
+    axios
+      .patch(submitUrl, formatFormDataForApi(formData))
+      .then(() => {
+        setIsSubmitting(false)
+      })
+      .catch(() => {
+        setIsSubmitting(false)
+        setIsSubmitError(true)
+      })
   }
   const generateOptionsObjectFromAnswers = (answers) =>
     answers.map((answer) => ({
@@ -34,21 +59,21 @@ const RestorationAimsForm = () => {
   return (
     <MainFormDiv>
       <SectionFormTitle>Restoration Aims</SectionFormTitle>
-      <form onSubmit={validateInputs(handleSubmit)}>
+      <Form onSubmit={validateInputs(handleSubmit)}>
         <CheckboxGroupMangroveWithLabel
-          fieldName='ecologicalAims'
+          fieldName='1'
           reactHookFormInstance={reactHookFormInstance}
           options={ecologicalAimsOptions}
           question={restorationAimsQuestionsAndAnswers[1].question}
         />
         <CheckboxGroupMangroveWithLabel
-          fieldName='socioEconomicAims'
+          fieldName='2'
           reactHookFormInstance={reactHookFormInstance}
           options={socioEconomicAimsOptions}
           question={restorationAimsQuestionsAndAnswers[2].question}
         />
         <CheckboxGroupMangroveWithLabel
-          fieldName='otherAims'
+          fieldName='3'
           reactHookFormInstance={reactHookFormInstance}
           options={otherAimsOptions}
           question={restorationAimsQuestionsAndAnswers[3].question}
@@ -57,8 +82,9 @@ const RestorationAimsForm = () => {
           <FormLabel>{restorationAimsQuestionsAndAnswers[4].question}</FormLabel>
         </FormQuestionDiv>
         <div>Question 3.4 is complicated and will be built in a later ticket (#41)</div>
+        {isSubmitError && <ErrorText>{language.error.submit}</ErrorText>}
         <ButtonSubmit isSubmitting={isSubmitting} />
-      </form>
+      </Form>
     </MainFormDiv>
   )
 }

--- a/mrtt-ui/src/components/RestorationAimsForm/restorationAimsQuestionsAndAnswers.js
+++ b/mrtt-ui/src/components/RestorationAimsForm/restorationAimsQuestionsAndAnswers.js
@@ -1,0 +1,67 @@
+export default {
+  1: {
+    question: '3 .1 What are the ecological aim(s) of the project activities at the site?',
+    answers: [
+      'Increase mangrove area',
+      'Improve mangrove condition/halt or reduce degradation',
+      'Increase mangrove species richness',
+      'Offset mangrove loss from another area',
+      'Habitat protection',
+      'Increase native fauna/wildlife',
+      'Increase native flora/vegetation (non-mangrove)',
+      'Reduce invasive species',
+      'Increase ecological resilience',
+      'Increase habitat connectivity',
+      'Restore hydrological connectivity',
+      'Improve sediment dynamics',
+      'Improve nutrient cycling',
+      'Increase carbon storage and sequestration',
+      'None',
+      'Unknown',
+      'Other'
+    ]
+  },
+  2: {
+    question: '3.2 What are the socio-economic aim(s) of project activities at the site?',
+    answers: [
+      'Enhance fisheries/restore fishing grounds',
+      'Provide sustainable timber resources',
+      'Provide sustainable non-timber products ',
+      'Improve water quality',
+      'Prevent or ameliorate pollution',
+      'Coastal storm or flood protection',
+      'Erosion control or coastal stability',
+      'Carbon offsets/trading',
+      'Tourism and recreation',
+      'Land reclamation',
+      'Generate employment and income',
+      "Promote women's equal representation and participation in employment",
+      'Safeguard cultural or spiritual importance',
+      'Safeguard traditional practises',
+      'Increase food security',
+      'Secure management rights and land tenure',
+      'Improve local community health',
+      'Coastal beautification or aesthetic value',
+      'Support local community natural resource management institutions',
+      'Encourage community involvement',
+      'Education/raise environmental awareness',
+      'Sustainable financing',
+      'None',
+      'Unknown',
+      'Other'
+    ]
+  },
+  3: {
+    question: '3.3 What are the other aim(s) of project activities at the site?',
+    answers: [
+      'Have site designated as a protected area',
+      'Meet international commitments/national targets',
+      'Influence government policy',
+      'Improve restoration techniques',
+      'Answer scientific research questions',
+      'None',
+      'Other'
+    ]
+  },
+  4: { question: '3.4 Of the selected aims, identify which are primary, or co-benefits ' }
+}

--- a/mrtt-ui/src/language.js
+++ b/mrtt-ui/src/language.js
@@ -1,0 +1,7 @@
+const error = { submit: 'Submit failed, please try again.' }
+const form = {
+  checkboxGroupOtherLabel: 'Other',
+  checkboxGroupOtherInputPlaceholder: 'If other, please state.'
+}
+
+export default { error, form }

--- a/mrtt-ui/src/library/mapDataForApi.js
+++ b/mrtt-ui/src/library/mapDataForApi.js
@@ -1,14 +1,14 @@
 import { questionMapping } from '../data/questionMapping'
 
-// set up data structure for api
+// set up data structure for api using question_id and answer_value object
 // ensure formTitle is the same is title in questionMapping
 export const mapDataForApi = (formTitle, data) => {
   const preppedData = []
+
   for (const [key, value] of Object.entries(data)) {
-    // map question ids with keys
     // longer version of Object.hasOwnProperty
-    // checks if key exists in question mapping section, then gets value of that key to use with question_id
     if (Object.prototype.hasOwnProperty.call(questionMapping[formTitle], key)) {
+      // map question ids with descriptive question keys
       preppedData.push({ question_id: questionMapping[formTitle][key], answer_value: value })
     }
   }

--- a/mrtt-ui/src/library/mapDataForApi.js
+++ b/mrtt-ui/src/library/mapDataForApi.js
@@ -1,0 +1,16 @@
+import { questionMapping } from '../data/questionMapping'
+
+// set up data structure for api
+// ensure formTitle is the same is title in questionMapping
+export const mapDataForApi = (formTitle, data) => {
+  const preppedData = []
+  for (const [key, value] of Object.entries(data)) {
+    // map question ids with keys
+    // longer version of Object.hasOwnProperty
+    // checks if key exists in question mapping section, then gets value of that key to use with question_id
+    if (Object.prototype.hasOwnProperty.call(questionMapping[formTitle], key)) {
+      preppedData.push({ question_id: questionMapping[formTitle][key], answer_value: value })
+    }
+  }
+  return preppedData
+}

--- a/mrtt-ui/src/styles/forms.js
+++ b/mrtt-ui/src/styles/forms.js
@@ -1,12 +1,15 @@
+import { Typography } from '@mui/material'
 import { styled } from '@mui/material/styles'
 
-export const MainFormDiv = styled('div')(() => ({
+export const MainFormDiv = styled('div')`
   display: 'flex',
-  flexDirection: 'column',
-  justifyContent: 'center',
-  alignItems: 'center',
-  margin: '1.5em'
-}))
+  flex-direction: column;
+  justify-content: center;
+  align-items: stretch;
+  padding: 1.5em;
+  width: 100%;
+  box-sizing: border-box;
+`
 
 export const FormQuestionDiv = styled('div')(() => ({
   display: 'flex',
@@ -14,3 +17,13 @@ export const FormQuestionDiv = styled('div')(() => ({
   marginBottom: '1em',
   marginTop: '2em'
 }))
+
+export const SectionFormTitle = styled(Typography)`
+  marginbottom: '0.5em';
+`
+SectionFormTitle.defaultProps = { variant: 'h4' }
+
+export const Form = styled('form')`
+  display: flex;
+  flex-direction: column;
+`

--- a/mrtt-ui/src/styles/typography.js
+++ b/mrtt-ui/src/styles/typography.js
@@ -1,0 +1,6 @@
+import { styled, Typography } from '@mui/material'
+
+export const ErrorText = styled(Typography)`
+  color: red;
+`
+ErrorText.defaultProps = { variant: 'subtitle' }

--- a/mrtt-ui/src/views/Home.js
+++ b/mrtt-ui/src/views/Home.js
@@ -1,7 +1,13 @@
 import React from 'react'
+import FakeSite from '../components/FakeSite'
 
 function Home() {
-  return <div className='home'>HOME PAGE</div>
+  return (
+    <>
+      <div className='home'>HOME PAGE</div>
+      <FakeSite />
+    </>
+  )
 }
 
 export default Home


### PR DESCRIPTION
# Description

- submit section 3 (restoration aims) to api using patch to not overwrite other section answers
- made reusable ErrorText component
- made language file for reusable text


closes #47 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


# Instructions

- On both the project details form, and restoration aims form simulate a 404 by changing the api url, then submit. Look at the error text
- submit both forms, go look at postman to see the data submitted (and not wiping other section data out)

# How Has This Been Tested?

manual - see instructions

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
