### PR TITLE
[98] feat: basic landscapes list page.

### DIFF
--- a/mrtt-ui/src/language.js
+++ b/mrtt-ui/src/language.js
@@ -26,6 +26,7 @@ const pages = {
     noOtherOrganizations: 'There are no other organizations'
   },
   sites: { title: 'Sites', newSiteButton: 'New Site' },
+  landscapes: { title: 'Landscapes', newLandscapeButton: 'New Landscape' },
   siteform: {
     getEditSiteSuccessMessage: (siteName) => `${siteName} has been edited`,
     getNewSiteSuccessMessage: (siteName) => `${siteName}, has been created`,

--- a/mrtt-ui/src/views/Landscapes.js
+++ b/mrtt-ui/src/views/Landscapes.js
@@ -1,8 +1,61 @@
-import React from 'react'
+import { Stack } from '@mui/material'
+import axios from 'axios'
+import React, { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { toast } from 'react-toastify'
+import LoadingIndicator from '../components/LoadingIndicator'
+import language from '../language'
+import { ButtonPrimary } from '../styles/buttons'
+import { LinkCard, PagePadding, RowSpaceBetween } from '../styles/containers'
+import { H4 } from '../styles/typography'
 
-/** Scaffold component for the /landscapes route */
+const landscapesUrl = `${process.env.REACT_APP_API_URL}/landscapes/`
 function Landscapes() {
-  return <div>Landscapes (views/Landscapes)</div>
+  const [isLoading, setIsLoading] = useState(true)
+  const [landscapes, setLandscapes] = useState([])
+
+  useEffect(function loadSitesData() {
+    axios
+      .get(landscapesUrl)
+      .then(({ data }) => {
+        setIsLoading(false)
+        setLandscapes(data)
+      })
+      .catch(() => toast.error(language.error.apiLoad))
+  }, [])
+
+  const landscapesList = landscapes
+    .sort((landscapeA, landscapeB) => {
+      const landscapeAName = landscapeA.landscape_name?.toLowerCase()
+      const landscapeBName = landscapeB.landscape_name?.toLowerCase()
+
+      if (landscapeAName < landscapeBName) {
+        return -1
+      }
+      if (landscapeAName < landscapeBName) {
+        return 1
+      }
+      return 0
+    })
+    .map(({ landscape_name, id }) => (
+      <LinkCard key={id} to='#'>
+        {landscape_name}
+      </LinkCard>
+    ))
+
+  return isLoading ? (
+    <LoadingIndicator />
+  ) : (
+    <PagePadding>
+      <RowSpaceBetween>
+        <H4>{language.pages.landscapes.title}</H4>
+        <ButtonPrimary component={Link} to='#'>
+          {language.pages.landscapes.newLandscapeButton}
+        </ButtonPrimary>
+      </RowSpaceBetween>
+      <Stack>{landscapesList}</Stack>
+    </PagePadding>
+  )
 }
 
 export default Landscapes


### PR DESCRIPTION
closes #98 

basic landscapes list

out of scope: create, edit, delete, filter, extra info api doesnt support, onclick for single landscape
