### PR TITLE
Chore/section 2 bug fixes

### DIFF
--- a/mrtt-ui/src/components/ProjectDetailsForm.js
+++ b/mrtt-ui/src/components/ProjectDetailsForm.js
@@ -82,17 +82,23 @@ function ProjectDetailsForm() {
     }
   }
 
-  const { control, handleSubmit, formState, watch, reset: resetForm } = useForm(formOptions)
+  const {
+    control,
+    handleSubmit: validateInputs,
+    formState,
+    watch,
+    reset: resetForm
+  } = useForm(formOptions)
   const { errors } = formState
   const { siteId } = useParams()
-  const registrationAnswersUrl = `${process.env.REACT_APP_API_URL}/sites/${siteId}/registration_answers`
+  const apiAnswersUrl = `${process.env.REACT_APP_API_URL}/sites/${siteId}/registration_answers`
   let watchHasProjectEndDate = watch('hasProjectEndDate', false)
   /* showEndDateInput is a hack because MUI follows native html and casts values to strings.
    The api casts them to boolean so we support both */
   const showEndDateInput = watchHasProjectEndDate === 'true' || watchHasProjectEndDate === true
 
   useInitializeQuestionMappedForm({
-    apiUrl: registrationAnswersUrl,
+    apiUrl: apiAnswersUrl,
     resetForm,
     questionMapping: questionMapping.projectDetails,
     setIsLoading
@@ -124,14 +130,14 @@ function ProjectDetailsForm() {
     }
   }
 
-  const onSubmit = async (data) => {
+  const handleSubmit = async (formData) => {
     setIsSubmitting(true)
     setIsError(false)
 
-    if (!data) return
+    if (!formData) return
 
     axios
-      .patch(registrationAnswersUrl, mapDataForApi('projectDetails', data))
+      .patch(apiAnswersUrl, mapDataForApi('projectDetails', formData))
       .then(() => {
         setIsSubmitting(false)
       })
@@ -146,7 +152,7 @@ function ProjectDetailsForm() {
   ) : (
     <MainFormDiv>
       <SectionFormTitle>Project Details Form</SectionFormTitle>
-      <Form onSubmit={handleSubmit(onSubmit)}>
+      <Form onSubmit={validateInputs(handleSubmit)}>
         {/* Has project end date radio group */}
         <FormQuestionDiv>
           <FormLabel id='has-project-end-date-label'>

--- a/mrtt-ui/src/components/SiteBackgroundForm.js
+++ b/mrtt-ui/src/components/SiteBackgroundForm.js
@@ -266,7 +266,7 @@ const ProjectDetailsForm = () => {
           question={questions.landTenure.question}
           shouldAddOtherOptionWithClarification={true}
         />
-        <ErrorText>{errors.protectionStatus?.selectedValues?.message}</ErrorText>
+        <ErrorText>{errors.landTenure?.selectedValues?.message}</ErrorText>
         {/* customaryRights */}
         <FormQuestionDiv>
           <FormLabel>{questions.customaryRights.question}</FormLabel>

--- a/mrtt-ui/src/components/SiteBackgroundForm.js
+++ b/mrtt-ui/src/components/SiteBackgroundForm.js
@@ -26,10 +26,16 @@ import { multiselectWithOtherValidation } from '../validation/multiSelectWithOth
 import { siteBackground as questions } from '../data/questions'
 import CheckboxGroupWithLabelAndController from './CheckboxGroupWithLabelAndController'
 import language from '../language'
+import LoadingIndicator from './LoadingIndicator'
+import useInitializeQuestionMappedForm from '../library/useInitializeQuestionMappedForm'
+import { questionMapping } from '../data/questionMapping'
 
 const ProjectDetailsForm = () => {
   const { siteId } = useParams()
-  const registrationAnswersUrl = `${process.env.REACT_APP_API_URL}/sites/${siteId}/registration_answers`
+  const apiAnswersUrl = `${process.env.REACT_APP_API_URL}/sites/${siteId}/registration_answers`
+  const [isSubmitting, setisSubmitting] = useState(false)
+  const [isError, setIsError] = useState(false)
+  const [isLoading, setIsLoading] = useState(false)
 
   const validationSchema = yup.object().shape({
     stakeholders: yup
@@ -46,7 +52,7 @@ const ProjectDetailsForm = () => {
     lawStatus: yup.string(),
     managementArea: yup.string(),
     protectionStatus: multiselectWithOtherValidation,
-    areStakeholdersInvolved: yup.string(),
+    areStakeholdersInvolved: yup.string().nullable(),
     govermentArrangement: yup.array().of(yup.string()),
     landTenure: multiselectWithOtherValidation,
     customaryRights: yup.string()
@@ -63,7 +69,8 @@ const ProjectDetailsForm = () => {
   const {
     handleSubmit: validateInputs,
     formState: { errors },
-    control
+    control,
+    reset: resetForm
   } = reactHookFormInstance
 
   const {
@@ -72,17 +79,21 @@ const ProjectDetailsForm = () => {
     remove: stakeholdersRemove
   } = useFieldArray({ name: 'stakeholders', control })
 
-  const [isSubmitting, setisSubmitting] = useState(false)
-  const [isError, setIsError] = useState(false)
+  useInitializeQuestionMappedForm({
+    apiUrl: apiAnswersUrl,
+    questionMapping: questionMapping.siteBackground,
+    resetForm,
+    setIsLoading
+  })
 
-  const handleSubmit = async (data) => {
+  const handleSubmit = async (formData) => {
     setisSubmitting(true)
     setIsError(false)
 
-    if (!data) return
+    if (!formData) return
 
     axios
-      .patch(registrationAnswersUrl, mapDataForApi('siteBackground', data))
+      .patch(apiAnswersUrl, mapDataForApi('siteBackground', formData))
       .then(() => {
         setisSubmitting(false)
       })
@@ -104,7 +115,9 @@ const ProjectDetailsForm = () => {
   const getStakeholder = (stakeholder) =>
     stakeholdersFields.find((field) => field.stakeholderType === stakeholder)
 
-  return (
+  return isLoading ? (
+    <LoadingIndicator></LoadingIndicator>
+  ) : (
     <MainFormDiv>
       {/* Select Stakeholders */}
       <SectionFormTitle>Site Background Form</SectionFormTitle>
@@ -210,7 +223,7 @@ const ProjectDetailsForm = () => {
         <FormQuestionDiv>
           <FormLabel>{questions.areStakeholdersInvolved.question}</FormLabel>
           <Controller
-            name='areStakeholdersInvolved '
+            name='areStakeholdersInvolved'
             control={control}
             defaultValue=''
             render={({ field }) => (

--- a/mrtt-ui/src/data/questionMapping.js
+++ b/mrtt-ui/src/data/questionMapping.js
@@ -14,7 +14,7 @@ export const questionMapping = {
     protectionStatus: '2.5',
     areStakeholdersInvolved: '2.6',
     governmentArrangement: '2.7',
-    landTenture: '2.8',
+    landTenure: '2.8',
     customaryRights: '2.9'
   },
   restorationAims: {

--- a/mrtt-ui/src/library/useInitializeQuestionMappedForm.js
+++ b/mrtt-ui/src/library/useInitializeQuestionMappedForm.js
@@ -30,6 +30,7 @@ const useInitializeQuestionMappedForm = ({
             }
           })
           .catch(() => {
+            setIsLoading(false)
             toast.error(language.error.apiLoad)
           })
       }


### PR DESCRIPTION
# Description

- added initial form answer fetch for section 2
- fixed a bug in 2.5 where incorrect error message was showing up
- added update to loading indicator to `setLoading` to false if we catch an error
- updated apiUrl variable naming in section 1 to match the other sections

# Fixes[ issue 115
](https://github.com/globalmangrovewatch/gmw-users/issues/115)
- going to make a separate ticket for an issue where nested checked items do not show up as checked if you load answers from api (2.1). This is similar [to this ticket](https://github.com/globalmangrovewatch/gmw-users/issues/93).  This is due to the nesting involved.

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Instructions

1. Go to section 2
2. Fill out answers
3. Submit form
4. Refresh page
5. Ensure answers pre-populate

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
