### PR TITLE
Bug fix for 5.3f : fix bad input

### DIFF
--- a/mrtt-ui/src/components/PreRestorationAssessmentForm.js
+++ b/mrtt-ui/src/components/PreRestorationAssessmentForm.js
@@ -86,7 +86,7 @@ function PreRestorationAssessmentForm() {
       .of(
         yup.object().shape({
           mangroveSpeciesType: yup.mixed(),
-          percentageComposition: yup.array().nullable()
+          percentageComposition: yup.mixed()
         })
       )
       .default([]),
@@ -459,7 +459,7 @@ function PreRestorationAssessmentForm() {
                   <Controller
                     name={`speciesComposition.${mangroveSpecieIndex}.percentageComposition`}
                     control={control}
-                    defaultValue={''}
+                    defaultValue={0}
                     render={({ field }) => (
                       <TextField {...field} sx={{ maxWidth: '10em' }} label='% Number'></TextField>
                     )}
@@ -467,7 +467,6 @@ function PreRestorationAssessmentForm() {
                 </SelectedInputSection>
               )
             })}
-            <ErrorText>{errors.speciesComposition?.message}</ErrorText>
           </FormQuestionDiv>
         ) : null}
         {siteAssessmentBeforeProjectWatcher === 'Yes' ? (

--- a/mrtt-ui/src/components/PreRestorationAssessmentForm.js
+++ b/mrtt-ui/src/components/PreRestorationAssessmentForm.js
@@ -16,6 +16,7 @@ import { useState, useCallback } from 'react'
 import { yupResolver } from '@hookform/resolvers/yup'
 import * as yup from 'yup'
 import axios from 'axios'
+import { styled } from '@mui/material/styles'
 
 import {
   Form,
@@ -86,7 +87,7 @@ function PreRestorationAssessmentForm() {
       .of(
         yup.object().shape({
           mangroveSpeciesType: yup.mixed(),
-          percentageComposition: yup.mixed()
+          percentageComposition: yup.number().typeError('Please enter a number')
         })
       )
       .default([]),
@@ -456,14 +457,25 @@ function PreRestorationAssessmentForm() {
               return (
                 <SelectedInputSection key={mangroveSpecieIndex}>
                   <FormLabel>{mangroveSpecie.mangroveSpeciesType}</FormLabel>
-                  <Controller
-                    name={`speciesComposition.${mangroveSpecieIndex}.percentageComposition`}
-                    control={control}
-                    defaultValue={0}
-                    render={({ field }) => (
-                      <TextField {...field} sx={{ maxWidth: '10em' }} label='% Number'></TextField>
-                    )}
-                  />
+                  <TabularInputRowDiv>
+                    <Controller
+                      name={`speciesComposition.${mangroveSpecieIndex}.percentageComposition`}
+                      control={control}
+                      defaultValue={0}
+                      render={({ field }) => (
+                        <TextField
+                          {...field}
+                          sx={{ maxWidth: '10em' }}
+                          label='% Number'></TextField>
+                      )}
+                    />
+                    <ErrorText>
+                      {
+                        errors.speciesComposition?.[mangroveSpecieIndex]?.percentageComposition
+                          ?.message
+                      }
+                    </ErrorText>
+                  </TabularInputRowDiv>
                 </SelectedInputSection>
               )
             })}
@@ -537,3 +549,8 @@ function PreRestorationAssessmentForm() {
 }
 
 export default PreRestorationAssessmentForm
+
+const TabularInputRowDiv = styled(FormLabel)`
+  display: flex;
+  flex-direction: column;
+`


### PR DESCRIPTION
# Description

Updated validation schema for speciesComposition to fix bad null input.

Fixes # [(192)](https://github.com/globalmangrovewatch/gmw-users/issues/192)

Testing

- create a new site
- go to section 1, add a country to ensure species get pulled in section 5
- go to section 5
- scroll to 5.3f
- add number inputs
- refresh page
- number inputs should still be there (they weren't saving before)
