### PR TITLE
Feature/206 manage org users part 1

### DIFF
--- a/mrtt-ui/src/App.js
+++ b/mrtt-ui/src/App.js
@@ -23,6 +23,7 @@ import SiteQuestionsOverview from './views/SiteQuestionsOverview/SiteQuestionsOv
 import Sites from './views/Sites'
 import themeMui from './styles/themeMui'
 import CostsForm from './components/CostsForm'
+import ManageOrganizationUsers from './views/ManageOrganizationUsers'
 
 function App() {
   return (
@@ -43,6 +44,10 @@ function App() {
               <Route
                 path='/organizations/:organizationId/edit'
                 element={<OrganizationForm isNewOrganization={false} />}
+              />
+              <Route
+                path='/organizations/:organizationId/users'
+                element={<ManageOrganizationUsers />}
               />
               <Route
                 path='/organizations/new'

--- a/mrtt-ui/src/components/CausesOfDeclineForm.js
+++ b/mrtt-ui/src/components/CausesOfDeclineForm.js
@@ -9,7 +9,6 @@ import {
   TextField,
   Typography
 } from '@mui/material'
-import { FormPageHeader, SectionFormSubtitle, StickyFormLabel } from '../styles/forms'
 import { toast } from 'react-toastify'
 import { useForm, useFieldArray, Controller } from 'react-hook-form'
 import { useParams } from 'react-router-dom'
@@ -18,11 +17,18 @@ import { yupResolver } from '@hookform/resolvers/yup'
 import * as yup from 'yup'
 import axios from 'axios'
 
+import {
+  Form,
+  FormPageHeader,
+  FormQuestionDiv,
+  NestedLabel1,
+  NestedLabel2,
+  StickyFormLabel
+} from '../styles/forms'
 import { causesOfDecline } from '../data/questions'
 import { causesOfDeclineOptions } from '../data/causesOfDeclineOptions'
 import { ContentWrapper } from '../styles/containers'
-import { ErrorText } from '../styles/typography'
-import { Form, FormQuestionDiv, SectionFormTitle, SubTitle, SubTitle2 } from '../styles/forms'
+import { ErrorText, PageSubtitle, PageTitle } from '../styles/typography'
 import { mapDataForApi } from '../library/mapDataForApi'
 import { questionMapping } from '../data/questionMapping'
 import language from '../language'
@@ -268,10 +274,8 @@ function CausesOfDeclineForm() {
   ) : (
     <ContentWrapper>
       <FormPageHeader>
-        <SectionFormTitle>
-          {language.pages.siteQuestionsOverview.formName.causesOfDecline}
-        </SectionFormTitle>
-        <SectionFormSubtitle>{site_name}</SectionFormSubtitle>
+        <PageTitle>{language.pages.siteQuestionsOverview.formName.causesOfDecline}</PageTitle>
+        <PageSubtitle>{site_name}</PageSubtitle>
       </FormPageHeader>
       <QuestionNav
         isSaving={isSubmitting}
@@ -304,7 +308,7 @@ function CausesOfDeclineForm() {
             {causesOfDeclineOptions.map((mainCause, mainCauseIndex) => {
               return (
                 <Box key={mainCauseIndex} sx={{ marginTop: '0.75em', marginBottom: '1.5em' }}>
-                  <SubTitle variant='subtitle1'>{mainCause.label}</SubTitle>
+                  <NestedLabel1>{mainCause.label}</NestedLabel1>
                   {typeof mainCause.children[0] === 'string'
                     ? mainCause.children.map((childOption, childIndex) => (
                         <Box key={childIndex}>
@@ -332,7 +336,7 @@ function CausesOfDeclineForm() {
                           key={subCauseIndex}
                           variant='subtitle2'
                           sx={{ marginLeft: '1em', marginTop: '0.75em' }}>
-                          <SubTitle2 variant='subtitle2'>{subCause.secondaryLabel}</SubTitle2>
+                          <NestedLabel2>{subCause.secondaryLabel}</NestedLabel2>
                           {subCause.secondaryChildren.map(
                             (secondaryChildOption, secondaryChildIndex) => {
                               return (
@@ -372,9 +376,7 @@ function CausesOfDeclineForm() {
             <StickyFormLabel>{causesOfDecline.levelsOfDegredation.question}</StickyFormLabel>
             {causesOfDeclineFields.map((mainCause, mainCauseIndex) => (
               <Box key={mainCauseIndex}>
-                <SubTitle sx={{ marginBottom: '0.5em', marginTop: '1em' }}>
-                  {mainCause.mainCauseLabel}
-                </SubTitle>
+                <NestedLabel1>{mainCause.mainCauseLabel}</NestedLabel1>
                 {mainCause.mainCauseAnswers?.map((answer, answerIndex) => {
                   return (
                     <Box key={answerIndex}>
@@ -413,9 +415,7 @@ function CausesOfDeclineForm() {
                 {mainCause.subCauses?.map((subCause, subCauseIndex) => {
                   return (
                     <Box key={subCauseIndex}>
-                      <SubTitle2 sx={{ marginLeft: '0.75em' }} variant='subtitle2'>
-                        {subCause.subCauseLabel}
-                      </SubTitle2>
+                      <NestedLabel2>{subCause.subCauseLabel}</NestedLabel2>
                       {subCause.subCauseAnswers?.map((subCauseAnswer, subCauseAnswerIndex) => {
                         return (
                           <Box key={subCauseAnswerIndex}>

--- a/mrtt-ui/src/components/CostsForm.js
+++ b/mrtt-ui/src/components/CostsForm.js
@@ -7,14 +7,7 @@ import { toast } from 'react-toastify'
 import { Controller, useForm } from 'react-hook-form'
 import { MenuItem, TextField } from '@mui/material'
 
-import {
-  Form,
-  FormPageHeader,
-  FormQuestionDiv,
-  SectionFormSubtitle,
-  SectionFormTitle,
-  StickyFormLabel
-} from '../styles/forms'
+import { Form, FormPageHeader, FormQuestionDiv, StickyFormLabel } from '../styles/forms'
 import QuestionNav from './QuestionNav'
 import useSiteInfo from '../library/useSiteInfo'
 import language from '../language'
@@ -22,7 +15,7 @@ import { ContentWrapper } from '../styles/containers'
 import { costs as questions } from '../data/questions'
 import CheckboxGroupWithLabelAndController from './CheckboxGroupWithLabelAndController'
 import { multiselectWithOtherValidationNoMinimum } from '../validation/multiSelectWithOther'
-import { ErrorText } from '../styles/typography'
+import { ErrorText, PageSubtitle, PageTitle } from '../styles/typography'
 import { mapDataForApi } from '../library/mapDataForApi'
 import { questionMapping } from '../data/questionMapping'
 import LoadingIndicator from './LoadingIndicator'
@@ -85,8 +78,8 @@ const CostsForm = () => {
   ) : (
     <ContentWrapper>
       <FormPageHeader>
-        <SectionFormTitle>{language.pages.siteQuestionsOverview.formName.costs}</SectionFormTitle>
-        <SectionFormSubtitle>{site_name}</SectionFormSubtitle>
+        <PageTitle>{language.pages.siteQuestionsOverview.formName.costs}</PageTitle>
+        <PageSubtitle>{site_name}</PageSubtitle>
       </FormPageHeader>
       <QuestionNav
         isSaving={isSubmitting}

--- a/mrtt-ui/src/components/PreRestorationAssessmentForm.js
+++ b/mrtt-ui/src/components/PreRestorationAssessmentForm.js
@@ -23,13 +23,11 @@ import {
   FormPageHeader,
   FormQuestionDiv,
   StickyFormLabel,
-  SectionFormSubtitle,
-  SectionFormTitle,
   SelectedInputSection,
   TabularLabel
 } from '../styles/forms'
 import { ContentWrapper } from '../styles/containers'
-import { ErrorText } from '../styles/typography'
+import { ErrorText, PageSubtitle, PageTitle } from '../styles/typography'
 import { findDataItem } from '../library/findDataItem'
 import { mangroveSpeciesPerCountryList } from '../data/mangroveSpeciesPerCountry'
 import { mapDataForApi } from '../library/mapDataForApi'
@@ -272,10 +270,10 @@ function PreRestorationAssessmentForm() {
   ) : (
     <ContentWrapper>
       <FormPageHeader>
-        <SectionFormTitle>
+        <PageTitle>
           {language.pages.siteQuestionsOverview.formName.preRestorationAssessment}
-        </SectionFormTitle>
-        <SectionFormSubtitle>{site_name}</SectionFormSubtitle>
+        </PageTitle>
+        <PageSubtitle>{site_name}</PageSubtitle>
       </FormPageHeader>
       <QuestionNav
         isSaving={isSubmitting}

--- a/mrtt-ui/src/components/ProjectDetailsForm.js
+++ b/mrtt-ui/src/components/ProjectDetailsForm.js
@@ -12,15 +12,8 @@ import turfConvex from '@turf/convex'
 import turfBbox from '@turf/bbox'
 import turfBboxPolygon from '@turf/bbox-polygon'
 
-import { ErrorText } from '../styles/typography'
-import {
-  StickyFormLabel,
-  FormPageHeader,
-  FormQuestionDiv,
-  SectionFormTitle,
-  Form,
-  SectionFormSubtitle
-} from '../styles/forms'
+import { ErrorText, PageSubtitle, PageTitle } from '../styles/typography'
+import { StickyFormLabel, FormPageHeader, FormQuestionDiv, Form } from '../styles/forms'
 import { mapDataForApi } from '../library/mapDataForApi'
 import { projectDetails as questions } from '../data/questions'
 import { questionMapping } from '../data/questionMapping'
@@ -165,10 +158,8 @@ function ProjectDetailsForm() {
   ) : (
     <ContentWrapper>
       <FormPageHeader>
-        <SectionFormTitle>
-          {language.pages.siteQuestionsOverview.formName.siteDetails}
-        </SectionFormTitle>
-        <SectionFormSubtitle>{site_name}</SectionFormSubtitle>
+        <PageTitle>{language.pages.siteQuestionsOverview.formName.siteDetails}</PageTitle>
+        <PageSubtitle>{site_name}</PageSubtitle>
       </FormPageHeader>
       <QuestionNav
         isSaving={isSubmitting}

--- a/mrtt-ui/src/components/RestorationAimsForm/RestorationAimsForm.js
+++ b/mrtt-ui/src/components/RestorationAimsForm/RestorationAimsForm.js
@@ -9,15 +9,9 @@ import {
   multiselectWithOtherValidation,
   multiselectWithOtherValidationNoMinimum
 } from '../../validation/multiSelectWithOther'
-import {
-  Form,
-  FormPageHeader,
-  FormQuestionDiv,
-  SectionFormSubtitle,
-  SectionFormTitle
-} from '../../styles/forms'
+import { Form, FormPageHeader, FormQuestionDiv } from '../../styles/forms'
 import { ContentWrapper } from '../../styles/containers'
-import { ErrorText } from '../../styles/typography'
+import { ErrorText, PageSubtitle, PageTitle } from '../../styles/typography'
 import { mapDataForApi } from '../../library/mapDataForApi'
 import { questionMapping } from '../../data/questionMapping'
 import { restorationAims as questions } from '../../data/questions'
@@ -92,10 +86,8 @@ const RestorationAimsForm = () => {
   ) : (
     <ContentWrapper>
       <FormPageHeader>
-        <SectionFormTitle>
-          {language.pages.siteQuestionsOverview.formName.restorationAims}
-        </SectionFormTitle>
-        <SectionFormSubtitle>{site_name}</SectionFormSubtitle>
+        <PageTitle>{language.pages.siteQuestionsOverview.formName.restorationAims}</PageTitle>
+        <PageSubtitle>{site_name}</PageSubtitle>
       </FormPageHeader>
       <QuestionNav
         isSaving={isSubmitting}

--- a/mrtt-ui/src/components/SiteBackgroundForm.js
+++ b/mrtt-ui/src/components/SiteBackgroundForm.js
@@ -7,16 +7,9 @@ import { yupResolver } from '@hookform/resolvers/yup'
 import * as yup from 'yup'
 import axios from 'axios'
 
-import {
-  Form,
-  FormPageHeader,
-  FormQuestionDiv,
-  SectionFormSubtitle,
-  SectionFormTitle,
-  StickyFormLabel
-} from '../styles/forms'
+import { Form, FormPageHeader, FormQuestionDiv, StickyFormLabel } from '../styles/forms'
 import { ContentWrapper } from '../styles/containers'
-import { ErrorText } from '../styles/typography'
+import { ErrorText, PageSubtitle, PageTitle } from '../styles/typography'
 import { mapDataForApi } from '../library/mapDataForApi'
 import { multiselectWithOtherValidation } from '../validation/multiSelectWithOther'
 import { questionMapping } from '../data/questionMapping'
@@ -140,10 +133,8 @@ const SiteBackgroundForm = () => {
   ) : (
     <ContentWrapper>
       <FormPageHeader>
-        <SectionFormTitle>
-          {language.pages.siteQuestionsOverview.formName.siteBackground}
-        </SectionFormTitle>
-        <SectionFormSubtitle>{site_name}</SectionFormSubtitle>
+        <PageTitle>{language.pages.siteQuestionsOverview.formName.siteBackground}</PageTitle>
+        <PageSubtitle>{site_name}</PageSubtitle>
       </FormPageHeader>
       <QuestionNav
         isSaving={isSubmitting}

--- a/mrtt-ui/src/components/SiteInterventions.js
+++ b/mrtt-ui/src/components/SiteInterventions.js
@@ -21,16 +21,9 @@ import { yupResolver } from '@hookform/resolvers/yup'
 import * as yup from 'yup'
 import axios from 'axios'
 
-import {
-  Form,
-  FormPageHeader,
-  FormQuestionDiv,
-  SectionFormSubtitle,
-  SectionFormTitle,
-  StickyFormLabel
-} from '../styles/forms'
+import { Form, FormPageHeader, FormQuestionDiv, StickyFormLabel } from '../styles/forms'
 import { ContentWrapper } from '../styles/containers'
-import { ErrorText } from '../styles/typography'
+import { ErrorText, PageSubtitle, PageTitle } from '../styles/typography'
 import { findDataItem } from '../library/findDataItem'
 import { mapDataForApi } from '../library/mapDataForApi'
 import { multiselectWithOtherValidationNoMinimum } from '../validation/multiSelectWithOther'
@@ -262,10 +255,8 @@ function SiteInterventionsForm() {
   ) : (
     <ContentWrapper>
       <FormPageHeader>
-        <SectionFormTitle>
-          {language.pages.siteQuestionsOverview.formName.siteInterventions}
-        </SectionFormTitle>
-        <SectionFormSubtitle>{site_name}</SectionFormSubtitle>
+        <PageTitle>{language.pages.siteQuestionsOverview.formName.siteInterventions}</PageTitle>
+        <PageSubtitle>{site_name}</PageSubtitle>
       </FormPageHeader>
       <QuestionNav
         isSaving={isSubmitting}

--- a/mrtt-ui/src/language.js
+++ b/mrtt-ui/src/language.js
@@ -89,6 +89,11 @@ const pages = {
       landscapeRequired: 'Please select a landscape'
     }
   },
+  manageOrganizationUsers: {
+    title: 'Users',
+    newUser: 'New User',
+    usersTable: { name: 'Name', admin: 'Admin', user: 'User', remove: 'Remove from Organization' }
+  },
   siteQuestionsOverview: {
     settings: 'Settings',
 

--- a/mrtt-ui/src/styles/forms.js
+++ b/mrtt-ui/src/styles/forms.js
@@ -11,15 +11,6 @@ export const MainFormDiv = styled('div')`
   flex-direction: column;
 `
 
-export const SectionFormTitle = styled('h1')`
-  font-weight: 400;
-  margin-bottom: 0;
-`
-
-export const SectionFormSubtitle = styled('h2')`
-  font-weight: 200;
-  margin-bottom: 0;
-`
 export const FormQuestionDiv = styled('div')`
   padding: ${themeMui.spacing(3)};
   display: flex;
@@ -55,11 +46,11 @@ export const RequiredIndicator = styled('span')`
   color: ${theme.form.requiredIndicatorColor};
   padding: 0 ${themeMui.spacing(1)};
 `
-export const SubTitle = styled('label')`
+export const NestedLabel1 = styled('label')`
   text-transform: uppercase;
   font-weight: 700;
 `
-export const SubTitle2 = styled('label')`
+export const NestedLabel2 = styled('label')`
   margin-top: 0.75em;
   text-transform: uppercase;
 `

--- a/mrtt-ui/src/styles/table.js
+++ b/mrtt-ui/src/styles/table.js
@@ -17,3 +17,11 @@ export const TableAlertnatingRows = styled('table')(({ theme: themeMui }) => ({
     padding: themeMui.spacing(1)
   }
 }))
+
+export const TdCenter = styled('td')`
+  text-align: center;
+`
+
+export const ThCenter = styled('th')`
+  text-align: center;
+`

--- a/mrtt-ui/src/styles/typography.js
+++ b/mrtt-ui/src/styles/typography.js
@@ -49,6 +49,12 @@ export const PageTitle = styled('h1')`
   text-transform: uppercase;
   letter-spacing: 2px;
 `
+
+export const PageSubtitle = styled('h2')`
+  font-weight: 200;
+  margin-bottom: 0;
+`
+
 export const ItemSubTitle = styled('p')`
   color: ${theme.color.slub};
   text-transform: uppercase;

--- a/mrtt-ui/src/views/Auth/LoginForm.js
+++ b/mrtt-ui/src/views/Auth/LoginForm.js
@@ -8,8 +8,8 @@ import axios from 'axios'
 
 import { ButtonCancel, ButtonSubmit } from '../../styles/buttons'
 import { ButtonContainer, PagePadding, RowFlexEnd } from '../../styles/containers'
-import { ErrorText } from '../../styles/typography'
-import { Form, MainFormDiv, SectionFormTitle } from '../../styles/forms'
+import { ErrorText, PageTitle } from '../../styles/typography'
+import { Form, MainFormDiv } from '../../styles/forms'
 import { FormLabel, TextField } from '@mui/material'
 import Button from '@mui/material/Button'
 import language from '../../language'
@@ -81,7 +81,7 @@ const LoginForm = () => {
   const form = (
     <MainFormDiv>
       <PagePadding>
-        <SectionFormTitle>Login</SectionFormTitle>
+        <PageTitle>Login</PageTitle>
         <Form onSubmit={validateInputs(handleSubmit)}>
           <FormLabel htmlFor='email'>Email* </FormLabel>
           <Controller

--- a/mrtt-ui/src/views/Auth/SignupForm.js
+++ b/mrtt-ui/src/views/Auth/SignupForm.js
@@ -8,8 +8,8 @@ import axios from 'axios'
 
 import { ButtonCancel, ButtonSubmit } from '../../styles/buttons'
 import { ButtonContainer, PagePadding, RowFlexEnd } from '../../styles/containers'
-import { ErrorText } from '../../styles/typography'
-import { Form, MainFormDiv, SectionFormTitle } from '../../styles/forms'
+import { ErrorText, PageTitle } from '../../styles/typography'
+import { Form, MainFormDiv } from '../../styles/forms'
 import { FormLabel, TextField } from '@mui/material'
 import language from '../../language'
 import LoadingIndicator from '../../components/LoadingIndicator'
@@ -67,7 +67,7 @@ const SignupForm = () => {
   const form = (
     <MainFormDiv>
       <PagePadding>
-        <SectionFormTitle>Sign-up</SectionFormTitle>
+        <PageTitle>Sign-up</PageTitle>
         <Form onSubmit={validateInputs(handleSubmit)}>
           <FormLabel htmlFor='name'>Name </FormLabel>
           <Controller

--- a/mrtt-ui/src/views/ManageOrganizationUsers.js
+++ b/mrtt-ui/src/views/ManageOrganizationUsers.js
@@ -1,0 +1,90 @@
+import { GroupRemove } from '@mui/icons-material'
+import { useParams } from 'react-router-dom'
+import axios from 'axios'
+import React, { useEffect, useState } from 'react'
+
+import { ButtonPrimary, ButtonSecondary } from '../styles/buttons'
+import { ContentWrapper, TitleAndActionContainer } from '../styles/containers'
+import { PageSubtitle, PageTitle } from '../styles/typography'
+import { TableAlertnatingRows, TdCenter, ThCenter } from '../styles/table'
+import language from '../language'
+import USER_ROLES from '../constants/userRoles'
+
+const pageLanguage = language.pages.manageOrganizationUsers
+
+const ManageOrganizationUsers = () => {
+  const [organizationName, setOrganizationName] = useState()
+  const [organizationUsers, setOrganizationUsers] = useState([])
+  const { organizationId } = useParams()
+  const organizationUrl = `${process.env.REACT_APP_API_URL}/organizations/${organizationId}`
+  const organizationUsersUrl = `${organizationUrl}/users`
+
+  useEffect(
+    function loadApiData() {
+      Promise.all([axios.get(organizationUrl), axios.get(organizationUsersUrl)]).then(
+        ([
+          {
+            data: { organization_name }
+          },
+          { data: organizationUsers }
+        ]) => {
+          setOrganizationName(organization_name)
+          setOrganizationUsers(organizationUsers)
+        }
+      )
+    },
+    [organizationUrl, organizationUsersUrl]
+  )
+  return (
+    <>
+      <ContentWrapper>
+        <TitleAndActionContainer>
+          <PageTitle>{pageLanguage.title} (Work in Progress!)</PageTitle>
+          <ButtonPrimary>{pageLanguage.newUser}</ButtonPrimary>
+        </TitleAndActionContainer>
+
+        <PageSubtitle>{organizationName}</PageSubtitle>
+        <TableAlertnatingRows>
+          <tbody>
+            <tr>
+              <th>{pageLanguage.usersTable.name}</th>
+              <ThCenter>{pageLanguage.usersTable.admin}</ThCenter>
+              <ThCenter>{pageLanguage.usersTable.user}</ThCenter>
+              <ThCenter>{pageLanguage.usersTable.remove}</ThCenter>
+            </tr>
+            {organizationUsers.map(({ id, name, role }) => (
+              <tr key={id}>
+                <td>{name}</td>
+                <TdCenter>
+                  <input
+                    type='radio'
+                    id={`${id}-${name}-role-admin`}
+                    name={`${id}-${name}-role`}
+                    value={USER_ROLES.orgAdmin}
+                    checked={role === USER_ROLES.orgAdmin}
+                  />
+                </TdCenter>
+                <TdCenter>
+                  <input
+                    type='radio'
+                    id={`${id}-${name}-role-user`}
+                    name={`${id}-${name}-role`}
+                    value={USER_ROLES.orgUser}
+                    checked={role === USER_ROLES.orgUser}
+                  />
+                </TdCenter>
+                <TdCenter>
+                  <ButtonSecondary>
+                    <GroupRemove />
+                  </ButtonSecondary>
+                </TdCenter>
+              </tr>
+            ))}
+          </tbody>
+        </TableAlertnatingRows>
+      </ContentWrapper>
+    </>
+  )
+}
+
+export default ManageOrganizationUsers

--- a/mrtt-ui/src/views/Organizations.js
+++ b/mrtt-ui/src/views/Organizations.js
@@ -38,14 +38,14 @@ function Organizations() {
 
   const yourOrganizationsList = (
     <UlUndecorated>
-      {yourOrganizations.map(({ id, organization_name, role }) => {
+      {yourOrganizations.map(({ id: organizationId, organization_name, role }) => {
         const canManageUsers = role === USER_ROLES.orgAdmin
         return (
-          <Card as='li' key={id}>
+          <Card as='li' key={organizationId}>
             <RowSpaceBetween>
               {organization_name}
               {canManageUsers ? (
-                <LinkLooksLikeButtonSecondary to='#'>
+                <LinkLooksLikeButtonSecondary to={`/organizations/${organizationId}/users`}>
                   {language.pages.organizations.manageUsers}
                 </LinkLooksLikeButtonSecondary>
               ) : null}


### PR DESCRIPTION
# Description

basic layout and basic reading from api for manage org users page
merged some subtitle and title components together for reuse (why the diff is a bit large for whats actually being built)


## Type of change

new feature
refactor

# Instructions

- login as user2
- navigate to organizations
- click 'manage users' for one of the orgs
- notice two users. their role should match the text in parenthesis in their name
- note none of the buttons work. Radios are read only for now. This feature is wip. 

# How Has This Been Tested?

manual


