### PR TITLE
Bug Fix for 2.1 : checked items now appear after submit + refresh

### DIFF
--- a/mrtt-ui/src/components/CausesOfDeclineForm.js
+++ b/mrtt-ui/src/components/CausesOfDeclineForm.js
@@ -84,7 +84,6 @@ function CausesOfDeclineForm() {
   const [isSubmitting, setisSubmitting] = useState(false)
   const [isError, setIsError] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
-  const [causesOfDeclineCopy, setCausesOfDeclineCopy] = useState([])
   const { siteId } = useParams()
   const apiAnswersUrl = `${process.env.REACT_APP_API_URL}/sites/${siteId}/registration_answers`
 
@@ -99,9 +98,6 @@ function CausesOfDeclineForm() {
             apiAnswers: data,
             questionMapping: questionMapping.causesOfDecline
           })
-          // nested answer set requires a custom solution for setting initial values
-          setCausesOfDeclineCopy(initialValuesForForm.causesOfDecline)
-          console.log('initial vals: ', initialValuesForForm.causesOfDecline)
 
           resetForm(initialValuesForForm)
         })
@@ -232,13 +228,6 @@ function CausesOfDeclineForm() {
       })
   }
 
-  const checkIfMainAnswerExists = (mainCauseIndex, childIndex, childOption) => {
-    const answer =
-      causesOfDeclineCopy?.[mainCauseIndex]?.mainCauseAnswers?.[childIndex]?.mainCauseAnswer
-
-    return answer === childOption ? true : false
-  }
-
   return isLoading ? (
     <LoadingIndicator />
   ) : (
@@ -278,11 +267,6 @@ function CausesOfDeclineForm() {
                             <ListItem>
                               <Checkbox
                                 value={childOption}
-                                checked={checkIfMainAnswerExists(
-                                  mainCauseIndex,
-                                  childIndex,
-                                  childOption
-                                )}
                                 onChange={(event) =>
                                   handleCausesOfDeclineOnChange({
                                     event,

--- a/mrtt-ui/src/components/CausesOfDeclineForm.js
+++ b/mrtt-ui/src/components/CausesOfDeclineForm.js
@@ -84,6 +84,7 @@ function CausesOfDeclineForm() {
   const [isSubmitting, setisSubmitting] = useState(false)
   const [isError, setIsError] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
+  const [causesOfDeclineCopy, setCausesOfDeclineCopy] = useState([])
   const { siteId } = useParams()
   const apiAnswersUrl = `${process.env.REACT_APP_API_URL}/sites/${siteId}/registration_answers`
 
@@ -98,6 +99,9 @@ function CausesOfDeclineForm() {
             apiAnswers: data,
             questionMapping: questionMapping.causesOfDecline
           })
+          // nested answer set requires a custom solution for setting initial values
+          setCausesOfDeclineCopy(initialValuesForForm.causesOfDecline)
+          console.log('initial vals: ', initialValuesForForm.causesOfDecline)
 
           resetForm(initialValuesForForm)
         })
@@ -228,6 +232,13 @@ function CausesOfDeclineForm() {
       })
   }
 
+  const checkIfMainAnswerExists = (mainCauseIndex, childIndex, childOption) => {
+    const answer =
+      causesOfDeclineCopy?.[mainCauseIndex]?.mainCauseAnswers?.[childIndex]?.mainCauseAnswer
+
+    return answer === childOption ? true : false
+  }
+
   return isLoading ? (
     <LoadingIndicator />
   ) : (
@@ -267,6 +278,11 @@ function CausesOfDeclineForm() {
                             <ListItem>
                               <Checkbox
                                 value={childOption}
+                                checked={checkIfMainAnswerExists(
+                                  mainCauseIndex,
+                                  childIndex,
+                                  childOption
+                                )}
                                 onChange={(event) =>
                                   handleCausesOfDeclineOnChange({
                                     event,

--- a/mrtt-ui/src/components/SiteBackgroundForm.js
+++ b/mrtt-ui/src/components/SiteBackgroundForm.js
@@ -253,36 +253,6 @@ const ProjectDetailsForm = () => {
           // shouldAddOtherOptionWithClarification={true}
         />
         <ErrorText>{errors.govermentArrangement?.message}</ErrorText>
-        {/* <FormQuestionDiv>
-          <FormLabel>{siteBackground.govermentArrangement.question}</FormLabel>
-          <Controller
-            name='governmentArrangement'
-            control={control}
-            defaultValue={[]}
-            render={({ field }) => (
-              <Select
-                {...field}
-                multiple
-                value={field.value}
-                label={language.form.selectLabel}
-                input={<OutlinedInput id='select-multiple-chip' label='Chip' />}
-                renderValue={(selected) => (
-                  <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
-                    {selected.map((value) => (
-                      <Chip key={value} label={value} />
-                    ))}
-                  </Box>
-                )}>
-                {siteBackground.govermentArrangement.options.map((item, index) => (
-                  <MenuItem key={index} value={item}>
-                    {item}
-                  </MenuItem>
-                ))}
-              </Select>
-            )}
-          />
-          <ErrorText>{errors.govermentArrangement?.message}</ErrorText>
-        </FormQuestionDiv> */}
         {/* Land Tenure */}
         <CheckboxGroupWithLabelAndController
           fieldName='landTenure'

--- a/mrtt-ui/src/components/SiteBackgroundForm.js
+++ b/mrtt-ui/src/components/SiteBackgroundForm.js
@@ -1,13 +1,13 @@
 import {
   Box,
   Checkbox,
-  Chip,
+  // Chip,
   FormLabel,
   List,
   ListItem,
   MenuItem,
-  OutlinedInput,
-  Select,
+  // OutlinedInput,
+  // Select,
   TextField,
   Typography
 } from '@mui/material'
@@ -23,7 +23,7 @@ import { ErrorText, Link } from '../styles/typography'
 import { FormQuestionDiv, MainFormDiv, SectionFormTitle } from '../styles/forms'
 import { mapDataForApi } from '../library/mapDataForApi'
 import { multiselectWithOtherValidation } from '../validation/multiSelectWithOther'
-import { siteBackground as questions } from '../data/questions'
+import { siteBackground } from '../data/questions'
 import { toast } from 'react-toastify'
 import CheckboxGroupWithLabelAndController from './CheckboxGroupWithLabelAndController'
 import language from '../language'
@@ -54,7 +54,7 @@ const ProjectDetailsForm = () => {
     managementArea: yup.string(),
     protectionStatus: multiselectWithOtherValidation,
     areStakeholdersInvolved: yup.string().nullable(),
-    govermentArrangement: yup.array().of(yup.string()),
+    governmentArrangement: yup.array().of(yup.string()),
     landTenure: multiselectWithOtherValidation,
     customaryRights: yup.string()
   })
@@ -127,9 +127,9 @@ const ProjectDetailsForm = () => {
       <Link to={-1}>&lt; {language.form.navigateBackToSiteOverview}</Link>
       <form onSubmit={validateInputs(handleSubmit)}>
         <FormQuestionDiv>
-          <FormLabel>{questions.stakeholders.question}</FormLabel>
+          <FormLabel>{siteBackground.stakeholders.question}</FormLabel>
           <List>
-            {questions.stakeholders.options.map((stakeholder, index) => (
+            {siteBackground.stakeholders.options.map((stakeholder, index) => (
               <ListItem key={index}>
                 <Box>
                   <Box>
@@ -167,14 +167,14 @@ const ProjectDetailsForm = () => {
         </FormQuestionDiv>
         {/* Select Management Status*/}
         <FormQuestionDiv>
-          <FormLabel>{questions.managementStatus.question}</FormLabel>
+          <FormLabel>{siteBackground.managementStatus.question}</FormLabel>
           <Controller
             name='managementStatus'
             control={control}
             defaultValue=''
             render={({ field }) => (
               <TextField {...field} select value={field.value} label={language.form.selectLabel}>
-                {questions.managementStatus.options.map((item, index) => (
+                {siteBackground.managementStatus.options.map((item, index) => (
                   <MenuItem key={index} value={item}>
                     {item}
                   </MenuItem>
@@ -186,14 +186,14 @@ const ProjectDetailsForm = () => {
         </FormQuestionDiv>
         {/* Law recognition */}
         <FormQuestionDiv>
-          <FormLabel>{questions.lawStatus.question}</FormLabel>
+          <FormLabel>{siteBackground.lawStatus.question}</FormLabel>
           <Controller
             name='lawStatus'
             control={control}
             defaultValue=''
             render={({ field }) => (
               <TextField {...field} select value={field.value} label={language.form.selectLabel}>
-                {questions.lawStatus.options.map((item, index) => (
+                {siteBackground.lawStatus.options.map((item, index) => (
                   <MenuItem key={index} value={item}>
                     {item}
                   </MenuItem>
@@ -205,7 +205,7 @@ const ProjectDetailsForm = () => {
         </FormQuestionDiv>
         {/* Management Area*/}
         <FormQuestionDiv>
-          <FormLabel>{questions.managementArea.question}</FormLabel>
+          <FormLabel>{siteBackground.managementArea.question}</FormLabel>
           <Controller
             name='managementArea'
             control={control}
@@ -218,21 +218,21 @@ const ProjectDetailsForm = () => {
         <CheckboxGroupWithLabelAndController
           fieldName='protectionStatus'
           reactHookFormInstance={reactHookFormInstance}
-          options={questions.protectionStatus.options}
-          question={questions.protectionStatus.question}
+          options={siteBackground.protectionStatus.options}
+          question={siteBackground.protectionStatus.question}
           shouldAddOtherOptionWithClarification={true}
         />
         <ErrorText>{errors.protectionStatus?.selectedValues?.message}</ErrorText>
         {/* areStakeholdersInvolved */}
         <FormQuestionDiv>
-          <FormLabel>{questions.areStakeholdersInvolved.question}</FormLabel>
+          <FormLabel>{siteBackground.areStakeholdersInvolved.question}</FormLabel>
           <Controller
             name='areStakeholdersInvolved'
             control={control}
             defaultValue=''
             render={({ field }) => (
               <TextField {...field} select value={field.value} label={language.form.selectLabel}>
-                {questions.areStakeholdersInvolved.options.map((item, index) => (
+                {siteBackground.areStakeholdersInvolved.options.map((item, index) => (
                   <MenuItem key={index} value={item}>
                     {item}
                   </MenuItem>
@@ -245,8 +245,16 @@ const ProjectDetailsForm = () => {
           </ErrorText>
         </FormQuestionDiv>
         {/* Government Arrangement */}
-        <FormQuestionDiv>
-          <FormLabel>{questions.govermentArrangement.question}</FormLabel>
+        <CheckboxGroupWithLabelAndController
+          fieldName='governmentArrangement'
+          reactHookFormInstance={reactHookFormInstance}
+          options={siteBackground.governmentArrangement.options}
+          question={siteBackground.governmentArrangement.question}
+          // shouldAddOtherOptionWithClarification={true}
+        />
+        <ErrorText>{errors.govermentArrangement?.message}</ErrorText>
+        {/* <FormQuestionDiv>
+          <FormLabel>{siteBackground.govermentArrangement.question}</FormLabel>
           <Controller
             name='governmentArrangement'
             control={control}
@@ -265,7 +273,7 @@ const ProjectDetailsForm = () => {
                     ))}
                   </Box>
                 )}>
-                {questions.govermentArrangement.options.map((item, index) => (
+                {siteBackground.govermentArrangement.options.map((item, index) => (
                   <MenuItem key={index} value={item}>
                     {item}
                   </MenuItem>
@@ -274,26 +282,26 @@ const ProjectDetailsForm = () => {
             )}
           />
           <ErrorText>{errors.govermentArrangement?.message}</ErrorText>
-        </FormQuestionDiv>
+        </FormQuestionDiv> */}
         {/* Land Tenure */}
         <CheckboxGroupWithLabelAndController
           fieldName='landTenure'
           reactHookFormInstance={reactHookFormInstance}
-          options={questions.landTenure.options}
-          question={questions.landTenure.question}
+          options={siteBackground.landTenure.options}
+          question={siteBackground.landTenure.question}
           shouldAddOtherOptionWithClarification={true}
         />
         <ErrorText>{errors.landTenure?.selectedValues?.message}</ErrorText>
         {/* customaryRights */}
         <FormQuestionDiv>
-          <FormLabel>{questions.customaryRights.question}</FormLabel>
+          <FormLabel>{siteBackground.customaryRights.question}</FormLabel>
           <Controller
             name='customaryRights'
             control={control}
             defaultValue=''
             render={({ field }) => (
               <TextField {...field} select value={field.value} label={language.form.selectLabel}>
-                {questions.customaryRights.options.map((item, index) => (
+                {siteBackground.customaryRights.options.map((item, index) => (
                   <MenuItem key={index} value={item}>
                     {item}
                   </MenuItem>

--- a/mrtt-ui/src/data/questions.js
+++ b/mrtt-ui/src/data/questions.js
@@ -77,7 +77,7 @@ const siteBackground = {
       '2.6 Are the stakeholders involved in project activities able to influence site management rules?',
     options: ['Yes', 'No', 'Partially']
   },
-  govermentArrangement: {
+  governmentArrangement: {
     question:
       '2.7 What best describes the governance arrangement of the site immediately before the project started?',
     options: [


### PR DESCRIPTION
# Description

Previously, when you would refresh, checked items would not appear after submitting answers for 2.1. This fixes the issue.

I added a new array for useState that always have up to date stakeholderTypes (string values, not the whole object). 

This is a more performance optimized version (as opposed to searching through an array of objects every time). Performance optimization will be much more noticeable in section 4 (the heavily nested section) when the same pattern is used .

Fixes # (missing issue, but similar to [4.2 bug](https://github.com/globalmangrovewatch/gmw-users/issues/93))

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Instructions

1. Go to section 2 (Site Background Form)
2. Submit answers (particularly for 2.1)
3. Refresh
4. Answers should be checked in 2.1

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
