### PR TITLE
[148] feat delete a landscape if no associated sites. (edit base to develop before merge)

### DIFF
--- a/mrtt-ui/src/components/ButtonSecondaryWithLoader.js
+++ b/mrtt-ui/src/components/ButtonSecondaryWithLoader.js
@@ -1,0 +1,21 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Button } from '@mui/material'
+
+const ButtonSecondaryWithLoader = ({ children, isHolding, disabled, holdingContent, ...props }) => {
+  return (
+    <Button variant='contained' {...props} disabled={isHolding || disabled}>
+      {isHolding ? holdingContent : children}
+    </Button>
+  )
+}
+
+ButtonSecondaryWithLoader.propTypes = {
+  children: PropTypes.node.isRequired,
+  disabled: PropTypes.bool,
+  holdingContent: PropTypes.node.isRequired,
+  isHolding: PropTypes.bool
+}
+ButtonSecondaryWithLoader.defaultProps = { isHolding: false, disabled: false }
+
+export default ButtonSecondaryWithLoader

--- a/mrtt-ui/src/language.js
+++ b/mrtt-ui/src/language.js
@@ -1,13 +1,15 @@
 const error = {
-  submit: 'Submit failed. Please try again.',
   apiLoad: 'Loading data from the api failed. Please try again.',
-  getItemDoesntExistMessage: (item) => `That ${item} doesnt exist.`
+  delete: 'Deleting that item failed. Please try again.',
+  getItemDoesntExistMessage: (item) => `That ${item} doesnt exist.`,
+  submit: 'Submit failed. Please try again.'
 }
 
 const success = {
   submit: 'The data has been saved.',
-  getEditThingSuccessMessage: (thing) => `${thing} has been edited`,
-  getCreateThingSuccessMessage: (thing) => `${thing}, has been created`
+  getEditThingSuccessMessage: (thing) => `${thing} has been edited.`,
+  getCreateThingSuccessMessage: (thing) => `${thing}, has been created.`,
+  getDeleteThingSuccessMessage: (thing) => `${thing} has been deleted.`
 }
 const form = {
   checkboxGroupOtherInputPlaceholder: 'If other, please state.',
@@ -34,11 +36,15 @@ const pages = {
   },
   sites: { title: 'Sites', newSiteButton: 'New Site' },
   landscapeForm: {
-    landscape: 'landscape',
-    titleEdit: 'Edit Landscape',
-    titleNew: 'New Landscape',
+    delete: 'Delete this landscape',
+    isAssociatedSites:
+      'You must change the associated sites to another landscape before you can delete this landscape.',
     labelName: 'Name',
     labelOrganizations: 'Organizations',
+    landscape: 'landscape',
+    noAssociatedSites: 'This landscape has no associated sites.',
+    titleEdit: 'Edit Landscape',
+    titleNew: 'New Landscape',
     validation: {
       nameRequired: 'Please enter a name'
     }
@@ -88,6 +94,7 @@ const pages = {
 
 const buttons = {
   cancel: 'Cancel',
+  deleting: 'Deleting...',
   edit: 'Edit',
   submit: 'Submit',
   submitting: 'Submitting...'


### PR DESCRIPTION
closes #148 

delete a landscape

Details:
- if there are associated sites, some explainer test shows, and the button is disabled
- if there are no associated sites, some different text shows, and the button is enabled
- a generic button was made to show what ever 'holding'/progress text while an operation is in progress.
