### PR TITLE
[148] create and edit a landscape

### DIFF
--- a/mrtt-ui/src/App.js
+++ b/mrtt-ui/src/App.js
@@ -45,16 +45,19 @@ function App() {
                 path='/organizations/new'
                 element={<OrganizationForm isNewOrganization={true} />}
               />
-              <Route path='/site/:siteId/edit' element={<SiteForm isNewSite={false} />} />
+              <Route path='/sites/:siteId/edit' element={<SiteForm isNewSite={false} />} />
               <Route
-                path='/site/:siteId/form/causes-of-decline'
+                path='/sites/:siteId/form/causes-of-decline'
                 element={<CausesOfDeclineForm />}
               />
-              <Route path='/site/:siteId/form/project-details' element={<ProjectDetailsForm />} />
-              <Route path='/site/:siteId/form/restoration-aims' element={<RestorationAimsForm />} />
-              <Route path='/site/:siteId/form/site-background' element={<SiteBackgroundForm />} />
-              <Route path='/site/:siteId/overview' element={<SiteQuestionsOverview />} />
-              <Route path='/site/new' element={<SiteForm isNewSite={true} />} />
+              <Route path='/sites/:siteId/form/project-details' element={<ProjectDetailsForm />} />
+              <Route
+                path='/sites/:siteId/form/restoration-aims'
+                element={<RestorationAimsForm />}
+              />
+              <Route path='/sites/:siteId/form/site-background' element={<SiteBackgroundForm />} />
+              <Route path='/sites/:siteId/overview' element={<SiteQuestionsOverview />} />
+              <Route path='/sites/new' element={<SiteForm isNewSite={true} />} />
               <Route path='/sites' element={<Sites />} />
             </Route>
 

--- a/mrtt-ui/src/components/SubmitErrorWithExtraErrorContent.js
+++ b/mrtt-ui/src/components/SubmitErrorWithExtraErrorContent.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import language from '../language'
+
+const SubmitErrorWithExtraErrorContent = ({ extraErrorContent }) => {
+  return (
+    <>
+      <p>{language.error.submit}</p>
+      <p>{extraErrorContent}</p>
+    </>
+  )
+}
+
+SubmitErrorWithExtraErrorContent.propTypes = { extraErrorContent: PropTypes.node.isRequired }
+
+export default SubmitErrorWithExtraErrorContent

--- a/mrtt-ui/src/language.js
+++ b/mrtt-ui/src/language.js
@@ -1,9 +1,14 @@
 const error = {
   submit: 'Submit failed. Please try again.',
   apiLoad: 'Loading data from the api failed. Please try again.',
-  getItemDoesntExistMessage: (item) => `That ${item} doesnt exits.`
+  getItemDoesntExistMessage: (item) => `That ${item} doesnt exist.`
 }
-const success = { submit: 'The data has been saved.' }
+
+const success = {
+  submit: 'The data has been saved.',
+  getEditThingSuccessMessage: (thing) => `${thing} has been edited`,
+  getCreateThingSuccessMessage: (thing) => `${thing}, has been created`
+}
 const form = {
   checkboxGroupOtherInputPlaceholder: 'If other, please state.',
   checkboxGroupOtherLabel: 'Other',
@@ -28,13 +33,26 @@ const pages = {
     titleYourOrganizations: 'Your Organizations'
   },
   sites: { title: 'Sites', newSiteButton: 'New Site' },
-  landscapes: { title: 'Landscapes', newLandscapeButton: 'New Landscape' },
+  landscapeForm: {
+    landscape: 'landscape',
+    titleEdit: 'Edit Landscape',
+    titleNew: 'New Landscape',
+    labelName: 'Name',
+    labelOrganizations: 'Organizations',
+    validation: {
+      nameRequired: 'Please enter a name'
+    }
+  },
+  landscapes: {
+    title: 'Landscapes',
+    newLandscapeButton: 'New Landscape'
+  },
   siteform: {
-    getEditSiteSuccessMessage: (siteName) => `${siteName} has been edited`,
-    getNewSiteSuccessMessage: (siteName) => `${siteName}, has been created`,
+    titleEditSite: 'Site Settings',
     titleNewSite: 'Create a site',
     labelName: 'Site Name',
     labelLandscape: 'Landscape',
+    site: 'site',
     validation: {
       nameRequired: 'Please enter a name',
       landscapeRequired: 'Please select a landscape'

--- a/mrtt-ui/src/styles/containers.js
+++ b/mrtt-ui/src/styles/containers.js
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom'
 import { Stack } from '@mui/material'
-import { styled } from '@mui/system'
+import { css, styled } from '@mui/system'
 import theme from './theme'
 import themeMui from './themeMui'
 
@@ -20,24 +20,31 @@ const ButtonContainer = styled(RowFlexEnd)`
 `
 const RowCenterCenter = styled('div')`
   display: flex;
-  height: 100%;
   align-items: center;
   justify-content: center;
 `
-const LinkCard = styled(Link)`
+
+const cardCss = css`
   background: white;
   border-color: ${theme.color.lightGrey};
   border-width: 2px;
   border-style: solid;
   color: ${theme.color.slub};
   margin: ${themeMui.spacing(2)} 0;
-  text-decoration: none;
   padding: ${themeMui.spacing(3)};
+`
+
+const LinkCard = styled(Link)`
+  ${cardCss}
+  text-decoration: none;
   &:hover {
     color: ${theme.color.text};
     border-color: ${theme.color.primary};
     border-width: 2px;
   }
+`
+const Card = styled('div')`
+  ${cardCss}
 `
 const ContentWrapper = styled('div')`
   padding: ${themeMui.spacing(2)};
@@ -65,8 +72,10 @@ const QuestionWrapper = styled('div')`
   flex-direction: column;
   max-width: ${theme.layout.maxContentWidth};
 `
+
 export {
   ButtonContainer,
+  Card,
   LinkCard,
   ContentWrapper,
   TitleAndActionContainer,

--- a/mrtt-ui/src/views/LandscapeForm.js
+++ b/mrtt-ui/src/views/LandscapeForm.js
@@ -1,14 +1,197 @@
-import { useParams } from 'react-router-dom'
+import { Controller, useForm } from 'react-hook-form'
+import { toast } from 'react-toastify'
+import { useNavigate, useParams } from 'react-router-dom'
+import { yupResolver } from '@hookform/resolvers/yup'
+import * as yup from 'yup'
+import axios from 'axios'
+import language from '../language'
 import PropTypes from 'prop-types'
-import React from 'react'
+import React, { useEffect, useState } from 'react'
+
+import {
+  ButtonContainer,
+  PaddedPageSection,
+  PaddedPageTopSection,
+  RowFlexEnd
+} from '../styles/containers'
+import { Autocomplete, FormLabel, TextField } from '@mui/material'
+import { ButtonCancel, ButtonSubmit } from '../styles/buttons'
+import { ErrorText } from '../styles/typography'
+import { Form, SectionFormTitle } from '../styles/forms'
+import ItemDoesntExist from '../components/ItemDoesntExist'
+import LoadingIndicator from '../components/LoadingIndicator'
+import SubmitErrorWithExtraErrorContent from '../components/SubmitErrorWithExtraErrorContent'
+
+const validationSchema = yup.object({
+  landscape_name: yup.string().required(language.pages.landscapeForm.validation.nameRequired),
+  organizations: yup.array()
+})
+
+const formDefaultValues = { landscape_name: '', selectedOrganizations: [] }
 
 const LandscapeForm = ({ isNewLandscape }) => {
+  const [doesLandscapeExist, setDoesLandscapeExist] = useState(true)
+  const [isLoading, setIsLoading] = useState(false)
+  const [isSubmitError, setIsSubmitError] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [organizationOptions, setOrganizationOptions] = useState([])
   const { landscapeId } = useParams()
-  return (
+  const landscapesUrl = `${process.env.REACT_APP_API_URL}/landscapes`
+  const landscapeUrl = `${landscapesUrl}/${landscapeId}`
+  const navigate = useNavigate()
+  const organizationsUrl = `${process.env.REACT_APP_API_URL}/organizations`
+
+  const {
+    control: formControl,
+    handleSubmit: validateInputs,
+    formState: { errors },
+    reset: resetForm
+  } = useForm({ resolver: yupResolver(validationSchema), defaultValues: formDefaultValues })
+
+  useEffect(
+    function loadApiData() {
+      const serverDataPromises = [axios.get(organizationsUrl)]
+      if (!isNewLandscape && landscapeId) {
+        serverDataPromises.push(axios.get(landscapeUrl))
+      }
+
+      Promise.all(serverDataPromises)
+        .then(([{ data: organizationsData }, landscapeResponse]) => {
+          if (!isNewLandscape && landscapeId && landscapeResponse) {
+            const { landscape_name, organizations: selectedOrganizations } = landscapeResponse.data
+            const landscapeDataFormattedForForm = {
+              landscape_name,
+              selectedOrganizations
+            }
+            resetForm(landscapeDataFormattedForForm)
+          }
+
+          setOrganizationOptions(organizationsData)
+          setIsLoading(false)
+        })
+        .catch((error) => {
+          setIsLoading(false)
+          if (error?.response?.status === 404) {
+            setDoesLandscapeExist(false)
+          } else {
+            toast.error(language.error.apiLoad)
+          }
+        })
+    },
+    [landscapeUrl, resetForm, isNewLandscape, landscapeId, organizationsUrl]
+  )
+
+  const formatDataForSubmit = ({ landscape_name, selectedOrganizations }) => {
+    const organizationIds = selectedOrganizations.map((organizationObject) => organizationObject.id)
+
+    return { landscape_name, organizations: organizationIds }
+  }
+
+  const postNewLandscape = (formData) => {
+    axios
+      .post(landscapesUrl, formatDataForSubmit(formData))
+      .then(({ data: { landscape_name } }) => {
+        setIsSubmitting(false)
+        toast.success(language.success.getCreateThingSuccessMessage(landscape_name))
+        navigate('/landscapes')
+      })
+      .catch((error) => {
+        setIsSubmitting(false)
+        setIsSubmitError(true)
+        toast.error(
+          <SubmitErrorWithExtraErrorContent extraErrorContent={error.response.data.error} />
+        )
+      })
+  }
+
+  const editLandscape = (formData) => {
+    axios
+      .patch(landscapeUrl, formatDataForSubmit(formData))
+      .then(({ data: { landscape_name } }) => {
+        setIsSubmitting(false)
+        toast.success(language.success.getEditThingSuccessMessage(landscape_name))
+        navigate('/landscapes')
+      })
+      .catch((error) => {
+        setIsSubmitting(false)
+        setIsSubmitError(true)
+        toast.error(
+          <SubmitErrorWithExtraErrorContent extraErrorContent={error.response.data.error} />
+        )
+      })
+  }
+  const handleSubmit = (formData) => {
+    setIsSubmitting(true)
+    setIsSubmitError(false)
+
+    if (isNewLandscape) {
+      postNewLandscape(formData)
+    }
+    if (!isNewLandscape) {
+      editLandscape(formData)
+    }
+  }
+
+  const handleCancelClick = () => {
+    navigate('/landscapes')
+  }
+  const form = !doesLandscapeExist ? (
+    <ItemDoesntExist item={language.pages.landscapeForm.landscape} />
+  ) : (
     <>
-      Placeholder landscape form for id: {landscapeId}. In new: {isNewLandscape?.toString()}
+      <PaddedPageTopSection>
+        <SectionFormTitle>
+          {isNewLandscape
+            ? language.pages.landscapeForm.titleNew
+            : language.pages.landscapeForm.titleEdit}
+        </SectionFormTitle>
+      </PaddedPageTopSection>
+      <PaddedPageSection>
+        <Form onSubmit={validateInputs(handleSubmit)}>
+          <FormLabel htmlFor='name'>{language.pages.landscapeForm.labelName}* </FormLabel>
+          <Controller
+            name='landscape_name'
+            control={formControl}
+            render={({ field }) => (
+              <TextField {...field} id='name' label={language.pages.landscapeForm.labelName} />
+            )}
+          />
+          <ErrorText>{errors?.landscape_name?.message}</ErrorText>
+          <FormLabel htmlFor='organizations'>
+            {language.pages.landscapeForm.labelOrganizations}
+          </FormLabel>
+          <Controller
+            name='selectedOrganizations'
+            control={formControl}
+            render={({ field }) => (
+              <Autocomplete
+                {...field}
+                disablePortal
+                multiple
+                options={organizationOptions}
+                getOptionLabel={(option) => (option ? option.organization_name : '')}
+                renderInput={(params) => (
+                  <TextField {...params} label='organizations' id='organizations' />
+                )}
+                onChange={(event, values) => {
+                  field.onChange(values)
+                }}
+                isOptionEqualToValue={(option, value) => option.id === value.id}
+              />
+            )}
+          />
+          <ErrorText>{errors?.organizations?.message}</ErrorText>
+          <RowFlexEnd>{isSubmitError && <ErrorText>{language.error.submit}</ErrorText>}</RowFlexEnd>
+          <ButtonContainer>
+            <ButtonCancel onClick={handleCancelClick} />
+            <ButtonSubmit isSubmitting={isSubmitting} />
+          </ButtonContainer>
+        </Form>
+      </PaddedPageSection>
     </>
   )
+
+  return isLoading ? <LoadingIndicator /> : form
 }
 
 LandscapeForm.propTypes = { isNewLandscape: PropTypes.bool.isRequired }

--- a/mrtt-ui/src/views/Landscapes.js
+++ b/mrtt-ui/src/views/Landscapes.js
@@ -2,13 +2,20 @@ import { Link } from 'react-router-dom'
 import { Stack } from '@mui/material'
 import { toast } from 'react-toastify'
 import axios from 'axios'
+
+import { ButtonPrimary } from '../styles/buttons'
+import {
+  Card,
+  ContentWrapper,
+  RowCenterCenter,
+  RowSpaceBetween,
+  TitleAndActionContainer
+} from '../styles/containers'
+import { ItemTitle, PageTitle } from '../styles/typography'
 import EditLink from '../components/EditLink'
 import language from '../language'
-import { ButtonPrimary } from '../styles/buttons'
 import LoadingIndicator from '../components/LoadingIndicator'
 import React, { useEffect, useState } from 'react'
-import { LinkCard, ContentWrapper, TitleAndActionContainer } from '../styles/containers'
-import { ItemTitle, PageTitle } from '../styles/typography'
 
 const landscapesUrl = `${process.env.REACT_APP_API_URL}/landscapes/`
 function Landscapes() {
@@ -39,10 +46,14 @@ function Landscapes() {
       return 0
     })
     .map(({ landscape_name, id }) => (
-      <LinkCard key={id} to='#'>
-        <ItemTitle>{landscape_name}</ItemTitle>
-        <EditLink to={`/landscapes/${id}/edit`} />
-      </LinkCard>
+      <Card key={id}>
+        <RowSpaceBetween>
+          <ItemTitle>{landscape_name}</ItemTitle>
+          <RowCenterCenter>
+            <EditLink to={`/landscapes/${id}/edit`} />
+          </RowCenterCenter>
+        </RowSpaceBetween>
+      </Card>
     ))
 
   return isLoading ? (

--- a/mrtt-ui/src/views/SiteForm.js
+++ b/mrtt-ui/src/views/SiteForm.js
@@ -61,9 +61,9 @@ const SiteForm = ({ isNewSite }) => {
               resetForm(siteResponse?.data)
             }
           })
-          .catch((err) => {
+          .catch((error) => {
             setIsLoading(false)
-            if (err?.response?.status === 404) {
+            if (error?.response?.status === 404) {
               setDoesItemExist(false)
             } else {
               toast.error(language.error.apiLoad)
@@ -79,7 +79,7 @@ const SiteForm = ({ isNewSite }) => {
       .post(sitesUrl, formData)
       .then(({ data: { site_name } }) => {
         setIsSubmitting(false)
-        toast.success(language.pages.siteform.getNewSiteSuccessMessage(site_name))
+        toast.success(language.success.getCreateThingSuccessMessage(site_name))
         navigate('/sites')
       })
       .catch(() => {
@@ -94,7 +94,7 @@ const SiteForm = ({ isNewSite }) => {
       .patch(siteUrl, formData)
       .then(({ data: { site_name } }) => {
         setIsSubmitting(false)
-        toast.success(language.pages.siteform.getEditSiteSuccessMessage(site_name))
+        toast.success(language.success.getEditThingSuccessMessage(site_name))
         navigate('/sites')
       })
       .catch(() => {
@@ -116,11 +116,11 @@ const SiteForm = ({ isNewSite }) => {
   }
 
   const handleCancelClick = () => {
-    navigate(-1)
+    navigate('/sites')
   }
 
   const form = !doesItemExist ? (
-    <ItemDoesntExist item='site' />
+    <ItemDoesntExist item={language.pages.siteform.site} />
   ) : (
     <ContentWrapper>
       <PageTitle>{isNewSite ? language.pages.siteform.titleNewSite : 'placeholder name'}</PageTitle>

--- a/mrtt-ui/src/views/SiteQuestionsOverview/SiteQuestionsOverview.js
+++ b/mrtt-ui/src/views/SiteQuestionsOverview/SiteQuestionsOverview.js
@@ -58,9 +58,9 @@ const SiteOverview = () => {
             setSite(siteData)
             setLandscape(landscapesData.find((landscape) => landscape.id === siteData.landscape_id))
           })
-          .catch((err) => {
+          .catch((error) => {
             setIsLoading(false)
-            if (err?.response?.status === 404) {
+            if (error?.response?.status === 404) {
               setDoesSiteExist(false)
             } else {
               toast.error(language.error.apiLoad)
@@ -81,7 +81,7 @@ const SiteOverview = () => {
             <ItemTitle as='h2'>{site?.site_name}</ItemTitle>
             <ItemSubTitle>{landscape?.landscape_name}</ItemSubTitle>
           </Stack>
-          <SettingsLink to={`/site/${siteId}/edit`} />
+          <SettingsLink to={`/sites/${siteId}/edit`} />
         </TitleAndActionContainer>
         <StyledSectionHeader>{pageLanguage.formGroupTitle.registration}</StyledSectionHeader>
         {/* this is a table instead of a ul to leave room for a cell that shows
@@ -91,28 +91,28 @@ const SiteOverview = () => {
           <tbody>
             <tr>
               <WideTh>
-                <Link to={`/site/${siteId}/form/project-details`}>
+                <Link to={`/sites/${siteId}/form/project-details`}>
                   {pageLanguage.formName.siteDetails}
                 </Link>
               </WideTh>
             </tr>
             <tr>
               <WideTh>
-                <Link to={`/site/${siteId}/form/site-background`}>
+                <Link to={`/sites/${siteId}/form/site-background`}>
                   {pageLanguage.formName.siteBackground}
                 </Link>
               </WideTh>
             </tr>
             <tr>
               <WideTh>
-                <Link to={`/site/${siteId}/form/restoration-aims`}>
+                <Link to={`/sites/${siteId}/form/restoration-aims`}>
                   {pageLanguage.formName.restorationAims}
                 </Link>
               </WideTh>
             </tr>
             <tr>
               <WideTh>
-                <Link to={`/site/${siteId}/form/causes-of-decline`}>
+                <Link to={`/sites/${siteId}/form/causes-of-decline`}>
                   {pageLanguage.formName.causesOfDeclin}
                 </Link>
               </WideTh>

--- a/mrtt-ui/src/views/Sites.js
+++ b/mrtt-ui/src/views/Sites.js
@@ -40,7 +40,7 @@ function Sites() {
       return 0
     })
     .map(({ site_name, landscape_name, id }) => (
-      <LinkCard key={id} to={`/site/${id}/overview`}>
+      <LinkCard key={id} to={`/sites/${id}/overview`}>
         <ItemTitle>{site_name}</ItemTitle>
         <ItemSubTitle>{landscape_name}</ItemSubTitle>
       </LinkCard>
@@ -52,7 +52,7 @@ function Sites() {
     <ContentWrapper>
       <TitleAndActionContainer>
         <PageTitle>{language.pages.sites.title}</PageTitle>
-        <ButtonPrimary component={Link} to='/site/new'>
+        <ButtonPrimary component={Link} to='/sites/new'>
           {language.pages.sites.newSiteButton}
         </ButtonPrimary>
       </TitleAndActionContainer>


### PR DESCRIPTION
# Description

- create a landscape
- edit a landscape


# Instructions

Editing:
- click new landscape button on landscape list page
- enter stuff in form
- click submit/cancel

Creating new landscape:
- click 'Edit' link in landscape 'card' on landscape list page
- enter stuff in form
- click submit/cancel


I noticed that the api wont let you use the same landscape name twice. There is no code other than 422 which feels fairly generic to filter on for specific user messaging, so the code is patching the server error message through to the error toast. (for now?). Made a tech debt ticket for it https://github.com/globalmangrovewatch/gmw-users/issues/167