### PR TITLE
[210] fix: sort sites by questions last answered date. If no questions answered yet, dont show last updated info.

### DIFF
--- a/mrtt-ui/src/views/Sites.js
+++ b/mrtt-ui/src/views/Sites.js
@@ -28,13 +28,14 @@ function Sites() {
 
   const sitesList = sites
     .sort((siteA, siteB) => {
-      const siteAName = siteA.site_name?.toLowerCase()
-      const siteBName = siteB.site_name?.toLowerCase()
+      console.log(siteA)
+      const siteALastUpdatedDate = siteA.section_last_updated
+      const siteBLastUpdatedDate = siteB.section_last_updated
 
-      if (siteAName < siteBName) {
+      if (siteALastUpdatedDate > siteBLastUpdatedDate || !siteALastUpdatedDate) {
         return -1
       }
-      if (siteAName < siteBName) {
+      if (siteALastUpdatedDate < siteBLastUpdatedDate) {
         return 1
       }
       return 0
@@ -53,9 +54,11 @@ function Sites() {
         <LinkCard key={id} to={`/sites/${id}/overview`}>
           <ItemTitle>{site_name}</ItemTitle>
           <ItemSubTitle>{landscape_name}</ItemSubTitle>
-          <p>
-            {language.pages.sites.lastUpdated}: {anySectionLastEditedString}
-          </p>
+          {section_last_updated ? (
+            <p>
+              {language.pages.sites.lastUpdated}: {anySectionLastEditedString}
+            </p>
+          ) : null}
         </LinkCard>
       )
     })


### PR DESCRIPTION
- If site has no last_updated_date from server, dont show in UI
- Sort sites by last updated date. New sites with no date show at top, then most recently updated




Decision context:
The api sends null for last updated date when a user newly created a site.  Ideally the BE deals with this brand new site initial date, but an exception was made here. 

The front end has no way of sending the api the right last updated date upon creating a new site, and we are running out of BE dev time, so I opted to just not show the last updated date if none of the questions have been answered (what informs the last updated date in the BE I believe).
<img width="903" alt="Screen Shot 2022-07-27 at 10 55 04 AM" src="https://user-images.githubusercontent.com/1740152/181305326-574bd276-b61b-4368-bcc2-506035f46b82.png">

