### PR TITLE
Feature/97 new site

### DIFF
--- a/mrtt-ui/src/App.js
+++ b/mrtt-ui/src/App.js
@@ -3,19 +3,19 @@ import { BrowserRouter as Router, Routes, Route } from 'react-router-dom'
 import { ThemeProvider } from '@mui/material/styles'
 import React from 'react'
 
+import { CustomToastContainer } from './components/CustomToastContainer'
+import CausesOfDeclineForm from './components/CausesOfDeclineForm'
+import GlobalLayout from './components/GlobalLayout'
 import Home from './views/Home'
 import Landscapes from './views/Landscapes'
-import Sites from './views/Sites'
 import Organizations from './views/Organizations'
-
-import { CustomToastContainer } from './components/CustomToastContainer'
-import GlobalLayout from './components/GlobalLayout'
 import ProjectDetailsForm from './components/ProjectDetailsForm'
-import SiteBackgroundForm from './components/SiteBackgroundForm'
 import RestorationAimsForm from './components/RestorationAimsForm/RestorationAimsForm'
-import CausesOfDeclineForm from './components/CausesOfDeclineForm'
+import SiteBackgroundForm from './components/SiteBackgroundForm'
+import SiteForm from './views/SiteForm'
+import SiteOverview from './views/SiteOverview'
+import Sites from './views/Sites'
 import themeMui from './styles/themeMui'
