### PR TITLE
Feat: [199] hook up section privacy input to api, loading indicator, …

### DIFF
--- a/mrtt-ui/src/components/CausesOfDeclineForm.js
+++ b/mrtt-ui/src/components/CausesOfDeclineForm.js
@@ -278,9 +278,9 @@ function CausesOfDeclineForm() {
         <PageSubtitle>{site_name}</PageSubtitle>
       </FormPageHeader>
       <QuestionNav
-        isSaving={isSubmitting}
-        isSaveError={isError}
-        onSave={handleSubmit(onSubmit)}
+        isFormSaving={isSubmitting}
+        isFormSaveError={isError}
+        onFormSave={handleSubmit(onSubmit)}
         currentSection='causes-of-decline'
       />
       <Form>

--- a/mrtt-ui/src/components/Costs/CostsForm.js
+++ b/mrtt-ui/src/components/Costs/CostsForm.js
@@ -270,9 +270,9 @@ const CostsForm = () => {
         <PageSubtitle>{site_name}</PageSubtitle>
       </FormPageHeader>
       <QuestionNav
-        isSaving={isSubmitting}
-        isSaveError={isSubmitError}
-        onSave={validateInputs(handleSubmit)}
+        isFormSaving={isSubmitting}
+        isFormSaveError={isSubmitError}
+        onFormSave={validateInputs(handleSubmit)}
         currentSection='costs'
       />
       <Form>

--- a/mrtt-ui/src/components/PreRestorationAssessment/PreRestorationAssessmentForm.js
+++ b/mrtt-ui/src/components/PreRestorationAssessment/PreRestorationAssessmentForm.js
@@ -280,9 +280,9 @@ function PreRestorationAssessmentForm() {
         <PageSubtitle>{site_name}</PageSubtitle>
       </FormPageHeader>
       <QuestionNav
-        isSaving={isSubmitting}
-        isSaveError={isError}
-        onSave={validateInputs(handleSubmit)}
+        isFormSaving={isSubmitting}
+        isFormSaveError={isError}
+        onFormSave={validateInputs(handleSubmit)}
         currentSection='pre-restoration-assessment'
       />
       <Form>

--- a/mrtt-ui/src/components/ProjectDetailsForm.js
+++ b/mrtt-ui/src/components/ProjectDetailsForm.js
@@ -162,9 +162,9 @@ function ProjectDetailsForm() {
         <PageSubtitle>{site_name}</PageSubtitle>
       </FormPageHeader>
       <QuestionNav
-        isSaving={isSubmitting}
-        isSaveError={isError}
-        onSave={validateInputs(handleSubmit)}
+        isFormSaving={isSubmitting}
+        isFormSaveError={isError}
+        onFormSave={validateInputs(handleSubmit)}
         currentSection='project-details'
       />
       <Form>

--- a/mrtt-ui/src/components/RestorationAimsForm/RestorationAimsForm.js
+++ b/mrtt-ui/src/components/RestorationAimsForm/RestorationAimsForm.js
@@ -90,9 +90,9 @@ const RestorationAimsForm = () => {
         <PageSubtitle>{site_name}</PageSubtitle>
       </FormPageHeader>
       <QuestionNav
-        isSaving={isSubmitting}
-        isSaveError={isSubmitError}
-        onSave={validateInputs(handleSubmit)}
+        isFormSaving={isSubmitting}
+        isFormSaveError={isSubmitError}
+        onFormSave={validateInputs(handleSubmit)}
         currentSection='restoration-aims'
       />
       <Form onSubmit={validateInputs(handleSubmit)}>

--- a/mrtt-ui/src/components/SiteBackgroundForm.js
+++ b/mrtt-ui/src/components/SiteBackgroundForm.js
@@ -137,9 +137,9 @@ const SiteBackgroundForm = () => {
         <PageSubtitle>{site_name}</PageSubtitle>
       </FormPageHeader>
       <QuestionNav
-        isSaving={isSubmitting}
-        isSaveError={isError}
-        onSave={validateInputs(handleSubmit)}
+        isFormSaving={isSubmitting}
+        isFormSaveError={isError}
+        onFormSave={validateInputs(handleSubmit)}
         currentSection='site-background'
       />
       {/* Select Stakeholders */}

--- a/mrtt-ui/src/components/SiteInterventions/SiteInterventions.js
+++ b/mrtt-ui/src/components/SiteInterventions/SiteInterventions.js
@@ -313,9 +313,9 @@ function SiteInterventionsForm() {
         <PageSubtitle>{site_name}</PageSubtitle>
       </FormPageHeader>
       <QuestionNav
-        isSaving={isSubmitting}
-        isSaveError={isSubmitError}
-        onSave={validateInputs(handleSubmit)}
+        isFormSaving={isSubmitting}
+        isFormSaveError={isSubmitError}
+        onFormSave={validateInputs(handleSubmit)}
         currentSection='site-interventions'
       />
       <Form>

--- a/mrtt-ui/src/constants/sectionNames.js
+++ b/mrtt-ui/src/constants/sectionNames.js
@@ -1,3 +1,5 @@
+// API section ids are generated from the order of this array.
+// Please make sure the order matches that.
 const SECTION_NAMES = [
   'project-details',
   'site-background',

--- a/mrtt-ui/src/language.js
+++ b/mrtt-ui/src/language.js
@@ -195,11 +195,14 @@ const header = {
 }
 
 const questionNav = {
-  returnToSite: 'Return to Site Form Overview',
-  previousSection: 'Previous Section',
   nextSection: 'Next Section',
+  previousSection: 'Previous Section',
+  privacySaveError: "Saving this section's privacy failed. Please try again.",
+  privacySavingSuccess: success.getEditThingSuccessMessage("This section's privacy"),
+  privacySelectUndefined: 'Select Privacy',
   private: 'Private',
-  public: 'Public'
+  public: 'Public',
+  returnToSite: 'Return to Site Form Overview'
 }
 
 export default {


### PR DESCRIPTION
# Description

hook up section privacy input (in section navigator bar)

Fixes #199 


# Test Instructions

- log in
- create a new site
- click on site, go to first section
- note the privacy select input in the section nav bar has placeholder text
- change its value 
- refresh section. See that the value persists/is loaded from server (note the placeholder is disabled and unselectable)
- move through other sections doing the same. 

HArd to test error messages without editing code, but this is what it looks like when the api fails to save privacy. 

<img width="754" alt="Screen Shot 2022-08-25 at 5 37 54 PM" src="https://user-images.githubusercontent.com/1740152/186787325-a916c93b-4d2d-4456-9951-a26f8805fd4a.png">


