### PR TITLE
added mobile-friendly hover states

### DIFF
--- a/mrtt-ui/src/components/EditLink.js
+++ b/mrtt-ui/src/components/EditLink.js
@@ -1,23 +1,14 @@
 import { Edit } from '@mui/icons-material'
-import { Link as LinkReactRouter } from 'react-router-dom'
-import { styled } from '@mui/system'
 import React from 'react'
 
 import language from '../language'
-import theme from '../styles/theme'
-
-export const CustomLink = styled(LinkReactRouter)`
-  color: ${theme.color.text};
-  text-decoration: none;
-  display: flex;
-  text-transform: uppercase;
-`
+import { ButtonSecondary } from '../styles/buttons'
 
 const EditLink = (props) => {
   return (
-    <CustomLink {...props}>
+    <ButtonSecondary {...props}>
       <Edit /> {language.buttons.edit}
-    </CustomLink>
+    </ButtonSecondary>
   )
 }
 

--- a/mrtt-ui/src/components/MobileFooter/MobileFooter.js
+++ b/mrtt-ui/src/components/MobileFooter/MobileFooter.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { styled } from '@mui/system'
+import { styled, css } from '@mui/system'
 import { Link, useLocation } from 'react-router-dom'
 import {
   Map as SitesIcon,
@@ -47,6 +47,9 @@ const LinkContainer = styled(Link)`
     gap: 1rem;
     padding: ${themeMui.spacing(1)} ${themeMui.spacing(2)};
   }
+  ${theme.hoverState(css`
+    color: ${theme.color.primaryHover};
+  `)}
 `
 
 function MobileFooter() {
@@ -60,11 +63,11 @@ function MobileFooter() {
       </LinkContainer>
       <LinkContainer to='/landscapes' active={String(/^\/landscapes/.test(pathname))}>
         <LandscapesIcon />
-        <span>landscapes</span>
+        <span>Landscapes</span>
       </LinkContainer>
       <LinkContainer to='/organizations' active={String(/^\/organizations/.test(pathname))}>
         <OrganizationsIcon />
-        <span>organizations</span>
+        <span>Organizations</span>
       </LinkContainer>
     </StyledFooter>
   )

--- a/mrtt-ui/src/styles/containers.js
+++ b/mrtt-ui/src/styles/containers.js
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom'
 import { Stack } from '@mui/material'
-import { styled } from '@mui/system'
+import { styled, css } from '@mui/system'
 import theme from './theme'
 import themeMui from './themeMui'
 
@@ -33,10 +33,13 @@ const LinkCard = styled(Link)`
   margin: ${themeMui.spacing(2)} 0;
   text-decoration: none;
   padding: ${themeMui.spacing(3)};
-  &:hover {
+  ${theme.hoverState(css`
     color: ${theme.color.text};
     border-color: ${theme.color.primary};
     border-width: 2px;
+  `)}
+  @media(hover: none) {
+    border-color: ${theme.color.primary};
   }
 `
 const ContentWrapper = styled('div')`

--- a/mrtt-ui/src/styles/theme.js
+++ b/mrtt-ui/src/styles/theme.js
@@ -1,3 +1,4 @@
+import { css } from '@emotion/react'
 const color = {
   bodyBackground: '#fafafa',
   primary: '#009b93',
@@ -17,7 +18,6 @@ const color = {
 const form = {
   requiredIndicatorColor: `${color.red}`
 }
-
 const typography = {
   fontStack: ['Open Sans', 'sans-serif'],
   xsmallFontSize: '1rem',
@@ -39,4 +39,11 @@ const layout = {
   maxContentWidth: '96rem'
 }
 
-export default { color, border, layout, typography, form }
+const hoverState = (content) => css`
+  @media (hover: hover) {
+    &:hover:not([disabled]) {
+      ${content};
+    }
+  }
+`
+export default { hoverState, color, border, layout, typography, form }

--- a/mrtt-ui/src/views/Landscapes.js
+++ b/mrtt-ui/src/views/Landscapes.js
@@ -39,9 +39,9 @@ function Landscapes() {
       return 0
     })
     .map(({ landscape_name, id }) => (
-      <LinkCard key={id} to='#'>
+      <LinkCard key={id} to={`/landscapes/${id}/edit`}>
         <ItemTitle>{landscape_name}</ItemTitle>
-        <EditLink to={`/landscapes/${id}/edit`} />
+        <EditLink component={Link} to={`/landscapes/${id}/edit`} />
       </LinkCard>
     ))
 

--- a/mrtt-ui/src/views/SiteQuestionsOverview/SiteQuestionsOverview.js
+++ b/mrtt-ui/src/views/SiteQuestionsOverview/SiteQuestionsOverview.js
@@ -1,4 +1,5 @@
-import { Link, useParams } from 'react-router-dom'
+import { useParams } from 'react-router-dom'
+import { Link } from '../../styles/typography'
 import { Settings } from '@mui/icons-material'
 import { Stack } from '@mui/material'
 import { styled } from '@mui/system'
@@ -6,25 +7,17 @@ import { toast } from 'react-toastify'
 import axios from 'axios'
 import React, { useEffect, useState } from 'react'
 
-import { ItemSubTitle, ItemTitle, XSmallUpperCase } from '../../styles/typography'
+import { ItemSubTitle, ItemTitle } from '../../styles/typography'
 import { ContentWrapper, TitleAndActionContainer } from '../../styles/containers'
 import { TableAlertnatingRows } from '../../styles/table'
 import AddMonitoringSectionMenu from './AddMonitoringSectionMenu'
 import ItemDoesntExist from '../../components/ItemDoesntExist'
 import language from '../../language'
 import LoadingIndicator from '../../components/LoadingIndicator'
-import theme from '../../styles/theme'
+import { ButtonSecondary } from '../../styles/buttons'
 
 const pageLanguage = language.pages.siteQuestionsOverview
 
-const SettingsLinkWrapper = styled(Link)`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  flex-direction: column;
-  text-decoration: none;
-  color: ${theme.color.text};
-`
 const WideTh = styled('th')`
   width: 100%;
 `
@@ -32,12 +25,6 @@ const StyledSectionHeader = styled('h3')`
   text-transform: uppercase;
   font-weight: 100;
 `
-const SettingsLink = (props) => (
-  <SettingsLinkWrapper {...props}>
-    <Settings />
-    <XSmallUpperCase>{pageLanguage.settings}</XSmallUpperCase>
-  </SettingsLinkWrapper>
-)
 
 const SiteOverview = () => {
   const [doesSiteExist, setDoesSiteExist] = useState(true)
@@ -81,7 +68,9 @@ const SiteOverview = () => {
             <ItemTitle as='h2'>{site?.site_name}</ItemTitle>
             <ItemSubTitle>{landscape?.landscape_name}</ItemSubTitle>
           </Stack>
-          <SettingsLink to={`/site/${siteId}/edit`} />
+          <ButtonSecondary component={Link} to={`/site/${siteId}/edit`}>
+            <Settings /> Settings
+          </ButtonSecondary>
         </TitleAndActionContainer>
         <StyledSectionHeader>{pageLanguage.formGroupTitle.registration}</StyledSectionHeader>
         {/* this is a table instead of a ul to leave room for a cell that shows


### PR DESCRIPTION
# Description

Added mobile-friendly hover states meaning that the hover states won't "stick" on moblie. Issue described in [this csstricks article](https://css-tricks.com/solving-sticky-hover-states-with-media-hover-hover/).

Used `ButtonSecondary` for the settings link on the site and for the edit button on the landscape cards for consistency.

The idea behind the edit button on the landscape card is because eventually there will also be links to the sites that use that landscape. Otherwise just clicking the card will take you to edit, and the button would be redundant.

I made editing the landscape the default action when clicking the card. 