### PR TITLE
[BUG FIX] Section 4 form - update checked items to display correctly in 4.2 upon initial load

### DIFF
--- a/mrtt-ui/src/components/CausesOfDeclineForm.js
+++ b/mrtt-ui/src/components/CausesOfDeclineForm.js
@@ -84,8 +84,7 @@ function CausesOfDeclineForm() {
   const [isSubmitting, setisSubmitting] = useState(false)
   const [isError, setIsError] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
-  // an array for managing isChecked items
-  const [causesOfDeclineTypes, setCausesOfDeclineTypes] = useState([])
+  const [causesOfDeclineTypesIsChecked, setCausesOfDeclineTypes] = useState([])
   const { siteId } = useParams()
   const apiAnswersUrl = `${process.env.REACT_APP_API_URL}/sites/${siteId}/registration_answers`
 
@@ -147,7 +146,7 @@ function CausesOfDeclineForm() {
       (subCause) => subCause.subCauseLabel === subCauseLabel
     )
     const currentSubCause = currentMainCause?.subCauses?.[subCauseIndex]
-    const causesOfDeclineTypesCopy = causesOfDeclineTypes
+    const causesOfDeclineTypesIsCheckedCopy = causesOfDeclineTypesIsChecked
 
     //  case: checked, no subCause, and mainCause does not exist
     if (event.target.checked && !subCauseLabel && mainCauseIndex === -1) {
@@ -155,7 +154,7 @@ function CausesOfDeclineForm() {
         mainCauseLabel,
         mainCauseAnswers: [{ mainCauseAnswer: childOption, levelOfDegredation: '' }]
       })
-      causesOfDeclineTypesCopy.push(`${mainCauseLabel}-${childOption}`)
+      causesOfDeclineTypesIsCheckedCopy.push(`${mainCauseLabel}-${childOption}`)
     }
     // case: checked, no subCause, mainCause exists
     else if (event.target.checked && !subCauseLabel && mainCauseIndex > -1) {
@@ -164,7 +163,7 @@ function CausesOfDeclineForm() {
         levelOfDegredation: ''
       })
       causesOfDeclineUpdate(currentMainCause)
-      causesOfDeclineTypesCopy.push(`${mainCauseLabel}-${childOption}`)
+      causesOfDeclineTypesIsCheckedCopy.push(`${mainCauseLabel}-${childOption}`)
     }
     // case: checked, subCause, mainCause does not exist
     else if (event.target.checked && subCauseLabel && mainCauseIndex === -1) {
@@ -177,7 +176,7 @@ function CausesOfDeclineForm() {
           }
         ]
       })
-      causesOfDeclineTypesCopy.push(`${subCauseLabel}-${secondaryChildOption}`)
+      causesOfDeclineTypesIsCheckedCopy.push(`${subCauseLabel}-${secondaryChildOption}`)
     }
     // case: checked, subCause, mainCause does exist
     else if (event.target.checked && subCauseLabel && mainCauseIndex > -1) {
@@ -197,7 +196,7 @@ function CausesOfDeclineForm() {
         })
         causesOfDeclineUpdate(currentMainCause)
       }
