### PR TITLE
[180] feat: generic ConfirmPrompt component for reuse, using a confim prompt for landscape delete

### DIFF
--- a/mrtt-ui/src/components/ConfirmPrompt/ConfirmPrompt.js
+++ b/mrtt-ui/src/components/ConfirmPrompt/ConfirmPrompt.js
@@ -1,0 +1,42 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Dialog } from '@mui/material'
+import { ButtonContainer, PaddedSection, RowFlexEnd } from '../../styles/containers'
+import { H2 } from '../../styles/typography'
+import { ButtonCancel, ButtonPrimary } from '../../styles/buttons'
+
+const ConfirmPrompt = ({ title, promptText, confirmButtonText, isOpen, setIsOpen, onConfirm }) => {
+  const handleCancelClick = () => {
+    setIsOpen(false)
+  }
+
+  const handleConfirmClick = () => {
+    setIsOpen(false)
+    onConfirm()
+  }
+  return (
+    <Dialog open={isOpen}>
+      <PaddedSection>
+        <H2>{title}</H2>
+        <p>{promptText}</p>
+        <RowFlexEnd>
+          <ButtonContainer>
+            <ButtonCancel onClick={handleCancelClick}>fsdjkl</ButtonCancel>
+            <ButtonPrimary onClick={handleConfirmClick}>{confirmButtonText}</ButtonPrimary>
+          </ButtonContainer>
+        </RowFlexEnd>
+      </PaddedSection>
+    </Dialog>
+  )
+}
+
+ConfirmPrompt.propTypes = {
+  confirmButtonText: PropTypes.string.isRequired,
+  isOpen: PropTypes.bool.isRequired,
+  onConfirm: PropTypes.func.isRequired,
+  promptText: PropTypes.string.isRequired,
+  setIsOpen: PropTypes.func.isRequired,
+  title: PropTypes.string.isRequired
+}
+
+export default ConfirmPrompt

--- a/mrtt-ui/src/components/ConfirmPrompt/ConfirmPrompt.stories.js
+++ b/mrtt-ui/src/components/ConfirmPrompt/ConfirmPrompt.stories.js
@@ -1,0 +1,24 @@
+import { action } from '@storybook/addon-actions'
+
+import React, { useState } from 'react'
+
+import ConfirmPrompt from './ConfirmPrompt'
+
+export default {
+  title: 'ConfirmPrompt',
+  component: ConfirmPrompt
+}
+
+export const Basic = () => {
+  const [isOpen, setIsOpen] = useState(true)
+  return (
+    <ConfirmPrompt
+      isOpen={isOpen}
+      setIsOpen={setIsOpen}
+      title='X'
+      promptText='Should X bla bla bla bla bla bjkdls dshjkf ashj sfhjaskf ashjk?'
+      confirmButtonText='Do it!'
+      onConfirm={action('confirmed')}
+    />
+  )
+}