-import Site from './views/Site'
 
 function App() {
   return (
@@ -27,11 +27,13 @@ function App() {
             <Route path='/' element={<Home />} />
             <Route path='/landscapes' element={<Landscapes />} />
             <Route path='/organizations' element={<Organizations />} />
-            <Route path='/site/:siteId' element={<Site />} />
+            <Route path='/site/:siteId/edit' element={<SiteForm isNewSite={false} />} />
             <Route path='/site/:siteId/form/causes-of-decline' element={<CausesOfDeclineForm />} />
             <Route path='/site/:siteId/form/project-details' element={<ProjectDetailsForm />} />
             <Route path='/site/:siteId/form/restoration-aims' element={<RestorationAimsForm />} />
             <Route path='/site/:siteId/form/site-background' element={<SiteBackgroundForm />} />
+            <Route path='/site/:siteId/overview' element={<SiteOverview />} />
+            <Route path='/site/new' element={<SiteForm isNewSite={true} />} />
             <Route path='/sites' element={<Sites />} />
           </Routes>
         </GlobalLayout>

--- a/mrtt-ui/src/components/CausesOfDeclineForm.js
+++ b/mrtt-ui/src/components/CausesOfDeclineForm.js
@@ -217,7 +217,7 @@ function CausesOfDeclineForm() {
     'data', data
 
     axios
-      .put(apiAnswersUrl, mapDataForApi('causesOfDecline', data))
+      .patch(apiAnswersUrl, mapDataForApi('causesOfDecline', data))
       .then(() => {
         setisSubmitting(false)
       })

--- a/mrtt-ui/src/components/ItemDoesntExist.js
+++ b/mrtt-ui/src/components/ItemDoesntExist.js
@@ -1,0 +1,12 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { RowCenterCenter } from '../styles/containers'
+import language from '../language'
+
+const ItemDoesntExist = ({ item }) => {
+  return <RowCenterCenter>{language.error.getItemDoesntExistMessage(item)}</RowCenterCenter>
+}
+
+ItemDoesntExist.propTypes = { item: PropTypes.string.isRequired }
+
+export default ItemDoesntExist

--- a/mrtt-ui/src/components/ProjectDetailsForm.js
+++ b/mrtt-ui/src/components/ProjectDetailsForm.js
@@ -19,14 +19,12 @@ import { mapDataForApi } from '../library/mapDataForApi'
 import { projectDetails as questions } from '../data/questions'
 import { questionMapping } from '../data/questionMapping'
 import { useParams } from 'react-router-dom'
-import countries from '../data/countries.json'
 import emptyFeatureCollection from '../data/emptyFeatureCollection'
-import formatApiAnswersForForm from '../library/formatApiAnswersForForm'
 import language from '../language'
 import LoadingIndicator from './LoadingIndicator'
 import mangroveCountries from '../data/mangrove_countries.json'
 import ProjectAreaMap from './ProjectAreaMap'
-import usePopulateQuestionFormWithInitialValues from '../library/usePopulateQuestionFormWithInitialValues'
+import useInitializeQuestionMappedForm from '../library/useInitializeQuestionMappedForm'
 
 const sortCountries = (a, b) => {
   const textA = a.properties.country.toUpperCase()
@@ -93,7 +91,7 @@ function ProjectDetailsForm() {
    The api casts them to boolean so we support both */
   const showEndDateInput = watchHasProjectEndDate === 'true' || watchHasProjectEndDate === true
 
-  usePopulateQuestionFormWithInitialValues({
+  useInitializeQuestionMappedForm({
     apiUrl: registrationAnswersUrl,
     resetForm,
     questionMapping: questionMapping.projectDetails,

--- a/mrtt-ui/src/components/ProjectDetailsForm.js
+++ b/mrtt-ui/src/components/ProjectDetailsForm.js
@@ -2,8 +2,8 @@ import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns'
 import { FormControlLabel, FormLabel, Radio, RadioGroup, Stack, TextField } from '@mui/material'
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider'
 import { MobileDatePicker } from '@mui/x-date-pickers/MobileDatePicker'
-import { useEffect, useState } from 'react'
 import { useForm, Controller } from 'react-hook-form'
+import { useState } from 'react'
 import { yupResolver } from '@hookform/resolvers/yup'
 import * as yup from 'yup'
 import Autocomplete from '@mui/material/Autocomplete'
@@ -18,13 +18,15 @@ import { MainFormDiv, FormQuestionDiv, SectionFormTitle, Form } from '../styles/
 import { mapDataForApi } from '../library/mapDataForApi'
 import { projectDetails as questions } from '../data/questions'
 import { questionMapping } from '../data/questionMapping'
-import { toast } from 'react-toastify'
 import { useParams } from 'react-router-dom'
+import countries from '../data/countries.json'
+import emptyFeatureCollection from '../data/emptyFeatureCollection'
 import formatApiAnswersForForm from '../library/formatApiAnswersForForm'
 import language from '../language'
+import LoadingIndicator from './LoadingIndicator'
 import mangroveCountries from '../data/mangrove_countries.json'
-import emptyFeatureCollection from '../data/emptyFeatureCollection'
 import ProjectAreaMap from './ProjectAreaMap'
+import usePopulateQuestionFormWithInitialValues from '../library/usePopulateQuestionFormWithInitialValues'
 
 const sortCountries = (a, b) => {
   const textA = a.properties.country.toUpperCase()
@@ -38,6 +40,7 @@ const siteAreaError = 'Please provide a site area'
 function ProjectDetailsForm() {
   const [mapExtent, setMapExtent] = useState()
   const [isError, setIsError] = useState(false)
+  const [isLoading, setIsLoading] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const validationSchema = yup.object().shape({
     hasProjectEndDate: yup.boolean(),
@@ -90,26 +93,12 @@ function ProjectDetailsForm() {
    The api casts them to boolean so we support both */
   const showEndDateInput = watchHasProjectEndDate === 'true' || watchHasProjectEndDate === true
 
-  useEffect(
-    function initializeFormWithApiData() {
-      if (resetForm && registrationAnswersUrl) {
-        axios
-          .get(registrationAnswersUrl)
-          .then(({ data }) => {
-            const initialValuesForForm = formatApiAnswersForForm({
-              apiAnswers: data,
-              questionMapping: questionMapping.projectDetails
-            })
-
-            resetForm(initialValuesForForm)
-          })
-          .catch(() => {
-            toast.error(language.error.apiLoad)
-          })
-      }
-    },
-    [registrationAnswersUrl, resetForm]
-  )
+  usePopulateQuestionFormWithInitialValues({
+    apiUrl: registrationAnswersUrl,
+    resetForm,
+    questionMapping: questionMapping.projectDetails,
+    setIsLoading
+  })
 
   const onCountriesChange = (field, features) => {
     try {
@@ -155,13 +144,17 @@ function ProjectDetailsForm() {
       })
   }
 
-  return (
+  return isLoading ? (
+    <LoadingIndicator />
+  ) : (
     <MainFormDiv>
       <SectionFormTitle>Project Details Form</SectionFormTitle>
       <Form onSubmit={handleSubmit(onSubmit)}>
         {/* Has project end date radio group */}
         <FormQuestionDiv>
-          <FormLabel>{questions.hasProjectEndDate.question}</FormLabel>
+          <FormLabel id='has-project-end-date-label'>
+            {questions.hasProjectEndDate.question}
+          </FormLabel>
           <Controller
             name='hasProjectEndDate'
             control={control}
@@ -169,7 +162,7 @@ function ProjectDetailsForm() {
             render={({ field }) => (
               <RadioGroup
                 {...field}
-                aria-labelledby='demo-radio-buttons-group-label'
+                aria-labelledby='has-project-end-date-label'
                 name='radio-buttons-group'>
                 <FormControlLabel value={true} control={<Radio />} label='Yes' />
                 <FormControlLabel value={false} control={<Radio />} label='No' />
@@ -180,7 +173,7 @@ function ProjectDetailsForm() {
         {/* Start Date */}
         <FormQuestionDiv>
           <FormLabel>Project Duration</FormLabel>
-          <FormLabel>{questions.projectStartDate.question}</FormLabel>
+          <FormLabel htmlFor='start-date'>{questions.projectStartDate.question}</FormLabel>
           <Controller
             name='projectStartDate'
             control={control}
@@ -189,6 +182,7 @@ function ProjectDetailsForm() {
               <LocalizationProvider dateAdapter={AdapterDateFns} {...field} ref={null}>
                 <Stack spacing={3}>
                   <MobileDatePicker
+                    id='start-date'
                     label='Project start date'
                     value={field.value}
                     onChange={(newValue) => {
@@ -205,7 +199,7 @@ function ProjectDetailsForm() {
         {/* End Date */}
         {showEndDateInput && (
           <FormQuestionDiv>
-            <FormLabel>{questions.projectEndDate.question}</FormLabel>
+            <FormLabel htmlFor='end-date'>{questions.projectEndDate.question}</FormLabel>
             <Controller
               name='projectEndDate'
               control={control}
@@ -213,6 +207,7 @@ function ProjectDetailsForm() {
                 <LocalizationProvider dateAdapter={AdapterDateFns} {...field} ref={null}>
                   <Stack spacing={3}>
                     <MobileDatePicker
+                      id='end-date'
                       label='Project end date'
                       value={field.value}
                       onChange={(newValue) => {
@@ -229,7 +224,7 @@ function ProjectDetailsForm() {
         )}
         {/* Countries selector */}
         <FormQuestionDiv>
-          <FormLabel>{questions.countries.question}</FormLabel>
+          <FormLabel htmlFor='countries'>{questions.countries.question}</FormLabel>
           <Controller
             name='countries'
             control={control}
@@ -241,7 +236,7 @@ function ProjectDetailsForm() {
                 multiple
                 options={countriesGeojson}
                 getOptionLabel={(feature) => (feature ? feature.properties.country : '')}
-                renderInput={(params) => <TextField {...params} label='Country' />}
+                renderInput={(params) => <TextField {...params} label='Country' id='countries' />}
                 onChange={(e, values) => {
                   onCountriesChange(field, values)
                 }}

--- a/mrtt-ui/src/components/RestorationAimsForm/RestorationAimsForm.js
+++ b/mrtt-ui/src/components/RestorationAimsForm/RestorationAimsForm.js
@@ -15,7 +15,7 @@ import { restorationAims as questions } from '../../data/questions'
 import CheckboxGroupWithLabelAndController from '../CheckboxGroupWithLabelAndController'
 import language from '../../language'
 import LoadingIndicator from '../LoadingIndicator'
-import usePopulateQuestionFormWithInitialValues from '../../library/usePopulateQuestionFormWithInitialValues'
+import useInitializeQuestionMappedForm from '../../library/useInitializeQuestionMappedForm'
 
 const RestorationAimsForm = () => {
   const { siteId } = useParams()
@@ -42,7 +42,7 @@ const RestorationAimsForm = () => {
     reset: resetForm
   } = reactHookFormInstance
 
-  usePopulateQuestionFormWithInitialValues({
+  useInitializeQuestionMappedForm({
     apiUrl: apiAnswersUrl,
     resetForm,
     questionMapping: questionMapping.restorationAims,

--- a/mrtt-ui/src/components/RestorationAimsForm/RestorationAimsForm.js
+++ b/mrtt-ui/src/components/RestorationAimsForm/RestorationAimsForm.js
@@ -1,7 +1,6 @@
-import { toast } from 'react-toastify'
-import { useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { useParams } from 'react-router-dom'
+import { useState } from 'react'
 import { yupResolver } from '@hookform/resolvers/yup'
 import * as yup from 'yup'
 import axios from 'axios'

--- a/mrtt-ui/src/components/RestorationAimsForm/RestorationAimsForm.js
+++ b/mrtt-ui/src/components/RestorationAimsForm/RestorationAimsForm.js
@@ -14,9 +14,9 @@ import { multiselectWithOtherValidation } from '../../validation/multiSelectWith
 import { questionMapping } from '../../data/questionMapping'
 import { restorationAims as questions } from '../../data/questions'
 import CheckboxGroupWithLabelAndController from '../CheckboxGroupWithLabelAndController'
-import formatApiAnswersForForm from '../../library/formatApiAnswersForForm'
 import language from '../../language'
 import LoadingIndicator from '../LoadingIndicator'
+import usePopulateQuestionFormWithInitialValues from '../../library/usePopulateQuestionFormWithInitialValues'
 
 const RestorationAimsForm = () => {
   const { siteId } = useParams()
@@ -43,24 +43,12 @@ const RestorationAimsForm = () => {
     reset: resetForm
   } = reactHookFormInstance
 
-  const _loadSiteData = useEffect(() => {
-    if (apiAnswersUrl && resetForm) {
-      setIsLoading(true)
-      axios
-        .get(apiAnswersUrl)
-        .then(({ data }) => {
-          setIsLoading(false)
-          const initialValuesForForm = formatApiAnswersForForm({
-            apiAnswers: data,
-            questionMapping: questionMapping.restorationAims
-          })
-          resetForm(initialValuesForForm)
-        })
-        .catch(() => {
-          toast.error(language.error.apiLoad)
-        })
-    }
-  }, [apiAnswersUrl, resetForm])
+  usePopulateQuestionFormWithInitialValues({
+    apiUrl: apiAnswersUrl,
+    resetForm,
+    questionMapping: questionMapping.restorationAims,
+    setIsLoading
+  })
 
   const handleSubmit = (formData) => {
     setIsSubmitting(true)

--- a/mrtt-ui/src/components/SiteBackgroundForm.js
+++ b/mrtt-ui/src/components/SiteBackgroundForm.js
@@ -79,7 +79,7 @@ const ProjectDetailsForm = () => {
     if (!data) return
 
     axios
-      .put(url, mapDataForApi('siteBackground', data))
+      .patch(url, mapDataForApi('siteBackground', data))
       .then(() => {
         setisSubmitting(false)
       })

--- a/mrtt-ui/src/data/mockLandscapes.js
+++ b/mrtt-ui/src/data/mockLandscapes.js
@@ -1,0 +1,8 @@
+const mockLandscapes = [
+  { id: 1, name: 'Landscape 1' },
+  { id: 2, name: 'Landscape 2' },
+  { id: 3, name: 'Landscape 3' },
+  { id: 4, name: 'Landscape 4' }
+]
+
+export default mockLandscapes

--- a/mrtt-ui/src/data/mockOrganizations.js
+++ b/mrtt-ui/src/data/mockOrganizations.js
@@ -6,13 +6,13 @@ const mockOrganizations = [
   { id: 3, name: 'Fake Org 3', isCurrentUserMember: true },
   { id: 6, name: 'Fake Org 4', isCurrentUserMember: false },
   { id: 5, name: 'Fake Org 5', isCurrentUserMember: false },
-  { id: 6, name: 'Fake Org 6', isCurrentUserMember: false },
   { id: 7, name: 'Fake Org 7', isCurrentUserMember: true },
   { id: 8, name: 'Fake Org 8', isCurrentUserMember: false },
   { id: 9, name: 'Fake Org 9', isCurrentUserMember: false },
   { id: 10, name: 'Fake Org 10', isCurrentUserMember: false },
   { id: 11, name: 'Fake Org 11', isCurrentUserMember: true },
-  { id: 12, name: 'Fake Org 12', isCurrentUserMember: false }
+  { id: 12, name: 'Fake Org 12', isCurrentUserMember: false },
+  { id: 13, name: 'Fake Org 13', isCurrentUserMember: false }
 ]
 
 export default mockOrganizations

--- a/mrtt-ui/src/language.js
+++ b/mrtt-ui/src/language.js
@@ -1,6 +1,7 @@
 const error = {
   submit: 'Submit failed. please try again.',
-  apiLoad: 'Loading data from the api failed. Please try again.'
+  apiLoad: 'Loading data from the api failed. Please try again.',
+  getItemDoesntExistMessage: (item) => `That ${item} doesnt exits.`
 }
 const form = {
   checkboxGroupOtherLabel: 'Other',
@@ -19,7 +20,23 @@ const pages = {
     titleOtherOrganizations: 'Other Organizations',
     titleYourOrganizations: 'Your Organizations'
   },
-  sites: { title: 'Sites', newSiteButton: 'New Site' }
+  sites: { title: 'Sites', newSiteButton: 'New Site' },
+  siteform: {
+    getEditSiteSuccessMessage: (siteName) => `The site had been renamed to ${siteName}`,
+    getNewSiteSuccessMessage: (siteName) => `The site, ${siteName}, has been created`,
+    titleNewSite: 'Create a site',
+    labelName: 'Name',
+    labelLandscape: 'Landscape',
+    validation: {
+      nameRequired: 'Please enter a name'
+    }
+  }
+}
+
+const buttons = {
+  cancel: 'Cancel',
+  submit: 'Submit',
+  submitting: 'Submitting...'
 }
 
 const maybePluralize = (count, noun, suffix = 's') => `${count} ${noun}${count !== 1 ? suffix : ''}`
@@ -53,4 +70,4 @@ const projectAreaMap = {
   }
 }
 
-export default { error, form, multiselectWithOtherFormQuestion, pages, projectAreaMap }
+export default { error, form, multiselectWithOtherFormQuestion, pages, buttons, projectAreaMap }

--- a/mrtt-ui/src/language.js
+++ b/mrtt-ui/src/language.js
@@ -28,7 +28,8 @@ const pages = {
     labelName: 'Name',
     labelLandscape: 'Landscape',
     validation: {
-      nameRequired: 'Please enter a name'
+      nameRequired: 'Please enter a name',
+      landscapeRequired: 'Please select a landscape'
     }
   }
 }

--- a/mrtt-ui/src/library/useInitializeQuestionMappedForm.js
+++ b/mrtt-ui/src/library/useInitializeQuestionMappedForm.js
@@ -5,12 +5,7 @@ import { useEffect } from 'react'
 import formatApiAnswersForForm from './formatApiAnswersForForm'
 import language from '../language'
 
-const usePopulateQuestionFormWithInitialValues = ({
-  apiUrl,
-  resetForm,
-  setIsLoading,
-  questionMapping
-}) => {
+const useInitializeQuestionMappedForm = ({ apiUrl, resetForm, setIsLoading, questionMapping }) => {
   useEffect(
     function initializeFormWithApiData() {
       if (resetForm && apiUrl) {
@@ -33,4 +28,4 @@ const usePopulateQuestionFormWithInitialValues = ({
   )
 }
 
-export default usePopulateQuestionFormWithInitialValues
+export default useInitializeQuestionMappedForm

--- a/mrtt-ui/src/library/usePopulateQuestionFormWithInitialValues.js
+++ b/mrtt-ui/src/library/usePopulateQuestionFormWithInitialValues.js
@@ -1,0 +1,36 @@
+import axios from 'axios'
+import { toast } from 'react-toastify'
+import { useEffect } from 'react'
+
+import formatApiAnswersForForm from './formatApiAnswersForForm'
+import language from '../language'
+
+const usePopulateQuestionFormWithInitialValues = ({
+  apiUrl,
+  resetForm,
+  setIsLoading,
+  questionMapping
+}) => {
+  useEffect(
+    function initializeFormWithApiData() {
+      if (resetForm && apiUrl) {
+        axios
+          .get(apiUrl)
+          .then(({ data }) => {
+            setIsLoading(false)
+            const initialValuesForForm = formatApiAnswersForForm({
+              apiAnswers: data,
+              questionMapping
+            })
+            resetForm(initialValuesForForm)
+          })
+          .catch(() => {
+            toast.error(language.error.apiLoad)
+          })
+      }
+    },
+    [apiUrl, resetForm, setIsLoading, questionMapping]
+  )
+}
+
+export default usePopulateQuestionFormWithInitialValues

--- a/mrtt-ui/src/styles/buttons.js
+++ b/mrtt-ui/src/styles/buttons.js
@@ -1,14 +1,18 @@
 import { Button } from '@mui/material'
 import { styled } from '@mui/system'
 import PropTypes from 'prop-types'
+import language from '../language'
 
 const ButtonPrimary = styled(Button)``
 ButtonPrimary.defaultProps = { variant: 'contained' }
 
+const ButtonSecondary = styled(Button)``
+ButtonSecondary.defaultProps = { variant: 'outlined' }
+
 const ButtonSubmit = ({ isSubmitting }) => {
   return (
     <Button sx={{ marginTop: '1em' }} variant='contained' type='submit' disabled={isSubmitting}>
-      {isSubmitting ? 'Submitting...' : 'Submit'}
+      {isSubmitting ? language.buttons.submitting : language.buttons.submit}
     </Button>
   )
 }
@@ -17,4 +21,8 @@ ButtonSubmit.propTypes = {
   isSubmitting: PropTypes.bool.isRequired
 }
 
-export { ButtonPrimary, ButtonSubmit }
+const ButtonCancel = (props) => (
+  <ButtonSecondary {...props}>{language.buttons.cancel}</ButtonSecondary>
+)
+
+export { ButtonPrimary, ButtonSubmit, ButtonSecondary, ButtonCancel }

--- a/mrtt-ui/src/styles/containers.js
+++ b/mrtt-ui/src/styles/containers.js
@@ -16,14 +16,9 @@ const RowFlexEnd = styled('div')`
   justify-content: flex-end;
 `
 
-const ButtonContainer = styled(RowFlexEnd)(
-  ({ theme: themeMui }) => `
-  & > * {
-    margin-left: ${themeMui.spacing(2)};
-
-  }
-  `
-)
+const ButtonContainer = styled(RowFlexEnd)(({ theme: themeMui }) => ({
+  '&& > *': { marginLeft: themeMui.spacing(2) }
+}))
 
 const RowCenterCenter = styled('div')`
   display: flex;

--- a/mrtt-ui/src/styles/containers.js
+++ b/mrtt-ui/src/styles/containers.js
@@ -11,6 +11,27 @@ const RowSpaceBetween = styled('div')`
   justify-content: space-between;
 `
 
+const RowFlexEnd = styled('div')`
+  display: flex;
+  justify-content: flex-end;
+`
+
+const ButtonContainer = styled(RowFlexEnd)(
+  ({ theme: themeMui }) => `
+  & > * {
+    margin-left: ${themeMui.spacing(2)};
+
+  }
+  `
+)
+
+const RowCenterCenter = styled('div')`
+  display: flex;
+  height: 100%;
+  align-items: center;
+  justify-content: center;
+`
+
 const LinkCard = styled(Link)(({ theme: themeMui }) => ({
   padding: `${themeMui.spacing(3)} ${themeMui.spacing(1)}`,
   border: theme.border.primary,
@@ -19,4 +40,4 @@ const LinkCard = styled(Link)(({ theme: themeMui }) => ({
   color: theme.color.text
 }))
 
-export { PagePadding, RowSpaceBetween, LinkCard }
+export { PagePadding, RowSpaceBetween, LinkCard, RowCenterCenter, RowFlexEnd, ButtonContainer }

--- a/mrtt-ui/src/views/SiteForm.js
+++ b/mrtt-ui/src/views/SiteForm.js
@@ -1,0 +1,157 @@
+import { Controller, useForm } from 'react-hook-form'
+import { toast } from 'react-toastify'
+import { useEffect, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { yupResolver } from '@hookform/resolvers/yup'
+import * as yup from 'yup'
+import axios from 'axios'
+import PropTypes from 'prop-types'
+
+import { ButtonCancel, ButtonSubmit } from '../styles/buttons'
+import { ButtonContainer, RowFlexEnd } from '../styles/containers'
+import { ErrorText } from '../styles/typography'
+import { Form, MainFormDiv, SectionFormTitle } from '../styles/forms'
+import { FormLabel, MenuItem, Select, TextField } from '@mui/material'
+import ItemDoesntExist from '../components/ItemDoesntExist'
+import language from '../language'
+import LoadingIndicator from '../components/LoadingIndicator'
+import mockLandscapes from '../data/mockLandscapes'
+
+const validationSchema = yup.object({
+  site_name: yup.string().required(language.pages.siteform.validation.nameRequired),
+  landscape: yup.string()
+})
+
+const formDefaultValues = { site_name: '', landscape: '' }
+
+const SiteForm = ({ isNewSite }) => {
+  const { siteId } = useParams()
+  const [isLoading, setIsLoading] = useState(false)
+  const [isSubmitError, setIsSubmitError] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [doesItemNotExist, setDoesItemNotExist] = useState(false)
+  const sitesUrl = `${process.env.REACT_APP_API_URL}/sites/`
+  const navigate = useNavigate()
+
+  const {
+    control: formControl,
+    handleSubmit: validateInputs,
+    formState: { errors },
+    reset: resetForm
+  } = useForm({ resolver: yupResolver(validationSchema), defaultValues: formDefaultValues })
+
+  useEffect(
+    function initializeFormWithApiData() {
+      if (resetForm && sitesUrl && siteId && !isNewSite) {
+        setIsLoading(true)
+        axios
+          .get(`${sitesUrl}${siteId}`)
+          .then(({ data }) => {
+            setIsLoading(false)
+            resetForm(data)
+          })
+          .catch((err) => {
+            setIsLoading(false)
+            if (err?.response?.status === 404) {
+              setDoesItemNotExist(true)
+            } else {
+              toast.error(language.error.apiLoad)
+            }
+          })
+      }
+    },
+    [siteId, resetForm, sitesUrl, isNewSite]
+  )
+
+  const postNewSite = (formData) => {
+    axios
+      .post(sitesUrl, formData)
+      .then(({ data: { site_name } }) => {
+        setIsSubmitting(false)
+        toast.success(language.pages.siteform.getNewSiteSuccessMessage(site_name))
+        navigate('/sites')
+      })
+      .catch(() => {
+        setIsSubmitting(false)
+        setIsSubmitError(true)
+        toast.error(language.error.submit)
+      })
+  }
+
+  const editSite = (formData) => {
+    axios
+      .put(`${sitesUrl}${siteId}`, formData)
+      .then(({ data: { site_name } }) => {
+        setIsSubmitting(false)
+        toast.success(language.pages.siteform.getEditSiteSuccessMessage(site_name))
+        navigate('/sites')
+      })
+      .catch(() => {
+        setIsSubmitting(false)
+        setIsSubmitError(true)
+        toast.error(language.error.submit)
+      })
+  }
+
+  const handleSubmit = (formData) => {
+    setIsSubmitting(true)
+    setIsSubmitError(false)
+    if (isNewSite) {
+      postNewSite(formData)
+    }
+    if (!isNewSite) {
+      editSite(formData)
+    }
+  }
+
+  const handleCancelClick = () => {
+    navigate(-1)
+  }
+
+  const form = doesItemNotExist ? (
+    <ItemDoesntExist item='site' />
+  ) : (
+    <MainFormDiv>
+      <SectionFormTitle>
+        {isNewSite ? language.pages.siteform.titleNewSite : 'placeholder name'}
+      </SectionFormTitle>
+      <Form onSubmit={validateInputs(handleSubmit)}>
+        <FormLabel htmlFor='name'>{language.pages.siteform.labelName}* </FormLabel>
+        <Controller
+          name='site_name'
+          control={formControl}
+          render={({ field }) => (
+            <TextField {...field} id='name' label={language.pages.siteform.labelName} />
+          )}
+        />
+        <ErrorText>{errors?.site_name?.message}</ErrorText>
+        <FormLabel htmlFor='landscape'>{language.pages.siteform.labelLandscape} </FormLabel>
+        <Controller
+          name='landscape'
+          control={formControl}
+          render={({ field }) => (
+            <Select {...field} id='landscape' label={language.pages.siteform.labelLandscape}>
+              {mockLandscapes.map((landscape) => (
+                <MenuItem key={landscape.id} value={landscape.id}>
+                  {landscape.name}
+                </MenuItem>
+              ))}
+            </Select>
+          )}
+        />
+        <ErrorText>{errors?.landscape?.message}</ErrorText>
+        <RowFlexEnd>{isSubmitError && <ErrorText>{language.error.submit}</ErrorText>}</RowFlexEnd>
+        <ButtonContainer>
+          <ButtonCancel onClick={handleCancelClick} />
+          <ButtonSubmit isSubmitting={isSubmitting} />
+        </ButtonContainer>
+      </Form>
+    </MainFormDiv>
+  )
+
+  return isLoading ? <LoadingIndicator /> : form
+}
+
+SiteForm.propTypes = { isNewSite: PropTypes.bool.isRequired }
+
+export default SiteForm

--- a/mrtt-ui/src/views/SiteForm.js
+++ b/mrtt-ui/src/views/SiteForm.js
@@ -19,7 +19,7 @@ import mockLandscapes from '../data/mockLandscapes'
 
 const validationSchema = yup.object({
   site_name: yup.string().required(language.pages.siteform.validation.nameRequired),
-  landscape: yup.string()
+  landscape: yup.string().required(language.pages.siteform.validation.landscapeRequired)
 })
 
 const formDefaultValues = { site_name: '', landscape: '' }
@@ -125,7 +125,7 @@ const SiteForm = ({ isNewSite }) => {
           )}
         />
         <ErrorText>{errors?.site_name?.message}</ErrorText>
-        <FormLabel htmlFor='landscape'>{language.pages.siteform.labelLandscape} </FormLabel>
+        <FormLabel htmlFor='landscape'>{language.pages.siteform.labelLandscape}* </FormLabel>
         <Controller
           name='landscape'
           control={formControl}

--- a/mrtt-ui/src/views/SiteForm.js
+++ b/mrtt-ui/src/views/SiteForm.js
@@ -29,7 +29,7 @@ const SiteForm = ({ isNewSite }) => {
   const [isLoading, setIsLoading] = useState(false)
   const [isSubmitError, setIsSubmitError] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
-  const [doesItemNotExist, setDoesItemNotExist] = useState(false)
+  const [doesItemExist, setDoesItemExist] = useState(true)
   const sitesUrl = `${process.env.REACT_APP_API_URL}/sites/`
   const navigate = useNavigate()
 
@@ -53,7 +53,7 @@ const SiteForm = ({ isNewSite }) => {
           .catch((err) => {
             setIsLoading(false)
             if (err?.response?.status === 404) {
-              setDoesItemNotExist(true)
+              setDoesItemExist(false)
             } else {
               toast.error(language.error.apiLoad)
             }
@@ -80,7 +80,7 @@ const SiteForm = ({ isNewSite }) => {
 
   const editSite = (formData) => {
     axios
-      .put(`${sitesUrl}${siteId}`, formData)
+      .patch(`${sitesUrl}${siteId}`, formData)
       .then(({ data: { site_name } }) => {
         setIsSubmitting(false)
         toast.success(language.pages.siteform.getEditSiteSuccessMessage(site_name))
@@ -108,7 +108,7 @@ const SiteForm = ({ isNewSite }) => {
     navigate(-1)
   }
 
-  const form = doesItemNotExist ? (
+  const form = !doesItemExist ? (
     <ItemDoesntExist item='site' />
   ) : (
     <MainFormDiv>

--- a/mrtt-ui/src/views/SiteOverview.js
+++ b/mrtt-ui/src/views/SiteOverview.js
@@ -1,0 +1,7 @@
+import React from 'react'
+
+const SiteOverview = () => {
+  return <>SiteOverview placeholder</>
+}
+
+export default SiteOverview

--- a/mrtt-ui/src/views/Sites.js
+++ b/mrtt-ui/src/views/Sites.js
@@ -24,11 +24,24 @@ function Sites() {
       .catch(() => toast.error(language.error.apiLoad))
   }, [])
 
-  const sitesList = sites.map(({ site_name, id }) => (
-    <LinkCard key={id} to={`/site/${id}`}>
-      {site_name}
-    </LinkCard>
-  ))
+  const sitesList = sites
+    .sort((siteA, siteB) => {
+      const siteAName = siteA.site_name?.toLowerCase()
+      const siteBName = siteB.site_name?.toLowerCase()
+
+      if (siteAName < siteBName) {
+        return -1
+      }
+      if (siteAName < siteBName) {
+        return 1
+      }
+      return 0
+    })
+    .map(({ site_name, id }) => (
+      <LinkCard key={id} to={`/site/${id}/overview`}>
+        {site_name}
+      </LinkCard>
+    ))
 
   return isLoading ? (
     <LoadingIndicator />
@@ -36,7 +49,7 @@ function Sites() {
     <PagePadding>
       <RowSpaceBetween>
         <H4>{language.pages.sites.title}</H4>
-        <ButtonPrimary component={Link} to='#'>
+        <ButtonPrimary component={Link} to='/site/new'>
           {language.pages.sites.newSiteButton}
         </ButtonPrimary>
       </RowSpaceBetween>


### PR DESCRIPTION
- nav to new site form
- made form for new site and edit site
- cancel button
- edit site that doesnt exist - 'no site' messaging to user
- made reusable hook for populating questions forms (turns out not reusable for editing a site, but still valuable)
- minor bugs encountered fixed
- user can select mock landscapes, but server doesnt yet accept that data, just site name
- user cant yet nav to edit mode of form at `/site/:siteId/edit`