-      causesOfDeclineTypesCopy.push(`${subCauseLabel}-${secondaryChildOption}`)
+      causesOfDeclineTypesIsCheckedCopy.push(`${subCauseLabel}-${secondaryChildOption}`)
     }
     // case: unchecked, no subCause
     else if (!event.target.checked && !subCauseLabel) {
@@ -213,10 +212,10 @@ function CausesOfDeclineForm() {
         currentMainCause.mainCauseAnswers.splice(childOptionIndex, 1)
         causesOfDeclineUpdate(currentMainCause)
       }
-      const typeIndex = causesOfDeclineTypesCopy.findIndex(
+      const typeIndex = causesOfDeclineTypesIsCheckedCopy.findIndex(
         (type) => type === `${mainCauseLabel}-${childOption}`
       )
-      causesOfDeclineTypesCopy.splice(typeIndex, 1)
+      causesOfDeclineTypesIsCheckedCopy.splice(typeIndex, 1)
     }
     // case: unchecked, subCause exists
     else if (!event.target.checked && subCauseLabel) {
@@ -237,13 +236,12 @@ function CausesOfDeclineForm() {
       if (currentMainCause.subCauses.length === 0) {
         causesOfDeclineRemove(mainCauseIndex)
       }
-      const typeIndex = causesOfDeclineTypesCopy.findIndex(
+      const typeIndex = causesOfDeclineTypesIsCheckedCopy.findIndex(
         (type) => type === `${subCauseLabel}-${secondaryChildOption}`
       )
-      causesOfDeclineTypesCopy.splice(typeIndex, 1)
+      causesOfDeclineTypesIsCheckedCopy.splice(typeIndex, 1)
     }
-    setCausesOfDeclineTypes(causesOfDeclineTypesCopy)
-    console.log('types: ', causesOfDeclineTypes)
+    setCausesOfDeclineTypes(causesOfDeclineTypesIsCheckedCopy)
   }
 
   const onSubmit = async (data) => {
@@ -305,7 +303,7 @@ function CausesOfDeclineForm() {
                             <ListItem>
                               <Checkbox
                                 value={childOption}
-                                checked={causesOfDeclineTypes.includes(
+                                checked={causesOfDeclineTypesIsChecked.includes(
                                   `${mainCause.label}-${childOption}`
                                 )}
                                 onChange={(event) =>
@@ -334,7 +332,7 @@ function CausesOfDeclineForm() {
                                     control={
                                       <Checkbox
                                         value={secondaryChildOption}
-                                        checked={causesOfDeclineTypes.includes(
+                                        checked={causesOfDeclineTypesIsChecked.includes(
                                           `${subCause.secondaryLabel}-${secondaryChildOption}`
                                         )}
                                         onChange={(event) =>

--- a/mrtt-ui/src/components/CausesOfDeclineForm.js
+++ b/mrtt-ui/src/components/CausesOfDeclineForm.js
@@ -1,5 +1,5 @@
 import { toast } from 'react-toastify'
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import axios from 'axios'
 import { useParams } from 'react-router-dom'
 import {
@@ -32,9 +32,9 @@ import { causesOfDeclineOptions } from '../data/causesOfDeclineOptions'
 import { ErrorText, Link } from '../styles/typography'
 import { mapDataForApi } from '../library/mapDataForApi'
 import { questionMapping } from '../data/questionMapping'
-import formatApiAnswersForForm from '../library/formatApiAnswersForForm'
 import language from '../language'
 import LoadingIndicator from './LoadingIndicator'
+import useInitializeQuestionMappedForm from '../library/useInitializeQuestionMappedForm'
 
 function CausesOfDeclineForm() {
   const validationSchema = yup.object().shape({
@@ -84,28 +84,18 @@ function CausesOfDeclineForm() {
   const [isSubmitting, setisSubmitting] = useState(false)
   const [isError, setIsError] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
+  // an array for managing isChecked items
+  // const [causesOfDeclineTypes, setCausesOfDeclineTypes] = useState([])
   const { siteId } = useParams()
   const apiAnswersUrl = `${process.env.REACT_APP_API_URL}/sites/${siteId}/registration_answers`
 
-  const _loadSiteData = useEffect(() => {
-    if (apiAnswersUrl && resetForm) {
-      setIsLoading(true)
-      axios
-        .get(apiAnswersUrl)
-        .then(({ data }) => {
-          setIsLoading(false)
-          const initialValuesForForm = formatApiAnswersForForm({
-            apiAnswers: data,
-            questionMapping: questionMapping.causesOfDecline
-          })
-
-          resetForm(initialValuesForForm)
-        })
-        .catch(() => {
-          toast.error(language.error.apiLoad)
-        })
-    }
-  }, [apiAnswersUrl, resetForm])
+  useInitializeQuestionMappedForm({
+    apiUrl: apiAnswersUrl,
+    questionMapping: questionMapping.causesOfDecline,
+    resetForm,
+    setIsLoading
+    // successCallback: setInitialStakeholderTypesFromServerData
+  })
 
   // big function with many different cases for Q4.2 due to the nesting involved in this question type
   const handleCausesOfDeclineOnChange = ({

--- a/mrtt-ui/src/components/CausesOfDeclineForm.js
+++ b/mrtt-ui/src/components/CausesOfDeclineForm.js
@@ -84,7 +84,7 @@ function CausesOfDeclineForm() {
   const [isSubmitting, setisSubmitting] = useState(false)
   const [isError, setIsError] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
-  const [causesOfDeclineTypesIsChecked, setCausesOfDeclineTypes] = useState([])
+  const [causesOfDeclineTypesIsChecked, setCausesOfDeclineTypesIsChecked] = useState([])
   const { siteId } = useParams()
   const apiAnswersUrl = `${process.env.REACT_APP_API_URL}/sites/${siteId}/registration_answers`
 
@@ -93,7 +93,7 @@ function CausesOfDeclineForm() {
     const initialCausesOfDecline =
       serverResponse?.data.find((dataItem) => dataItem.question_id === '4.2')?.answer_value ?? []
 
-    const initialCausesOfDeclineTypes = []
+    const initialCausesOfDeclineTypesIsChecked = []
 
     // function that adds `${cause}-${causeAnswer}` to initialCausesOfDeclineTypes array, to simplify
     // isChecked lookups (as opposed to searching through deeply nested values every time)
@@ -104,7 +104,9 @@ function CausesOfDeclineForm() {
         const label = cause.mainCauseLabel
         // adding maincause label appended to answer to avoid situations
         // where we have the same answers for different causes
-        mainCauseAnswers.forEach((answer) => initialCausesOfDeclineTypes.push(`${label}-${answer}`))
+        mainCauseAnswers.forEach((answer) =>
+          initialCausesOfDeclineTypesIsChecked.push(`${label}-${answer}`)
+        )
       }
       // map types for subCase options
       else {
@@ -114,12 +116,12 @@ function CausesOfDeclineForm() {
           const label = subCause.subCauseLabel
           const answers = subCause.subCauseAnswers
           answers.forEach((answer) => {
-            initialCausesOfDeclineTypes.push(`${label}-${answer.subCauseAnswer}`)
+            initialCausesOfDeclineTypesIsChecked.push(`${label}-${answer.subCauseAnswer}`)
           })
         })
       }
     })
-    setCausesOfDeclineTypes(initialCausesOfDeclineTypes)
+    setCausesOfDeclineTypesIsChecked(initialCausesOfDeclineTypesIsChecked)
   }, [])
 
   useInitializeQuestionMappedForm({
@@ -241,7 +243,7 @@ function CausesOfDeclineForm() {
       )
       causesOfDeclineTypesIsCheckedCopy.splice(typeIndex, 1)
     }
-    setCausesOfDeclineTypes(causesOfDeclineTypesIsCheckedCopy)
+    setCausesOfDeclineTypesIsChecked(causesOfDeclineTypesIsCheckedCopy)
   }
 
   const onSubmit = async (data) => {

--- a/mrtt-ui/src/components/CausesOfDeclineForm.js
+++ b/mrtt-ui/src/components/CausesOfDeclineForm.js
@@ -102,12 +102,10 @@ function CausesOfDeclineForm() {
       // map types for mainCause options
       if (cause.mainCauseAnswers) {
         const mainCauseAnswers = cause.mainCauseAnswers?.map((answer) => answer.mainCauseAnswer)
-
+        const label = cause.mainCauseLabel
         // adding maincause label appended to answer to avoid situations
         // where we have the same answers for different causes
-        mainCauseAnswers.forEach((answer) =>
-          initialCausesOfDeclineTypes.push(`${cause.mainCauseLabel}-${answer}`)
-        )
+        mainCauseAnswers.forEach((answer) => initialCausesOfDeclineTypes.push(`${label}-${answer}`))
       }
       // map types for subCase options
       else {
@@ -124,8 +122,6 @@ function CausesOfDeclineForm() {
     })
     setCausesOfDeclineTypes(initialCausesOfDeclineTypes)
   }, [])
-
-  console.log('causeOF Types', causesOfDeclineTypes)
 
   useInitializeQuestionMappedForm({
     apiUrl: apiAnswersUrl,
@@ -151,6 +147,7 @@ function CausesOfDeclineForm() {
       (subCause) => subCause.subCauseLabel === subCauseLabel
     )
     const currentSubCause = currentMainCause?.subCauses?.[subCauseIndex]
+    const causesOfDeclineTypesCopy = causesOfDeclineTypes
 
     //  case: checked, no subCause, and mainCause does not exist
     if (event.target.checked && !subCauseLabel && mainCauseIndex === -1) {
@@ -158,6 +155,7 @@ function CausesOfDeclineForm() {
         mainCauseLabel,
         mainCauseAnswers: [{ mainCauseAnswer: childOption, levelOfDegredation: '' }]
       })
+      causesOfDeclineTypesCopy.push(`${mainCauseLabel}-${childOption}`)
     }
     // case: checked, no subCause, mainCause exists
     else if (event.target.checked && !subCauseLabel && mainCauseIndex > -1) {
@@ -165,8 +163,8 @@ function CausesOfDeclineForm() {
         mainCauseAnswer: childOption,
         levelOfDegredation: ''
       })
-
       causesOfDeclineUpdate(currentMainCause)
+      causesOfDeclineTypesCopy.push(`${mainCauseLabel}-${childOption}`)
     }
     // case: checked, subCause, mainCause does not exist
     else if (event.target.checked && subCauseLabel && mainCauseIndex === -1) {
@@ -179,6 +177,7 @@ function CausesOfDeclineForm() {
           }
         ]
       })
+      causesOfDeclineTypesCopy.push(`${subCauseLabel}-${secondaryChildOption}`)
     }
     // case: checked, subCause, mainCause does exist
     else if (event.target.checked && subCauseLabel && mainCauseIndex > -1) {
@@ -198,6 +197,7 @@ function CausesOfDeclineForm() {
         })
         causesOfDeclineUpdate(currentMainCause)
       }
+      causesOfDeclineTypesCopy.push(`${subCauseLabel}-${secondaryChildOption}`)
     }
     // case: unchecked, no subCause
     else if (!event.target.checked && !subCauseLabel) {
@@ -213,6 +213,10 @@ function CausesOfDeclineForm() {
         currentMainCause.mainCauseAnswers.splice(childOptionIndex, 1)
         causesOfDeclineUpdate(currentMainCause)
       }
+      const typeIndex = causesOfDeclineTypesCopy.findIndex(
+        (type) => type === `${mainCauseLabel}-${childOption}`
+      )
+      causesOfDeclineTypesCopy.splice(typeIndex, 1)
     }
     // case: unchecked, subCause exists
     else if (!event.target.checked && subCauseLabel) {
@@ -233,7 +237,13 @@ function CausesOfDeclineForm() {
       if (currentMainCause.subCauses.length === 0) {
         causesOfDeclineRemove(mainCauseIndex)
       }
+      const typeIndex = causesOfDeclineTypesCopy.findIndex(
+        (type) => type === `${subCauseLabel}-${secondaryChildOption}`
+      )
+      causesOfDeclineTypesCopy.splice(typeIndex, 1)
     }
+    setCausesOfDeclineTypes(causesOfDeclineTypesCopy)
+    console.log('types: ', causesOfDeclineTypes)
   }
 
   const onSubmit = async (data) => {
@@ -295,6 +305,9 @@ function CausesOfDeclineForm() {
                             <ListItem>
                               <Checkbox
                                 value={childOption}
+                                checked={causesOfDeclineTypes.includes(
+                                  `${mainCause.label}-${childOption}`
+                                )}
                                 onChange={(event) =>
                                   handleCausesOfDeclineOnChange({
                                     event,
@@ -321,6 +334,9 @@ function CausesOfDeclineForm() {
                                     control={
                                       <Checkbox
                                         value={secondaryChildOption}
+                                        checked={causesOfDeclineTypes.includes(
+                                          `${subCause.secondaryLabel}-${secondaryChildOption}`
+                                        )}
                                         onChange={(event) =>
                                           handleCausesOfDeclineOnChange({
                                             event,

--- a/mrtt-ui/src/components/SiteBackgroundForm.js
+++ b/mrtt-ui/src/components/SiteBackgroundForm.js
@@ -34,8 +34,7 @@ const ProjectDetailsForm = () => {
   const [isSubmitting, setisSubmitting] = useState(false)
   const [isError, setIsError] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
-  // an array for managing isChecked items
-  const [stakeholderTypes, setStakeholderTypes] = useState([])
+  const [stakeholderTypesIsChecked, setStakeholderTypesIsChecked] = useState([])
 
   const validationSchema = yup.object().shape({
     stakeholders: yup
@@ -83,10 +82,10 @@ const ProjectDetailsForm = () => {
     const initialStakeholders =
       serverResponse?.data.find((dataItem) => dataItem.question_id === '2.1')?.answer_value ?? []
 
-    const initialStakeholderTypes = initialStakeholders?.map(
+    const initialStakeholderTypesIsChecked = initialStakeholders?.map(
       (stakeholder) => stakeholder.stakeholderType
     )
-    setStakeholderTypes(initialStakeholderTypes)
+    setStakeholderTypesIsChecked(initialStakeholderTypesIsChecked)
   }, [])
 
   useInitializeQuestionMappedForm({
@@ -117,19 +116,19 @@ const ProjectDetailsForm = () => {
   }
 
   const handleStakeholdersOnChange = (event, stakeholder) => {
-    const stakeholderTypesCopy = stakeholderTypes
+    const stakeholderTypesIsCheckedCopy = stakeholderTypesIsChecked
     if (event.target.checked) {
       stakeholdersAppend({ stakeholderType: stakeholder })
-      stakeholderTypesCopy.push(stakeholder)
+      stakeholderTypesIsCheckedCopy.push(stakeholder)
     } else {
       const fieldIndex = stakeholdersFields.findIndex(
         (field) => field.stakeholderType === stakeholder
       )
-      const typeIndex = stakeholderTypesCopy.findIndex((type) => type === stakeholder)
-      stakeholderTypesCopy.splice(typeIndex, 1)
+      const typeIndex = stakeholderTypesIsCheckedCopy.findIndex((type) => type === stakeholder)
+      stakeholderTypesIsCheckedCopy.splice(typeIndex, 1)
       stakeholdersRemove(fieldIndex)
     }
-    setStakeholderTypes(stakeholderTypesCopy)
+    setStakeholderTypesIsChecked(stakeholderTypesIsCheckedCopy)
   }
 
   const getStakeholder = (stakeholder) =>
@@ -152,7 +151,7 @@ const ProjectDetailsForm = () => {
                   <Box>
                     <Checkbox
                       value={stakeholder}
-                      checked={stakeholderTypes.includes(stakeholder)}
+                      checked={stakeholderTypesIsChecked.includes(stakeholder)}
                       onChange={(event) =>
                         handleStakeholdersOnChange(event, stakeholder)
                       }></Checkbox>

--- a/mrtt-ui/src/components/SiteBackgroundForm.js
+++ b/mrtt-ui/src/components/SiteBackgroundForm.js
@@ -120,16 +120,16 @@ const ProjectDetailsForm = () => {
     const stakeholderTypesCopy = stakeholderTypes
     if (event.target.checked) {
       stakeholdersAppend({ stakeholderType: stakeholder })
-      stakeholderTypes.push(stakeholder)
+      stakeholderTypesCopy.push(stakeholder)
     } else {
       const fieldIndex = stakeholdersFields.findIndex(
         (field) => field.stakeholderType === stakeholder
       )
       const typeIndex = stakeholderTypesCopy.findIndex((type) => type === stakeholder)
       stakeholderTypesCopy.splice(typeIndex, 1)
-      setStakeholderTypes(stakeholderTypesCopy)
       stakeholdersRemove(fieldIndex)
     }
+    setStakeholderTypes(stakeholderTypesCopy)
   }
 
   const getStakeholder = (stakeholder) =>

--- a/mrtt-ui/src/components/SiteBackgroundForm.js
+++ b/mrtt-ui/src/components/SiteBackgroundForm.js
@@ -34,6 +34,7 @@ const ProjectDetailsForm = () => {
   const [isSubmitting, setisSubmitting] = useState(false)
   const [isError, setIsError] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
+  // an array for managing isChecked items
   const [stakeholderTypes, setStakeholderTypes] = useState([])
 
   const validationSchema = yup.object().shape({


### PR DESCRIPTION
# Description

Fixes bug where checked items were not showing as checked upon initial load (when previous answers exist). 

I added an array which makes managing checked items easier to manage. When an item is checked/unchecked, a ``${label}-${answer}`` gets added or removed from the array. This is way less complicated than filtering through deeply nested items, and much less computationally expensive.
 
[Fixes # (93)](https://github.com/globalmangrovewatch/gmw-users/issues/93)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Instructions

1. Go to section 4
2.  Check items in 4.2
3. Submit 
4. Refresh to see checked items are still there


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
