### PR TITLE
7.5a + some tabular styling updates

### DIFF
--- a/mrtt-ui/src/components/Costs/CostsForm.js
+++ b/mrtt-ui/src/components/Costs/CostsForm.js
@@ -329,16 +329,18 @@ const CostsForm = () => {
             </FormQuestionDiv>
           </div>
         ) : null}
-        <FormQuestionDiv>
-          <CheckboxGroupWithLabelAndController
-            fieldName='nonmonetisedContributions'
-            reactHookFormInstance={reactHookFormInstance}
-            options={questions.nonmonetisedContributions.options}
-            question={questions.nonmonetisedContributions.question}
-            shouldAddOtherOptionWithClarification={true}
-          />
-          <ErrorText>{errors.nonmonetisedContributions?.selectedValues?.message}</ErrorText>
-        </FormQuestionDiv>
+        {supportForActivitiesWatcher?.selectedValues?.includes('Voluntary/Non-monetary') ? (
+          <FormQuestionDiv>
+            <CheckboxGroupWithLabelAndController
+              fieldName='nonmonetisedContributions'
+              reactHookFormInstance={reactHookFormInstance}
+              options={questions.nonmonetisedContributions.options}
+              question={questions.nonmonetisedContributions.question}
+              shouldAddOtherOptionWithClarification={true}
+            />
+            <ErrorText>{errors.nonmonetisedContributions?.selectedValues?.message}</ErrorText>
+          </FormQuestionDiv>
+        ) : null}
       </Form>
     </ContentWrapper>
   )

--- a/mrtt-ui/src/components/Costs/CostsForm.js
+++ b/mrtt-ui/src/components/Costs/CostsForm.js
@@ -70,7 +70,7 @@ const CostsForm = () => {
       )
       .default([]),
     costOfProjectActivities: yup.object().shape({
-      cost: yup.number().typeError('Please add a number'),
+      cost: yup.mixed(),
       currency: yup.string()
     }),
     nonmonetisedContributions: multiselectWithOtherValidationNoMinimum

--- a/mrtt-ui/src/components/Costs/CostsForm.js
+++ b/mrtt-ui/src/components/Costs/CostsForm.js
@@ -38,6 +38,12 @@ const getEndDate = (registrationAnswersFromServer) =>
 const getBreakdownOfCost = (registrationAnswersFromServer) =>
   findDataItem(registrationAnswersFromServer, '7.5') ?? []
 
