### PR TITLE
Feature/148 149 create edit landscape org routes

### DIFF
--- a/mrtt-ui/src/App.js
+++ b/mrtt-ui/src/App.js
@@ -6,18 +6,20 @@ import React from 'react'
 import { CustomToastContainer } from './components/CustomToastContainer'
 import CausesOfDeclineForm from './components/CausesOfDeclineForm'
 import GlobalLayout from './components/GlobalLayout'
+import LandscapeForm from './views/LandscapeForm'
 import Landscapes from './views/Landscapes'
+import LoginForm from './views/Auth/LoginForm'
+import OrganizationForm from './views/OrganizationForm'
 import Organizations from './views/Organizations'
 import ProjectDetailsForm from './components/ProjectDetailsForm'
+import ProtectedRoutes from './components/Auth/ProtectedRoutes'
 import RestorationAimsForm from './components/RestorationAimsForm/RestorationAimsForm'
+import SignupForm from './views/Auth/SignupForm'
 import SiteBackgroundForm from './components/SiteBackgroundForm'
 import SiteForm from './views/SiteForm'
-import SignupForm from './views/Auth/SignupForm'
-import LoginForm from './views/Auth/LoginForm'
 import SiteQuestionsOverview from './views/SiteQuestionsOverview/SiteQuestionsOverview'
 import Sites from './views/Sites'
 import themeMui from './styles/themeMui'