--- a/mrtt-ui/src/language.js
+++ b/mrtt-ui/src/language.js
@@ -37,6 +37,11 @@ const pages = {
   sites: { title: 'Sites', newSiteButton: 'New Site' },
   landscapeForm: {
     delete: 'Delete this landscape',
+    deletePropmt: {
+      title: 'Delete Landscape',
+      propmtText: 'Are you sure you wan to delete this landscape?',
+      buttonText: 'Yes, delete this landscape'
+    },
     isAssociatedSites:
       'You must change the associated sites to another landscape before you can delete this landscape.',
     labelName: 'Name',

--- a/mrtt-ui/src/styles/typography.js
+++ b/mrtt-ui/src/styles/typography.js
@@ -9,6 +9,10 @@ export const ErrorText = styled(Typography)`
 `
 ErrorText.defaultProps = { variant: 'subtitle' }
 
+export const H2 = styled('h2')`
+  margin: ${themeMui.spacing(1)} 0;
+`
+
 export const H4 = styled('h4')`
   margin: ${themeMui.spacing(1)} 0;
 `

--- a/mrtt-ui/src/views/LandscapeForm.js
+++ b/mrtt-ui/src/views/LandscapeForm.js
@@ -1,6 +1,5 @@
 import { Autocomplete, FormLabel, TextField } from '@mui/material'
 import { Controller, useForm } from 'react-hook-form'
-import { styled } from '@mui/system'
 import { toast } from 'react-toastify'
 import { useNavigate, useParams } from 'react-router-dom'
 import { yupResolver } from '@hookform/resolvers/yup'
@@ -18,17 +17,12 @@ import {
 import { ButtonCancel, ButtonSubmit } from '../styles/buttons'
 import { ErrorText } from '../styles/typography'
 import { Form, SectionFormTitle } from '../styles/forms'
+import ButtonSecondaryWithLoader from '../components/ButtonSecondaryWithLoader'
+import ConfirmPrompt from '../components/ConfirmPrompt/ConfirmPrompt'
 import ItemDoesntExist from '../components/ItemDoesntExist'
 import language from '../language'
 import LoadingIndicator from '../components/LoadingIndicator'
 import SubmitErrorWithExtraErrorContent from '../components/SubmitErrorWithExtraErrorContent'
-
-import themeMui from '../styles/themeMui'
-import ButtonSecondaryWithLoader from '../components/ButtonSecondaryWithLoader'
-
-const DeleteSectionWrapper = styled('div')`
-  margin-top: ${themeMui.spacing(2)};
-`
 
 const validationSchema = yup.object({
   landscape_name: yup.string().required(language.pages.landscapeForm.validation.nameRequired),
@@ -40,6 +34,7 @@ const formDefaultValues = { landscape_name: '', selectedOrganizations: [] }
 const LandscapeForm = ({ isNewLandscape }) => {
   const [doesLandscapeExist, setDoesLandscapeExist] = useState(true)
   const [isAssociatedSites, setIsAssociatedSites] = useState(false)
+  const [isDeleteConfirmPromptOpen, setIsDeleteConfirmPromptOpen] = useState(false)
   const [isDeleting, setIsDeleting] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
   const [isSubmitError, setIsSubmitError] = useState(false)
@@ -154,7 +149,7 @@ const LandscapeForm = ({ isNewLandscape }) => {
     navigate('/landscapes')
   }
 
-  const handleDeleteClick = () => {
+  const handleDeleteConfirm = () => {
     setIsDeleting(true)
     axios
       .delete(landscapeUrl)
@@ -167,6 +162,10 @@ const LandscapeForm = ({ isNewLandscape }) => {
         setIsDeleting(false)
         toast.error(language.error.delete)
       })
+  }
+
+  const handleDeleteClick = () => {
+    setIsDeleteConfirmPromptOpen(true)
   }
 
   const form = !doesLandscapeExist ? (
@@ -221,12 +220,19 @@ const LandscapeForm = ({ isNewLandscape }) => {
             <ButtonSubmit isSubmitting={isSubmitting} />
           </ButtonContainer>
         </Form>
-        <DeleteSectionWrapper>
-          {isAssociatedSites ? (
-            <p>{language.pages.landscapeForm.isAssociatedSites}</p>
-          ) : (
-            <p>{language.pages.landscapeForm.noAssociatedSites}</p>
-          )}
+      </PaddedSection>
+    </>
+  )
+
+  const deleteLandscapeSection = !isNewLandscape ? (
+    <>
+      <PaddedSection>
+        {isAssociatedSites ? (
+          <p>{language.pages.landscapeForm.isAssociatedSites}</p>
+        ) : (
+          <p>{language.pages.landscapeForm.noAssociatedSites}</p>
+        )}
+        <div>
           <ButtonSecondaryWithLoader
             disabled={isAssociatedSites}
             onClick={handleDeleteClick}
@@ -234,12 +240,27 @@ const LandscapeForm = ({ isNewLandscape }) => {
             holdingContent={language.buttons.deleting}>
             {language.pages.landscapeForm.delete}
           </ButtonSecondaryWithLoader>
-        </DeleteSectionWrapper>
+        </div>
       </PaddedSection>
+      <ConfirmPrompt
+        isOpen={isDeleteConfirmPromptOpen}
+        setIsOpen={setIsDeleteConfirmPromptOpen}
+        title={language.pages.landscapeForm.deletePropmt.title}
+        promptText={language.pages.landscapeForm.deletePropmt.propmtText}
+        confirmButtonText={language.pages.landscapeForm.deletePropmt.buttonText}
+        onConfirm={handleDeleteConfirm}
+      />
+    </>
+  ) : null
+
+  return isLoading ? (
+    <LoadingIndicator />
+  ) : (
+    <>
+      {form}
+      {deleteLandscapeSection}
     </>
   )
-
-  return isLoading ? <LoadingIndicator /> : form
 }
 
 LandscapeForm.propTypes = { isNewLandscape: PropTypes.bool.isRequired }


### PR DESCRIPTION

closes #180

instructions:
go to landscape form with no sites (maybe create new one for that), click delete button, see prompt, click cancel, click delete again, click 'yes, delete' button. 