+const getBiophysicalInterventions = (registrationAnswersFromServer) =>
+  findDataItem(registrationAnswersFromServer, '6.2a') ?? []
+
+const getOtherActivitiesImplemented = (registrationAnswersFromServer) =>
+  findDataItem(registrationAnswersFromServer, '6.4') ?? []
+
 const CostsForm = () => {
   const { site_name } = useSiteInfo()
   const validationSchema = yup.object({
@@ -113,6 +119,8 @@ const CostsForm = () => {
   const supportForActivitiesWatcher = watchForm('supportForActivities')
   const [showAddTabularInputRow, setShowAddTabularInputRow] = useState(false)
   const [hasEndDate, setHasEndDate] = useState(false)
+  // eslint-disable-next-line no-unused-vars
+  const [interventions, setInterventions] = useState([])
 
   const loadServerData = useCallback(
     (serverResponse) => {
@@ -133,6 +141,33 @@ const CostsForm = () => {
       if (breakdownOfCostInitialVal.length === 0) {
         breakdownOfCostReplace(defaultProjectActivities)
       }
+
+      const biophysicalInterventionsInitialVal = getBiophysicalInterventions(serverResponse)
+      const otherActivitiesImplementedInitialVal = getOtherActivitiesImplemented(serverResponse)
+
+      let interventionTypes = []
+      let otherInterventionActivities = []
+      let combinedInterventions = []
+
+      if (biophysicalInterventionsInitialVal.length) {
+        interventionTypes = biophysicalInterventionsInitialVal.map((item) => item.interventionType)
+      }
+
+      if (otherActivitiesImplementedInitialVal.selectedValues.length) {
+        otherInterventionActivities = otherActivitiesImplementedInitialVal.selectedValues
+      }
+      if (
+        otherActivitiesImplementedInitialVal.isOtherChecked === true &&
+        otherActivitiesImplementedInitialVal.otherValue.length
+      ) {
+        otherInterventionActivities.push(otherActivitiesImplementedInitialVal.otherValue)
+      }
+      combinedInterventions = interventionTypes.concat(otherInterventionActivities)
+
+      const filteredCombinedInterventions = combinedInterventions.filter((item) => item !== 'None')
+
+      console.log(filteredCombinedInterventions)
+      setInterventions(filteredCombinedInterventions)
     },
     [breakdownOfCostReplace]
   )
@@ -326,6 +361,9 @@ const CostsForm = () => {
                       updateItem={updateBreakdownOfCostItem}></BreakdownOfCostRow>
                   ))
                 : null}
+            </FormQuestionDiv>
+            <FormQuestionDiv>
+              <StickyFormLabel>{questions.percentageSplitOfActivities.question}</StickyFormLabel>
             </FormQuestionDiv>
           </div>
         ) : null}

--- a/mrtt-ui/src/components/Costs/PercentageSplitOfActivitiesRow.js
+++ b/mrtt-ui/src/components/Costs/PercentageSplitOfActivitiesRow.js
@@ -1,0 +1,48 @@
+import { useState, useEffect } from 'react'
+import PropTypes from 'prop-types'
+import { Box, TextField } from '@mui/material'
+
+import { TabularLabel, VerticalTabularBox, VerticalTabularInputSection } from '../../styles/forms'
+
+const PercentageSplitOfActivitiesRow = ({ label, percentage, index, updateItem }) => {
+  const [initialPercentage, setInitialPercentage] = useState('')
+  const [currentPercentage, setCurrentPercentage] = useState('')
+
+  const handleUpdate = () => {
+    if (currentPercentage !== initialPercentage) {
+      updateItem(index, currentPercentage)
+    }
+  }
+
+  const _setFormValues = useEffect(() => {
+    if (percentage) {
+      setCurrentPercentage(percentage)
+      setInitialPercentage(percentage)
+    }
+  }, [percentage])
+
+  return (
+    <VerticalTabularInputSection>
+      <VerticalTabularBox>
+        <TabularLabel>{label}</TabularLabel>
+        <Box>
+          <TextField
+            sx={{ marginTop: '1em', width: '8em' }}
+            value={currentPercentage}
+            label='percentage'
+            onBlur={handleUpdate}
+            onChange={(e) => setCurrentPercentage(e.target.value)}></TextField>
+        </Box>
+      </VerticalTabularBox>
+    </VerticalTabularInputSection>
+  )
+}
+
+PercentageSplitOfActivitiesRow.propTypes = {
+  label: PropTypes.string.isRequired,
+  percentage: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  updateItem: PropTypes.func.isRequired,
+  index: PropTypes.number.isRequired
+}
+
+export default PercentageSplitOfActivitiesRow

--- a/mrtt-ui/src/components/PreRestorationAssessment/PhysicalMeasurementRow.js
+++ b/mrtt-ui/src/components/PreRestorationAssessment/PhysicalMeasurementRow.js
@@ -1,9 +1,15 @@
 import { useState, useEffect } from 'react'
+// import { TextField } from '@mui/material'
 import PropTypes from 'prop-types'
-import { TextField } from '@mui/material'
 import { Delete } from '@mui/icons-material'
 
-import { VerticalTabularBox, TabularInputSection, TabularLabel } from '../../styles/forms'
+import {
+  LeftColumnDiv,
+  RowTextField,
+  TabularLabel,
+  VerticalTabularBox,
+  VerticalTabularInputSection
+} from '../../styles/forms'
 
 const PhysicalMeasurementRow = ({ label, value, unit, index, deleteItem, updateItem }) => {
   const [initialValue, setInitialValue] = useState('')
@@ -32,30 +38,33 @@ const PhysicalMeasurementRow = ({ label, value, unit, index, deleteItem, updateI
   }, [value, unit])
 
   return (
-    <TabularInputSection>
-      <TabularLabel>{label}</TabularLabel>
+    <VerticalTabularInputSection>
       <VerticalTabularBox>
-        <TextField
-          value={currentValue}
-          label='value'
-          onBlur={handleUpdate}
-          onChange={(e) => setCurrentValue(e.target.value)}></TextField>
-        <TextField
-          sx={{ width: '8em', marginLeft: '0.5em' }}
-          value={currentUnit}
-          label='unit'
-          onBlur={handleUpdate}
-          onChange={(e) => setCurrentUnit(e.target.value)}></TextField>
-        <Delete onClick={handleDelete} sx={{ marginLeft: '0.5em' }}></Delete>
+        <LeftColumnDiv>
+          <TabularLabel>{label}</TabularLabel>
+          <Delete onClick={handleDelete}></Delete>
+        </LeftColumnDiv>
+        <VerticalTabularBox>
+          <RowTextField
+            value={currentValue}
+            label='value'
+            onBlur={handleUpdate}
+            onChange={(e) => setCurrentValue(e.target.value)}></RowTextField>
+          <RowTextField
+            value={currentUnit}
+            label='unit'
+            onBlur={handleUpdate}
+            onChange={(e) => setCurrentUnit(e.target.value)}></RowTextField>
+        </VerticalTabularBox>
       </VerticalTabularBox>
-    </TabularInputSection>
+    </VerticalTabularInputSection>
   )
 }
 
 PhysicalMeasurementRow.propTypes = {
   label: PropTypes.string.isRequired,
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  unit: PropTypes.string.isRequired,
+  unit: PropTypes.string,
   deleteItem: PropTypes.func.isRequired,
   updateItem: PropTypes.func.isRequired,
   index: PropTypes.number.isRequired

--- a/mrtt-ui/src/components/SiteInterventions/MangroveAssociatedSpeciesRow.js
+++ b/mrtt-ui/src/components/SiteInterventions/MangroveAssociatedSpeciesRow.js
@@ -1,10 +1,15 @@
 import { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
-import { Box, MenuItem, TextField } from '@mui/material'
+import { MenuItem } from '@mui/material'
 import { Delete } from '@mui/icons-material'
-import { styled } from '@mui/material/styles'
 
-import { TabularInputSection, TabularLabel, VerticalTabularBox } from '../../styles/forms'
+import {
+  LeftColumnDiv,
+  RowTextField,
+  TabularInputSection,
+  TabularLabel,
+  VerticalTabularBox
+} from '../../styles/forms'
 import { purposeOptions, sourceOptions } from '../../data/siteInterventionOptions'
 
 const MangroveAssociatedSpeciesRow = ({
@@ -120,11 +125,3 @@ MangroveAssociatedSpeciesRow.propTypes = {
 }
 
 export default MangroveAssociatedSpeciesRow
-
-const RowTextField = styled(TextField)`
-  margin-top: 1em;
-`
-
-const LeftColumnDiv = styled(Box)`
-  display: flex;
-`

--- a/mrtt-ui/src/styles/forms.js
+++ b/mrtt-ui/src/styles/forms.js
@@ -1,4 +1,4 @@
-import { FormLabel } from '@mui/material'
+import { Box, FormLabel, TextField } from '@mui/material'
 import { styled } from '@mui/material/styles'
 import themeMui from './themeMui'
 import theme from '../styles/theme'
@@ -101,12 +101,22 @@ export const VerticalTabularBox = styled('div')`
   display: flex;
   flex-direction: column;
   cursor: pointer;
+  margin-top: '1em';
 `
 
 export const VerticalTabularInputSection = styled('div')`
   display: flex;
   flex-direction: row;
   align-items: flex-start;
-  margin-top: 1em;
+  margin-top: 2em;
   justify-content: space-between;
+`
+export const RowTextField = styled(TextField)`
+  margin-bottom: 1em;
+  max-width: 12em;
+`
+
+export const LeftColumnDiv = styled(Box)`
+  display: flex;
+  margin-bottom: 1em;
 `


### PR DESCRIPTION
- functionality for 7.5a
- added some style adjustments for tabular row sections, however they are still very inconsistent. I [created a task for this](https://github.com/globalmangrovewatch/gmw-users/issues/239)

to test:
1. create a new site
2. go to section 6
3. select & save items in 6.2 & 6.4 (will be used in 7.5a)
4. go to Costs section
5. Select 'Monetary' in 7.1
6. go to 7.5a
7. add percentages + save & refresh