### PR TITLE
create generic validation for multiselect with other

### DIFF
--- a/mrtt-ui/src/components/RestorationAimsForm/RestorationAimsForm.js
+++ b/mrtt-ui/src/components/RestorationAimsForm/RestorationAimsForm.js
@@ -11,41 +11,17 @@ import { restorationAims as questions } from '../../data/questions'
 import ButtonSubmit from '../ButtonSubmit'
 import CheckboxGroupWithLabelAndController from '../CheckboxGroupWithLabelAndController'
 import language from '../../language'
+import { multiselectWithOtherValidation } from '../../validation/multiSelectWithOther'
 
 const submitUrl = `${process.env.REACT_APP_API_URL}/sites/1/registration_answers`
-
-const otherIsCheckedButInputIsEmptyValidation = (schema) =>
-  schema.test({
-    name: 'isOtherCheckedAndEmpty',
-    message: language.restorationAimsForm.validation.clairfyOther,
-    test: (value, context) => {
-      const {
-        parent: { otherValue }
-      } = context
-      return otherValue !== undefined && otherValue !== ''
-    }
-  })
-
-const aimsValidation = yup.object({
-  selectedValues: yup
-    .array()
-    .of(yup.string())
-    .when('isOtherChecked', {
-      is: false || undefined,
-      then: (schema) => schema.min(1, language.restorationAimsForm.validation.selectAtleastOneAim),
-      otherwise: otherIsCheckedButInputIsEmptyValidation
-    }),
-  otherValue: yup.string(),
-  isOtherChecked: yup.bool()
-})
 
 const RestorationAimsForm = () => {
   const [isSubmitError, setIsSubmitError] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const validationSchema = yup.object({
-    ecologicalAims: aimsValidation,
-    socioEconomicAims: aimsValidation,
-    otherAims: aimsValidation
+    ecologicalAims: multiselectWithOtherValidation,
+    socioEconomicAims: multiselectWithOtherValidation,
+    otherAims: multiselectWithOtherValidation
   })
 
   const reactHookFormInstance = useForm({

--- a/mrtt-ui/src/language.js
+++ b/mrtt-ui/src/language.js
@@ -3,11 +3,11 @@ const form = {
   checkboxGroupOtherLabel: 'Other',
   checkboxGroupOtherInputPlaceholder: 'If other, please state.'
 }
-const restorationAimsForm = {
+const multiselectWithOtherFormQuestion = {
   validation: {
     selectAtleastOneAim: 'Please select at least one aim.',
     clairfyOther: 'Please clarify other aim.'
   }
 }
 
-export default { error, form, restorationAimsForm }
+export default { error, form, multiselectWithOtherFormQuestion }

--- a/mrtt-ui/src/language.js
+++ b/mrtt-ui/src/language.js
@@ -5,8 +5,8 @@ const form = {
 }
 const multiselectWithOtherFormQuestion = {
   validation: {
-    selectAtleastOneAim: 'Please select at least one aim.',
-    clairfyOther: 'Please clarify other aim.'
+    selectAtleastOneItem: 'Please select at least one item.',
+    clairfyOther: 'Please clarify other item.'
   }
 }
 

--- a/mrtt-ui/src/validation/multiSelectWithOther.js
+++ b/mrtt-ui/src/validation/multiSelectWithOther.js
@@ -1,0 +1,28 @@
+import language from '../language'
+import * as yup from 'yup'
+
+export const otherIsCheckedButInputIsEmptyValidation = (schema) =>
+  schema.test({
+    name: 'isOtherCheckedAndEmpty',
+    message: language.multiselectWithOtherFormQuestion.validation.clairfyOther,
+    test: (value, context) => {
+      const {
+        parent: { otherValue }
+      } = context
+      return otherValue !== undefined && otherValue !== ''
+    }
+  })
+
+export const multiselectWithOtherValidation = yup.object({
+  selectedValues: yup
+    .array()
+    .of(yup.string())
+    .when('isOtherChecked', {
+      is: false || undefined,
+      then: (schema) =>
+        schema.min(1, language.multiselectWithOtherFormQuestion.validation.selectAtleastOneAim),
+      otherwise: otherIsCheckedButInputIsEmptyValidation
+    }),
+  otherValue: yup.string(),
+  isOtherChecked: yup.bool()
+})

--- a/mrtt-ui/src/validation/multiSelectWithOther.js
+++ b/mrtt-ui/src/validation/multiSelectWithOther.js
@@ -19,8 +19,7 @@ export const multiselectWithOtherValidation = yup.object({
     .of(yup.string())
     .when('isOtherChecked', {
       is: false || undefined,
-      then: (schema) =>
-        schema.min(1, language.multiselectWithOtherFormQuestion.validation.selectAtleastOneAim),
+      then: (schema) => schema.min(1, language.multiselectWithOtherFormQuestion.validation.item),
       otherwise: otherIsCheckedButInputIsEmptyValidation
     }),
   otherValue: yup.string(),


### PR DESCRIPTION
# Description

I took your `aimsValidation` and made it into a more generic `multiselectWithOtherValidation`. Didn't change any functionality, mostly just renamed a few things. Now we can re-used this in any form with `multiselectWithOther `question type.

Fixes # [FEATURE] [Create reusable validation for multiple choice with other validation](https://github.com/globalmangrovewatch/gmw-users/issues/66)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Instructions

Explain what someone needs to do in order to test the functionality of the changes. 

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