-import ProtectedRoutes from './components/Auth/ProtectedRoutes'
 
 function App() {
   return (
@@ -29,8 +31,20 @@ function App() {
             <Route element={<ProtectedRoutes />}>
               <Route path='/' element={<Navigate to='/sites' replace />} />
               <Route path='/landscapes' element={<Landscapes />} />
+              <Route
+                path='/landscapes/:landscapeId/edit'
+                element={<LandscapeForm isNewLandscape={false} />}
+              />
+              <Route path='/landscapes/new' element={<LandscapeForm isNewLandscape={true} />} />
               <Route path='/organizations' element={<Organizations />} />
-              <Route path='/sites' element={<Sites />} />
+              <Route
+                path='/organizations/:organizationId/edit'
+                element={<OrganizationForm isNewOrganization={false} />}
+              />
+              <Route
+                path='/organizations/new'
+                element={<OrganizationForm isNewOrganization={true} />}
+              />
               <Route path='/site/:siteId/edit' element={<SiteForm isNewSite={false} />} />
               <Route
                 path='/site/:siteId/form/causes-of-decline'
@@ -41,6 +55,7 @@ function App() {
               <Route path='/site/:siteId/form/site-background' element={<SiteBackgroundForm />} />
               <Route path='/site/:siteId/overview' element={<SiteQuestionsOverview />} />
               <Route path='/site/new' element={<SiteForm isNewSite={true} />} />
+              <Route path='/sites' element={<Sites />} />
             </Route>
 
             <Route path='/auth/signup' element={<SignupForm />} />

--- a/mrtt-ui/src/components/EditLink.js
+++ b/mrtt-ui/src/components/EditLink.js
@@ -1,0 +1,26 @@
+import { Edit } from '@mui/icons-material'
+import { Link as LinkReactRouter } from 'react-router-dom'
+import { styled } from '@mui/system'
+import React from 'react'
+
+import language from '../language'
+import theme from '../styles/theme'
+
+export const CustomLink = styled(LinkReactRouter)`
+  color: ${theme.color.text};
+  text-decoration: none;
+  display: flex;
+  text-transform: uppercase;
+`
+
+const EditLink = (props) => {
+  return (
+    <CustomLink {...props}>
+      <Edit /> {language.buttons.edit}
+    </CustomLink>
+  )
+}
+
+EditLink.propTypes = {}
+
+export default EditLink

--- a/mrtt-ui/src/language.js
+++ b/mrtt-ui/src/language.js
@@ -19,11 +19,12 @@ const multiselectWithOtherFormQuestion = {
 
 const pages = {
   organizations: {
+    newOrganizationButton: 'New Org',
+    noOtherOrganizations: 'There are no other organizations',
+    noYourOrganizations: 'You dont have any organizations',
     title: 'Organizations',
     titleOtherOrganizations: 'Other Organizations',
-    titleYourOrganizations: 'Your Organizations',
-    noYourOrganizations: 'You dont have any organizations',
-    noOtherOrganizations: 'There are no other organizations'
+    titleYourOrganizations: 'Your Organizations'
   },
   sites: { title: 'Sites', newSiteButton: 'New Site' },
   landscapes: { title: 'Landscapes', newLandscapeButton: 'New Landscape' },
@@ -64,6 +65,7 @@ const pages = {
 
 const buttons = {
   cancel: 'Cancel',
+  edit: 'Edit',
   submit: 'Submit',
   submitting: 'Submitting...'
 }

--- a/mrtt-ui/src/views/LandscapeForm.js
+++ b/mrtt-ui/src/views/LandscapeForm.js
@@ -1,0 +1,16 @@
+import { useParams } from 'react-router-dom'
+import PropTypes from 'prop-types'
+import React from 'react'
+
+const LandscapeForm = ({ isNewLandscape }) => {
+  const { landscapeId } = useParams()
+  return (
+    <>
+      Placeholder landscape form for id: {landscapeId}. In new: {isNewLandscape?.toString()}
+    </>
+  )
+}
+
+LandscapeForm.propTypes = { isNewLandscape: PropTypes.bool.isRequired }
+
+export default LandscapeForm

--- a/mrtt-ui/src/views/Landscapes.js
+++ b/mrtt-ui/src/views/Landscapes.js
@@ -1,13 +1,14 @@
-import { Stack } from '@mui/material'
-import axios from 'axios'
-import React, { useEffect, useState } from 'react'
-import { Link } from 'react-router-dom'
-import { toast } from 'react-toastify'
-import LoadingIndicator from '../components/LoadingIndicator'
-import language from '../language'
 import { ButtonPrimary } from '../styles/buttons'
-import { LinkCard, PagePadding, RowSpaceBetween } from '../styles/containers'
 import { H4 } from '../styles/typography'
+import { Link } from 'react-router-dom'
+import { LinkCard, PagePadding, RowSpaceBetween } from '../styles/containers'
+import { Stack } from '@mui/material'
+import { toast } from 'react-toastify'
+import axios from 'axios'
+import EditLink from '../components/EditLink'
+import language from '../language'
+import LoadingIndicator from '../components/LoadingIndicator'
+import React, { useEffect, useState } from 'react'
 
 const landscapesUrl = `${process.env.REACT_APP_API_URL}/landscapes/`
 function Landscapes() {
@@ -39,7 +40,10 @@ function Landscapes() {
     })
     .map(({ landscape_name, id }) => (
       <LinkCard key={id} to='#'>
-        {landscape_name}
+        <RowSpaceBetween>
+          <>{landscape_name}</>
+          <EditLink to={`/landscapes/${id}/edit`} />
+        </RowSpaceBetween>
       </LinkCard>
     ))
 
@@ -49,7 +53,7 @@ function Landscapes() {
     <PagePadding>
       <RowSpaceBetween>
         <H4>{language.pages.landscapes.title}</H4>
-        <ButtonPrimary component={Link} to='#'>
+        <ButtonPrimary component={Link} to='/landscapes/new'>
           {language.pages.landscapes.newLandscapeButton}
         </ButtonPrimary>
       </RowSpaceBetween>

--- a/mrtt-ui/src/views/OrganizationForm.js
+++ b/mrtt-ui/src/views/OrganizationForm.js
@@ -1,0 +1,16 @@
+import { useParams } from 'react-router-dom'
+import PropTypes from 'prop-types'
+import React from 'react'
+
+const OrganizationForm = ({ isNewOrganization }) => {
+  const { organizationId } = useParams()
+  return (
+    <>
+      Placeholder org form for id: {organizationId}. Is new: {isNewOrganization?.toString()}
+    </>
+  )
+}
+
+OrganizationForm.propTypes = { isNewOrganization: PropTypes.bool.isRequired }
+
+export default OrganizationForm

--- a/mrtt-ui/src/views/Organizations.js
+++ b/mrtt-ui/src/views/Organizations.js
@@ -1,7 +1,9 @@
 import React, { useEffect, useState } from 'react'
 
+import { ButtonPrimary } from '../styles/buttons'
 import { H4, H5 } from '../styles/typography'
-import { PaddedPageSection, PaddedPageTopSection } from '../styles/containers'
+import { Link } from 'react-router-dom'
+import { PaddedPageSection, PaddedPageTopSection, RowSpaceBetween } from '../styles/containers'
 import { toast } from 'react-toastify'
 import { UlAlternating } from '../styles/lists'
 import axios from 'axios'
@@ -47,7 +49,12 @@ function Organizations() {
   ) : (
     <>
       <PaddedPageTopSection>
-        <H4>{language.pages.organizations.title}</H4>
+        <RowSpaceBetween>
+          <H4>{language.pages.organizations.title}</H4>
+          <ButtonPrimary component={Link} to='/organizations/new'>
+            {language.pages.organizations.newOrganizationButton}
+          </ButtonPrimary>
+        </RowSpaceBetween>
       </PaddedPageTopSection>
       <PaddedPageSection>
         <H5>{language.pages.organizations.titleYourOrganizations}</H5>


### PR DESCRIPTION
- new routes for create/edit org
- new routes for create/edit landscape
- edit landscape link navs to landscape form placeholder 
- new landscape button navs to landscape form placeholder
- new org button navs to org form placeholder
- edit org link not possible until we have auth (because we can only edit orgs that are 'ours')

This is part of a larger workflow for creating/editing and deleting landscapes. (I threw in some org routes, because I might as well since it is so similar and thats my next clump of work - sorry for the scope creep a little)