### PR TITLE
[143] feat: questions section navigation (privacy still WIP)

### DIFF
--- a/mrtt-ui/src/App.js
+++ b/mrtt-ui/src/App.js
@@ -22,6 +22,7 @@ import SiteForm from './views/SiteForm'
 import SiteQuestionsOverview from './views/SiteQuestionsOverview/SiteQuestionsOverview'
 import Sites from './views/Sites'
 import themeMui from './styles/themeMui'
+import CostsForm from './views/CostsForm'
 
 function App() {
   return (
@@ -60,7 +61,8 @@ function App() {
                 path='/sites/:siteId/form/causes-of-decline'
                 element={<CausesOfDeclineForm />}
               />
-              <Route path='/sites/:siteId/form/project-details' element={<ProjectDetailsForm />} />
+              <Route path='/sites/:siteId/form/costs' element={<CostsForm />} />
+              <Route path='/sites/:siteId/form/project-details/' element={<ProjectDetailsForm />} />
               <Route
                 path='/sites/:siteId/form/restoration-aims'
                 element={<RestorationAimsForm />}

--- a/mrtt-ui/src/components/ButtonSave.js
+++ b/mrtt-ui/src/components/ButtonSave.js
@@ -1,0 +1,24 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { ButtonPrimary } from '../styles/buttons'
+import language from '../language'
+
+const ButtonSave = ({ isSaving, component, ...restOfProps }) => {
+  const ComponentToUse = component ? component : ButtonPrimary
+  return (
+    <ComponentToUse disabled={isSaving} {...restOfProps}>
+      {isSaving ? language.buttons.saving : language.buttons.save}
+    </ComponentToUse>
+  )
+}
+
+ButtonSave.propTypes = {
+  isSaving: PropTypes.bool.isRequired,
+  component: PropTypes.any
+}
+
+ButtonSave.defaultProps = {
+  component: undefined
+}
+
+export default ButtonSave

--- a/mrtt-ui/src/components/CausesOfDeclineForm.js
+++ b/mrtt-ui/src/components/CausesOfDeclineForm.js
@@ -1,7 +1,3 @@
-import { toast } from 'react-toastify'
-import { useState, useCallback } from 'react'
-import axios from 'axios'
-import { useParams } from 'react-router-dom'
 import {
   Box,
   Checkbox,
@@ -13,24 +9,30 @@ import {
   TextField,
   Typography
 } from '@mui/material'
+import { FormPageHeader, SectionFormSubtitle, StickyFormLabel } from '../styles/forms'
+import { toast } from 'react-toastify'
 import { useForm, useFieldArray, Controller } from 'react-hook-form'
+import { useParams } from 'react-router-dom'
+import { useState, useCallback } from 'react'
 import { yupResolver } from '@hookform/resolvers/yup'
-import { FormPageHeader, StickyFormLabel } from '../styles/forms'
 import * as yup from 'yup'
+import axios from 'axios'
 
-import { Form, FormQuestionDiv, SectionFormTitle, SubTitle, SubTitle2 } from '../styles/forms'
-import { ButtonSubmit } from '../styles/buttons'
 import { causesOfDecline } from '../data/questions'
 import { causesOfDeclineOptions } from '../data/causesOfDeclineOptions'
-import { ErrorText, Link } from '../styles/typography'
+import { ContentWrapper } from '../styles/containers'
+import { ErrorText } from '../styles/typography'
+import { Form, FormQuestionDiv, SectionFormTitle, SubTitle, SubTitle2 } from '../styles/forms'
 import { mapDataForApi } from '../library/mapDataForApi'
 import { questionMapping } from '../data/questionMapping'
 import language from '../language'
 import LoadingIndicator from './LoadingIndicator'
+import QuestionNav from './QuestionNav'
 import useInitializeQuestionMappedForm from '../library/useInitializeQuestionMappedForm'
-import { ContentWrapper } from '../styles/containers'
+import useSiteInfo from '../library/useSiteInfo'
 
 function CausesOfDeclineForm() {
+  const { site_name } = useSiteInfo()
   const validationSchema = yup.object().shape({
     lossKnown: yup.string(),
     causesOfDecline: yup
@@ -266,10 +268,18 @@ function CausesOfDeclineForm() {
   ) : (
     <ContentWrapper>
       <FormPageHeader>
-        <SectionFormTitle>Causes of Decline</SectionFormTitle>
-        <Link to={-1}>&larr; {language.form.navigateBackToSiteOverview}</Link>
+        <SectionFormTitle>
+          {language.pages.siteQuestionsOverview.formName.causesOfDecline}
+        </SectionFormTitle>
+        <SectionFormSubtitle>{site_name}</SectionFormSubtitle>
       </FormPageHeader>
-      <Form onSubmit={handleSubmit(onSubmit)}>
+      <QuestionNav
+        isSaving={isSubmitting}
+        isSaveError={isError}
+        onSave={handleSubmit(onSubmit)}
+        currentSection='causes-of-decline'
+      />
+      <Form>
         <FormQuestionDiv>
           <StickyFormLabel>{causesOfDecline.lossKnown.question}</StickyFormLabel>
           <Controller
@@ -449,10 +459,6 @@ function CausesOfDeclineForm() {
             ))}
           </FormQuestionDiv>
         ) : null}
-        <FormQuestionDiv>
-          {isError && <ErrorText>Submit failed, please try again</ErrorText>}
-          <ButtonSubmit isSubmitting={isSubmitting}></ButtonSubmit>
-        </FormQuestionDiv>
       </Form>
     </ContentWrapper>
   )

--- a/mrtt-ui/src/components/PreRestorationAssessmentForm.js
+++ b/mrtt-ui/src/components/PreRestorationAssessmentForm.js
@@ -1,9 +1,3 @@
-import { useState, useCallback } from 'react'
-import axios from 'axios'
-import { useParams } from 'react-router-dom'
-import { useForm, useFieldArray, Controller } from 'react-hook-form'
-import { yupResolver } from '@hookform/resolvers/yup'
-import * as yup from 'yup'
 import {
   Box,
   Button,
@@ -16,31 +10,39 @@ import {
   Typography
 } from '@mui/material'
 import { toast } from 'react-toastify'
+import { useForm, useFieldArray, Controller } from 'react-hook-form'
+import { useParams } from 'react-router-dom'
+import { useState, useCallback } from 'react'
+import { yupResolver } from '@hookform/resolvers/yup'
+import * as yup from 'yup'
+import axios from 'axios'
 
 import {
   Form,
   FormPageHeader,
   FormQuestionDiv,
   StickyFormLabel,
+  SectionFormSubtitle,
   SectionFormTitle,
   SelectedInputSection,
   TabularLabel
 } from '../styles/forms'
 import { ContentWrapper } from '../styles/containers'
-import { questionMapping } from '../data/questionMapping'
-import { preRestorationAssessment as questions } from '../data/questions'
-import { mapDataForApi } from '../library/mapDataForApi'
-import { ButtonSubmit } from '../styles/buttons'
-import { ErrorText, Link } from '../styles/typography'
-import CheckboxGroupWithLabelAndController from './CheckboxGroupWithLabelAndController'
-import { multiselectWithOtherValidationNoMinimum } from '../validation/multiSelectWithOther'
-import useInitializeQuestionMappedForm from '../library/useInitializeQuestionMappedForm'
-import LoadingIndicator from './LoadingIndicator'
-import { mangroveSpeciesPerCountryList } from '../data/mangroveSpeciesPerCountry'
-import language from '../language'
-import TabularInputRow from './TabularInput/TabularInputRow'
-import AddTabularInputRow from './TabularInput/AddTabularInputRow'
+import { ErrorText } from '../styles/typography'
 import { findDataItem } from '../library/findDataItem'
+import { mangroveSpeciesPerCountryList } from '../data/mangroveSpeciesPerCountry'
+import { mapDataForApi } from '../library/mapDataForApi'
+import { multiselectWithOtherValidationNoMinimum } from '../validation/multiSelectWithOther'
+import { preRestorationAssessment as questions } from '../data/questions'
+import { questionMapping } from '../data/questionMapping'
+import AddTabularInputRow from './TabularInput/AddTabularInputRow'
+import CheckboxGroupWithLabelAndController from './CheckboxGroupWithLabelAndController'
+import language from '../language'
+import LoadingIndicator from './LoadingIndicator'
+import QuestionNav from './QuestionNav'
+import TabularInputRow from './TabularInput/TabularInputRow'
+import useInitializeQuestionMappedForm from '../library/useInitializeQuestionMappedForm'
+import useSiteInfo from '../library/useSiteInfo'
 
 const getSiteCountries = (registrationAnswersFromServer) =>
   findDataItem(registrationAnswersFromServer, '1.2') ?? []
@@ -52,6 +54,7 @@ const getPhysicalMeasurementsTaken = (registrationAnswersFromServer) =>
   findDataItem(registrationAnswersFromServer, '5.3g') ?? []
 
 function PreRestorationAssessmentForm() {
+  const { site_name } = useSiteInfo()
   const validationSchema = yup.object().shape({
     mangrovesPreviouslyOccured: yup.string(),
     mangroveRestorationAttempted: yup.string(),
@@ -251,10 +254,18 @@ function PreRestorationAssessmentForm() {
   ) : (
     <ContentWrapper>
       <FormPageHeader>
-        <SectionFormTitle>Pre Restoration Assessment Form</SectionFormTitle>
-        <Link to={-1}>&larr; {language.form.navigateBackToSiteOverview}</Link>
+        <SectionFormTitle>
+          {language.pages.siteQuestionsOverview.formName.preRestorationAssessment}
+        </SectionFormTitle>
+        <SectionFormSubtitle>{site_name}</SectionFormSubtitle>
       </FormPageHeader>
-      <Form onSubmit={validateInputs(handleSubmit)}>
+      <QuestionNav
+        isSaving={isSubmitting}
+        isSaveError={isError}
+        onSave={validateInputs(handleSubmit)}
+        currentSection='pre-restoration-assessment'
+      />
+      <Form>
         <FormQuestionDiv>
           <StickyFormLabel>{questions.mangrovesPreviouslyOccured.question}</StickyFormLabel>
           <Controller
@@ -520,10 +531,6 @@ function PreRestorationAssessmentForm() {
             )}
           />
           <ErrorText>{errors.guidanceForSiteRestoration?.message}</ErrorText>
-        </FormQuestionDiv>
-        <FormQuestionDiv>
-          {isError && <ErrorText>Submit failed, please try again</ErrorText>}
-          <ButtonSubmit isSubmitting={isSubmitting}></ButtonSubmit>
         </FormQuestionDiv>
       </Form>
     </ContentWrapper>

--- a/mrtt-ui/src/components/ProjectDetailsForm.js
+++ b/mrtt-ui/src/components/ProjectDetailsForm.js
@@ -12,14 +12,14 @@ import turfConvex from '@turf/convex'
 import turfBbox from '@turf/bbox'
 import turfBboxPolygon from '@turf/bbox-polygon'
 
-import { ButtonSubmit } from '../styles/buttons'
-import { ErrorText, Link } from '../styles/typography'
+import { ErrorText } from '../styles/typography'
 import {
   StickyFormLabel,
   FormPageHeader,
   FormQuestionDiv,
   SectionFormTitle,
-  Form
+  Form,
+  SectionFormSubtitle
 } from '../styles/forms'
 import { mapDataForApi } from '../library/mapDataForApi'
 import { projectDetails as questions } from '../data/questions'
@@ -33,6 +33,8 @@ import mangroveCountries from '../data/mangrove_countries.json'
 import ProjectAreaMap from './ProjectAreaMap'
 import useInitializeQuestionMappedForm from '../library/useInitializeQuestionMappedForm'
 import { ContentWrapper } from '../styles/containers'
+import QuestionNav from './QuestionNav'
+import useSiteInfo from '../library/useSiteInfo'
 
 const sortCountries = (a, b) => {
   const textA = a.properties.country.toUpperCase()
@@ -48,6 +50,7 @@ function ProjectDetailsForm() {
   const [isError, setIsError] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const { site_name } = useSiteInfo()
   const validationSchema = yup.object().shape({
     hasProjectEndDate: yup.boolean(),
     projectStartDate: yup.string().required('Select a start date'),
@@ -162,10 +165,18 @@ function ProjectDetailsForm() {
   ) : (
     <ContentWrapper>
       <FormPageHeader>
-        <SectionFormTitle>Project Details Form</SectionFormTitle>
-        <Link to={-1}>&larr; {language.form.navigateBackToSiteOverview}</Link>
+        <SectionFormTitle>
+          {language.pages.siteQuestionsOverview.formName.siteDetails}
+        </SectionFormTitle>
+        <SectionFormSubtitle>{site_name}</SectionFormSubtitle>
       </FormPageHeader>
-      <Form onSubmit={validateInputs(handleSubmit)}>
+      <QuestionNav
+        isSaving={isSubmitting}
+        isSaveError={isError}
+        onSave={validateInputs(handleSubmit)}
+        currentSection='project-details'
+      />
+      <Form>
         {/* Has project end date radio group */}
         <FormQuestionDiv>
           <StickyFormLabel id='has-project-end-date-label'>
@@ -283,10 +294,6 @@ function ProjectDetailsForm() {
             )}
           />
           <ErrorText>{errors.siteArea?.features?.message}</ErrorText>
-        </FormQuestionDiv>
-        <FormQuestionDiv>
-          {isError && <ErrorText>{language.error.submit}</ErrorText>}
-          <ButtonSubmit isSubmitting={isSubmitting} />
         </FormQuestionDiv>
       </Form>
     </ContentWrapper>

--- a/mrtt-ui/src/components/QuestionNav.js
+++ b/mrtt-ui/src/components/QuestionNav.js
@@ -1,0 +1,165 @@
+import { RowSpaceBetween } from '../styles/containers'
+import PropTypes from 'prop-types'
+import React from 'react'
+
+import { ArrowBack, ArrowBackIosNew, ArrowForwardIos } from '@mui/icons-material'
+import { css, styled } from '@mui/system'
+import { ErrorText, LinkLooksLikeButtonSecondary } from '../styles/typography'
+import { Stack } from '@mui/material'
+import { Link, useParams } from 'react-router-dom'
+import ButtonSave from './ButtonSave'
+import language from '../language'
+import theme from '../styles/theme'
+import themeMui from '../styles/themeMui'
+
+const SECTION_NAMES = [
+  'project-details',
+  'site-background',
+  'restoration-aims',
+  'causes-of-decline',
+  'pre-restoration-assessment',
+  'site-interventions',
+  'costs'
+]
+
+const getMobileNavButtonSecondaryCss = (props) => css`
+  align-items: center;
+  background-color: ${theme.color.white};
+  border: solid thin ${theme.color.primary};
+  color: ${theme.color.primary};
+  cursor: ${props.disabled ? 'auto' : 'pointer'};
+  display: inline-flex;
+  padding: ${themeMui.spacing(1)} ${themeMui.spacing(3)};
+  width: 100%;
+  ${props.disabled
+    ? css`
+        background-color: ${theme.color.bodyBackground};
+        border: solid thin ${theme.color.lightGrey};
+        color: ${theme.color.lightGrey};
+      `
+    : theme.hoverState(css`
+        background-color: ${theme.color.primary};
+        color: ${theme.color.white};
+      `)};
+`
+const LinkMobileNav = styled(Link)`
+  ${(props) => getMobileNavButtonSecondaryCss(props)}
+`
+
+const SelectMobileNav = styled('select')`
+  ${(props) => getMobileNavButtonSecondaryCss(props)}
+`
+
+const ButtonMobileNav = styled('button')`
+  ${(props) => getMobileNavButtonSecondaryCss(props)}
+`
+
+const SelectDesktopNav = styled('select')`
+  ${(props) => getMobileNavButtonSecondaryCss(props)}
+  border-radius: 4px;
+  height: 100%;
+  text-transform: uppercase;
+  width: inherit;
+`
+
+const MobileQuestionNavWrapper = styled('div')`
+  display: block;
+  margin-bottom: ${themeMui.spacing(3)};
+  @media (min-width: ${theme.layout.mediaQueryDesktop}) {
+    display: none;
+  }
+`
+
+const DesktopQuestionNavWrapper = styled('div')`
+  align-items: stretch;
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: ${themeMui.spacing(5)};
+  @media (max-width: ${theme.layout.mediaQueryDesktop}) {
+    display: none;
+  }
+  & div > * {
+    margin-right: ${themeMui.spacing(1)};
+  }
+`
+
+const QuestionNav = ({ isSaving, isSaveError, onSave, currentSection }) => {
+  const { siteId } = useParams()
+
+  const currentSectionNameIndex = SECTION_NAMES.indexOf(currentSection)
+  const previousSection = SECTION_NAMES[currentSectionNameIndex - 1]
+  const nextSection = SECTION_NAMES[currentSectionNameIndex + 1]
+
+  return (
+    <Stack>
+      <MobileQuestionNavWrapper>
+        <RowSpaceBetween>
+          <RowSpaceBetween>
+            <LinkMobileNav to={`/sites/${siteId}/overview`}>
+              <Stack>
+                <ArrowBack />
+              </Stack>
+            </LinkMobileNav>
+            <LinkMobileNav
+              to={!previousSection ? '#' : `/sites/${siteId}/form/${previousSection}`}
+              disabled={!previousSection}>
+              <ArrowBackIosNew />
+            </LinkMobileNav>
+            <LinkMobileNav
+              to={!nextSection ? '#' : `/sites/${siteId}/form/${nextSection}`}
+              disabled={!nextSection}>
+              <ArrowForwardIos />
+            </LinkMobileNav>
+          </RowSpaceBetween>
+          <SelectMobileNav
+            id='form-privacy'
+            value={'Placeholder'}
+            label='Placeholder (wip)'
+            onChange={() => {}}>
+            <option value={'Placeholder'}>Placeholder</option>
+            <option value={20}>Other Placeholder</option>
+          </SelectMobileNav>
+          <ButtonSave isSaving={isSaving} onClick={onSave} component={ButtonMobileNav} />
+        </RowSpaceBetween>
+      </MobileQuestionNavWrapper>
+      <DesktopQuestionNavWrapper>
+        <div>
+          <LinkLooksLikeButtonSecondary to={`/sites/${siteId}/overview`}>
+            <ArrowBack /> {language.questionNav.returnToSite}
+          </LinkLooksLikeButtonSecondary>
+          <LinkLooksLikeButtonSecondary
+            to={!previousSection ? '#' : `/sites/${siteId}/form/${previousSection}`}
+            disabled={!previousSection}>
+            <ArrowBackIosNew />
+            {language.questionNav.previousSection}
+          </LinkLooksLikeButtonSecondary>
+          <LinkLooksLikeButtonSecondary
+            to={!nextSection ? '#' : `/sites/${siteId}/form/${nextSection}`}
+            disabled={!nextSection}>
+            {language.questionNav.nextSection}
+            <ArrowForwardIos />
+          </LinkLooksLikeButtonSecondary>
+          <SelectDesktopNav
+            id='form-privacy'
+            value={'Placeholder'}
+            label='Placeholder (wip)'
+            onChange={() => {}}>
+            <option value={'Placeholder'}>WIP Value 1</option>
+            <option value={20}>WIP Value 2</option>
+          </SelectDesktopNav>
+        </div>
+        <ButtonSave isSaving={isSaving} onClick={onSave} />
+      </DesktopQuestionNavWrapper>
+      {isSaveError && <ErrorText>{language.error.submit}</ErrorText>}
+    </Stack>
+  )
+}
+
+QuestionNav.propTypes = {
+  currentSection: PropTypes.string.isRequired,
+  isSaving: PropTypes.bool.isRequired,
+  isSaveError: PropTypes.bool.isRequired,
+  onSave: PropTypes.func.isRequired
+}
+
+export default QuestionNav

--- a/mrtt-ui/src/components/RestorationAimsForm/RestorationAimsForm.js
+++ b/mrtt-ui/src/components/RestorationAimsForm/RestorationAimsForm.js
@@ -1,37 +1,45 @@
+import { useCallback, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { useParams } from 'react-router-dom'
-import { useCallback, useState } from 'react'
 import { yupResolver } from '@hookform/resolvers/yup'
 import * as yup from 'yup'
 import axios from 'axios'
 
-import { ButtonSubmit } from '../../styles/buttons'
-import { ErrorText, Link } from '../../styles/typography'
-import { Form, FormPageHeader, FormQuestionDiv, SectionFormTitle } from '../../styles/forms'
-import { mapDataForApi } from '../../library/mapDataForApi'
 import {
   multiselectWithOtherValidation,
   multiselectWithOtherValidationNoMinimum
 } from '../../validation/multiSelectWithOther'
+import {
+  Form,
+  FormPageHeader,
+  FormQuestionDiv,
+  SectionFormSubtitle,
+  SectionFormTitle
+} from '../../styles/forms'
+import { ContentWrapper } from '../../styles/containers'
+import { ErrorText } from '../../styles/typography'
+import { mapDataForApi } from '../../library/mapDataForApi'
 import { questionMapping } from '../../data/questionMapping'
 import { restorationAims as questions } from '../../data/questions'
 import { toast } from 'react-toastify'
 import language from '../../language'
 import LoadingIndicator from '../LoadingIndicator'
+import QuestionNav from '../QuestionNav'
 import RestorationAimsCheckboxGroupWithLabel from './RestorationAimsCheckboxGroupWithLabel'
 import useInitializeQuestionMappedForm from '../../library/useInitializeQuestionMappedForm'
-import { ContentWrapper } from '../../styles/containers'
+import useSiteInfo from '../../library/useSiteInfo'
 
 const getStakeholders = (registrationAnswersFromServer) =>
   registrationAnswersFromServer?.data.find((dataItem) => dataItem.question_id === '2.1')
     ?.answer_value ?? []
 const RestorationAimsForm = () => {
-  const { siteId } = useParams()
-  const apiAnswersUrl = `${process.env.REACT_APP_API_URL}/sites/${siteId}/registration_answers`
   const [isLoading, setIsLoading] = useState(false)
   const [isSubmitError, setIsSubmitError] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [stakeholders, setStakeholders] = useState([])
+  const { site_name } = useSiteInfo()
+  const { siteId } = useParams()
+  const apiAnswersUrl = `${process.env.REACT_APP_API_URL}/sites/${siteId}/registration_answers`
   const validationSchema = yup.object({
     ecologicalAims: multiselectWithOtherValidation,
     socioEconomicAims: multiselectWithOtherValidation,
@@ -84,8 +92,16 @@ const RestorationAimsForm = () => {
   ) : (
     <ContentWrapper>
       <FormPageHeader>
-        <SectionFormTitle>Restoration Aims</SectionFormTitle>
-        <Link to={-1}>&larr; {language.form.navigateBackToSiteOverview}</Link>
+        <SectionFormTitle>
+          {language.pages.siteQuestionsOverview.formName.restorationAims}
+        </SectionFormTitle>
+        <SectionFormSubtitle>{site_name}</SectionFormSubtitle>
+        <QuestionNav
+          isSaving={isSubmitting}
+          isSaveError={isSubmitError}
+          onSave={validateInputs(handleSubmit)}
+          currentSection='restoration-aims'
+        />
       </FormPageHeader>
       <Form onSubmit={validateInputs(handleSubmit)}>
         <FormQuestionDiv>
@@ -120,8 +136,6 @@ const RestorationAimsForm = () => {
           />
           <ErrorText>{errors.otherAims?.selectedValues?.message}</ErrorText>
         </FormQuestionDiv>
-        {isSubmitError && <ErrorText>{language.error.submit}</ErrorText>}
-        <ButtonSubmit isSubmitting={isSubmitting} />
       </Form>
     </ContentWrapper>
   )

--- a/mrtt-ui/src/components/SiteBackgroundForm.js
+++ b/mrtt-ui/src/components/SiteBackgroundForm.js
@@ -1,38 +1,41 @@
 import { Box, Checkbox, List, ListItem, MenuItem, TextField, Typography } from '@mui/material'
+import { toast } from 'react-toastify'
 import { useForm, useFieldArray, Controller } from 'react-hook-form'
 import { useParams } from 'react-router-dom'
 import { useState, useCallback } from 'react'
 import { yupResolver } from '@hookform/resolvers/yup'
 import * as yup from 'yup'
 import axios from 'axios'
-import { toast } from 'react-toastify'
 
-import { ButtonSubmit } from '../styles/buttons'
-import { ErrorText, Link } from '../styles/typography'
 import {
-  StickyFormLabel,
   Form,
+  FormPageHeader,
   FormQuestionDiv,
+  SectionFormSubtitle,
   SectionFormTitle,
-  FormPageHeader
+  StickyFormLabel
 } from '../styles/forms'
+import { ContentWrapper } from '../styles/containers'
+import { ErrorText } from '../styles/typography'
 import { mapDataForApi } from '../library/mapDataForApi'
 import { multiselectWithOtherValidation } from '../validation/multiSelectWithOther'
+import { questionMapping } from '../data/questionMapping'
 import { siteBackground } from '../data/questions'
 import CheckboxGroupWithLabelAndController from './CheckboxGroupWithLabelAndController'
 import language from '../language'
 import LoadingIndicator from './LoadingIndicator'
+import QuestionNav from './QuestionNav'
 import useInitializeQuestionMappedForm from '../library/useInitializeQuestionMappedForm'
-import { questionMapping } from '../data/questionMapping'
-import { ContentWrapper } from '../styles/containers'
+import useSiteInfo from '../library/useSiteInfo'
 
-const ProjectDetailsForm = () => {
-  const { siteId } = useParams()
-  const apiAnswersUrl = `${process.env.REACT_APP_API_URL}/sites/${siteId}/registration_answers`
-  const [isSubmitting, setisSubmitting] = useState(false)
+const SiteBackgroundForm = () => {
   const [isError, setIsError] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
+  const [isSubmitting, setisSubmitting] = useState(false)
   const [stakeholderTypesChecked, setStakeholderTypesChecked] = useState([])
+  const { site_name } = useSiteInfo()
+  const { siteId } = useParams()
+  const apiAnswersUrl = `${process.env.REACT_APP_API_URL}/sites/${siteId}/registration_answers`
 
   const validationSchema = yup.object().shape({
     stakeholders: yup
@@ -136,12 +139,20 @@ const ProjectDetailsForm = () => {
     <LoadingIndicator />
   ) : (
     <ContentWrapper>
-      {/* Select Stakeholders */}
       <FormPageHeader>
-        <SectionFormTitle>Site Background Form</SectionFormTitle>
-        <Link to={-1}>&larr; {language.form.navigateBackToSiteOverview}</Link>
+        <SectionFormTitle>
+          {language.pages.siteQuestionsOverview.formName.siteBackground}
+        </SectionFormTitle>
+        <SectionFormSubtitle>{site_name}</SectionFormSubtitle>
       </FormPageHeader>
-      <Form onSubmit={validateInputs(handleSubmit)}>
+      <QuestionNav
+        isSaving={isSubmitting}
+        isSaveError={isError}
+        onSave={validateInputs(handleSubmit)}
+        currentSection='site-background'
+      />
+      {/* Select Stakeholders */}
+      <Form>
         <FormQuestionDiv>
           <StickyFormLabel>{siteBackground.stakeholders.question}</StickyFormLabel>
           <List>
@@ -304,13 +315,9 @@ const ProjectDetailsForm = () => {
           />
           <ErrorText>{errors.customaryRights?.message}</ErrorText>
         </FormQuestionDiv>
-        <FormQuestionDiv>
-          {isError && <ErrorText>Submit failed, please try again</ErrorText>}
-          <ButtonSubmit isSubmitting={isSubmitting}></ButtonSubmit>
-        </FormQuestionDiv>
       </Form>
     </ContentWrapper>
   )
 }
 
-export default ProjectDetailsForm
+export default SiteBackgroundForm

--- a/mrtt-ui/src/components/SiteInterventions.js
+++ b/mrtt-ui/src/components/SiteInterventions.js
@@ -1,11 +1,3 @@
-import { useState, useCallback } from 'react'
-import axios from 'axios'
-import { useParams } from 'react-router-dom'
-import { Controller, useForm, useFieldArray } from 'react-hook-form'
-import { yupResolver } from '@hookform/resolvers/yup'
-import * as yup from 'yup'
-import { toast } from 'react-toastify'
-import { styled } from '@mui/material/styles'
 import {
   Box,
   Checkbox,
@@ -18,33 +10,44 @@ import {
   Typography
 } from '@mui/material'
 import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns'
+import { Controller, useForm, useFieldArray } from 'react-hook-form'
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider'
 import { MobileDatePicker } from '@mui/x-date-pickers/MobileDatePicker'
+import { styled } from '@mui/material/styles'
+import { toast } from 'react-toastify'
+import { useParams } from 'react-router-dom'
+import { useState, useCallback } from 'react'
+import { yupResolver } from '@hookform/resolvers/yup'
+import * as yup from 'yup'
+import axios from 'axios'
 
-import { ContentWrapper } from '../styles/containers'
 import {
   Form,
   FormPageHeader,
   FormQuestionDiv,
+  SectionFormSubtitle,
   SectionFormTitle,
   StickyFormLabel
 } from '../styles/forms'
-import { ErrorText, Link } from '../styles/typography'
-import language from '../language'
+import { ContentWrapper } from '../styles/containers'
+import { ErrorText } from '../styles/typography'
+import { findDataItem } from '../library/findDataItem'
+import { mapDataForApi } from '../library/mapDataForApi'
+import { multiselectWithOtherValidationNoMinimum } from '../validation/multiSelectWithOther'
 import { questionMapping } from '../data/questionMapping'
 import { siteInterventions as questions } from '../data/questions'
-import { mapDataForApi } from '../library/mapDataForApi'
-import { ButtonSubmit } from '../styles/buttons'
-import { multiselectWithOtherValidationNoMinimum } from '../validation/multiSelectWithOther'
-import useInitializeQuestionMappedForm from '../library/useInitializeQuestionMappedForm'
-import LoadingIndicator from './LoadingIndicator'
 import CheckboxGroupWithLabelAndController from './CheckboxGroupWithLabelAndController'
-import { findDataItem } from '../library/findDataItem'
+import language from '../language'
+import LoadingIndicator from './LoadingIndicator'
+import QuestionNav from './QuestionNav'
+import useInitializeQuestionMappedForm from '../library/useInitializeQuestionMappedForm'
+import useSiteInfo from '../library/useSiteInfo'
 
 const getBiophysicalInterventions = (registrationAnswersFromServer) =>
   findDataItem(registrationAnswersFromServer, '6.2a') ?? []
 
 function SiteInterventionsForm() {
+  const { site_name } = useSiteInfo()
   const validationSchema = yup.object({
     whichStakeholdersInvolved: multiselectWithOtherValidationNoMinimum,
     biophysicalInterventionsUsed: yup.array().of(
@@ -154,12 +157,18 @@ function SiteInterventionsForm() {
   ) : (
     <ContentWrapper>
       <FormPageHeader>
-        <SectionFormTitle>Site Interventions</SectionFormTitle>
-        <Link to={`/sites/${siteId}/overview`}>
-          &larr; {language.form.navigateBackToSiteOverview}
-        </Link>
+        <SectionFormTitle>
+          {language.pages.siteQuestionsOverview.formName.siteInterventions}
+        </SectionFormTitle>
+        <SectionFormSubtitle>{site_name}</SectionFormSubtitle>
       </FormPageHeader>
-      <Form onSubmit={validateInputs(handleSubmit)}>
+      <QuestionNav
+        isSaving={isSubmitting}
+        isSaveError={isSubmitError}
+        onSave={validateInputs(handleSubmit)}
+        currentSection='site-interventions'
+      />
+      <Form>
         <FormQuestionDiv>
           <CheckboxGroupWithLabelAndController
             fieldName='whichStakeholdersInvolved'
@@ -297,8 +306,6 @@ function SiteInterventionsForm() {
           />
           <ErrorText>{errors.otherActivitiesImplemented?.selectedValues?.message}</ErrorText>
         </FormQuestionDiv>
-        {isSubmitError && <ErrorText>{language.error.submit}</ErrorText>}
-        <ButtonSubmit isSubmitting={isSubmitting} />
       </Form>
     </ContentWrapper>
   )

--- a/mrtt-ui/src/language.js
+++ b/mrtt-ui/src/language.js
@@ -2,7 +2,7 @@ const error = {
   apiLoad: 'Loading data from the api failed. Please try again.',
   delete: 'Deleting that item failed. Please try again.',
   getItemDoesntExistMessage: (item) => `That ${item} doesnt exist.`,
-  submit: 'Submit failed. Please try again.'
+  submit: 'Saving failed. Please try again.'
 }
 
 const success = {
@@ -116,6 +116,8 @@ const buttons = {
   cancel: 'Cancel',
   deleting: 'Deleting...',
   edit: 'Edit',
+  save: 'Save',
+  saving: 'Saving...',
   submit: 'Submit',
   submitting: 'Submitting...'
 }
@@ -155,6 +157,14 @@ const header = {
   logout: 'Logout'
 }
 
+const questionNav = {
+  returnToSite: 'Return to Site Form Overview',
+  previousSection: 'Previous Section',
+  nextSection: 'Next Section',
+  private: 'Private',
+  public: 'Public'
+}
+
 export default {
   buttons,
   error,
@@ -163,5 +173,6 @@ export default {
   multiselectWithOtherFormQuestion,
   pages,
   projectAreaMap,
+  questionNav,
   success
 }

--- a/mrtt-ui/src/library/useSiteInfo.js
+++ b/mrtt-ui/src/library/useSiteInfo.js
@@ -1,0 +1,21 @@
+import axios from 'axios'
+import { useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
+
+const useSiteInfo = () => {
+  const { siteId } = useParams()
+  const [siteInfo, setSiteInfo] = useState({})
+
+  useEffect(
+    function getSiteInfo() {
+      axios.get(`${process.env.REACT_APP_API_URL}/sites/${siteId}`).then(({ data }) => {
+        setSiteInfo(data)
+      })
+    },
+    [siteId]
+  )
+
+  return siteInfo
+}
+
+export default useSiteInfo

--- a/mrtt-ui/src/styles/forms.js
+++ b/mrtt-ui/src/styles/forms.js
@@ -4,7 +4,7 @@ import themeMui from './themeMui'
 import theme from '../styles/theme'
 
 export const FormPageHeader = styled('div')`
-  padding: ${themeMui.spacing(2)};
+  padding: ${themeMui.spacing(2)} 0;
 `
 export const MainFormDiv = styled('div')`
   display: flex;
@@ -13,6 +13,11 @@ export const MainFormDiv = styled('div')`
 
 export const SectionFormTitle = styled('h1')`
   font-weight: 400;
+  margin-bottom: 0;
+`
+
+export const SectionFormSubtitle = styled('h2')`
+  font-weight: 200;
   margin-bottom: 0;
 `
 export const FormQuestionDiv = styled('div')`

--- a/mrtt-ui/src/styles/typography.js
+++ b/mrtt-ui/src/styles/typography.js
@@ -1,5 +1,6 @@
 import { styled, Typography, Link as LinkMui } from '@mui/material'
 import { Link as LinkReactRouter } from 'react-router-dom'
+import { ButtonSecondary } from './buttons'
 
 import theme from './theme'
 import themeMui from './themeMui'
@@ -18,6 +19,10 @@ export const H4 = styled('h4')`
 `
 
 export const Link = (props) => <LinkMui component={LinkReactRouter} {...props} />
+
+export const LinkLooksLikeButtonSecondary = (props) => (
+  <ButtonSecondary component={LinkReactRouter} {...props} />
+)
 
 export const SmallUpperCase = styled('div')`
   text-transform: uppercase;

--- a/mrtt-ui/src/views/CostsForm.js
+++ b/mrtt-ui/src/views/CostsForm.js
@@ -1,0 +1,26 @@
+import React from 'react'
+
+import { FormPageHeader, SectionFormSubtitle, SectionFormTitle } from '../styles/forms'
+import QuestionNav from '../components/QuestionNav'
+import useSiteInfo from '../library/useSiteInfo'
+import language from '../language'
+import { ContentWrapper } from '../styles/containers'
+
+const CostsForm = () => {
+  const { site_name } = useSiteInfo()
+
+  return (
+    <ContentWrapper>
+      <FormPageHeader>
+        <SectionFormTitle>{language.pages.siteQuestionsOverview.formName.costs}</SectionFormTitle>
+        <SectionFormSubtitle>{site_name}</SectionFormSubtitle>
+      </FormPageHeader>
+      <QuestionNav isSaving={true} isSaveError={true} onSave={() => {}} currentSection='costs' />
+      Costs Form Placeholder
+    </ContentWrapper>
+  )
+}
+
+CostsForm.propTypes = {}
+
+export default CostsForm

--- a/mrtt-ui/src/views/SiteQuestionsOverview/SiteQuestionsOverview.js
+++ b/mrtt-ui/src/views/SiteQuestionsOverview/SiteQuestionsOverview.js
@@ -1,5 +1,4 @@
-import { useParams } from 'react-router-dom'
-import { Link } from '../../styles/typography'
+import { useParams, Link as LinkReactRouter } from 'react-router-dom'
 import { Settings } from '@mui/icons-material'
 import { Stack } from '@mui/material'
 import { styled } from '@mui/system'
@@ -7,7 +6,7 @@ import { toast } from 'react-toastify'
 import axios from 'axios'
 import React, { useEffect, useState } from 'react'
 
-import { ItemSubTitle, ItemTitle } from '../../styles/typography'
+import { ItemSubTitle, ItemTitle, Link } from '../../styles/typography'
 import { ContentWrapper, TitleAndActionContainer } from '../../styles/containers'
 import { TableAlertnatingRows } from '../../styles/table'
 import AddMonitoringSectionMenu from './AddMonitoringSectionMenu'
@@ -68,7 +67,7 @@ const SiteOverview = () => {
             <ItemTitle as='h2'>{site?.site_name}</ItemTitle>
             <ItemSubTitle>{landscape?.landscape_name}</ItemSubTitle>
           </Stack>
-          <ButtonSecondary component={Link} to={`/site/${siteId}/edit`}>
+          <ButtonSecondary component={LinkReactRouter} to={`/sites/${siteId}/edit`}>
             <Settings /> Settings
           </ButtonSecondary>
         </TitleAndActionContainer>


### PR DESCRIPTION
# Description

Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change.

Closes #143 

Instructions: 
- Click on any section of the form. Use the form nav buttons to move to adjacent forms or back to site overview. Use save button to save the form (moved to top of form, removed submit button)
- Notice that when on the first of last form, the next and previous buttons disable when appropriate

Note that privacy functionality is WIP. That needs some schema/ backend thinking through, so will be another ticket