### PR TITLE
feat: [247] dont show 3.4 nested question for 'unknown' and 'none' op…

### DIFF
--- a/mrtt-ui/src/components/CheckboxGroup/CheckboxGroup.js
+++ b/mrtt-ui/src/components/CheckboxGroup/CheckboxGroup.js
@@ -28,13 +28,14 @@ const CheckboxGroup = forwardRef(
   (
     {
       id,
-      onBlur,
+      onBlur = () => {},
       onChange,
       options,
-      shouldAddOtherOptionWithClarification,
-      value,
-      SelectedMarkup,
-      shouldReturnEvent
+      optionsExcludedFromShowingSelectedMarkup = [],
+      shouldAddOtherOptionWithClarification = false,
+      value = [],
+      SelectedMarkup = undefined,
+      shouldReturnEvent = false
     },
     ref
   ) => {
@@ -97,6 +98,11 @@ const CheckboxGroup = forwardRef(
     const nonOtherCheckboxInputs = options.map((option) => {
       const isChecked = nonOtherSelectedValues.includes(option.value)
       const optionId = makeValidClassName(`${id}-${option.value}`)
+      const isInExcludeFromSelectedMarkupList = optionsExcludedFromShowingSelectedMarkup.includes(
+        option.value
+      )
+      const isSelectedMarkupShowing =
+        isChecked && SelectedMarkup && !isInExcludeFromSelectedMarkupList
 
       return (
         <Stack key={option.value}>
@@ -114,7 +120,7 @@ const CheckboxGroup = forwardRef(
             }
             label={option.label}
           />
-          {isChecked && SelectedMarkup ? (
+          {isSelectedMarkupShowing ? (
             <SelectedMarkup optionId={optionId} optionValue={option.value} />
           ) : null}
         </Stack>
@@ -168,6 +174,7 @@ CheckboxGroup.propTypes = {
       value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
     })
   ).isRequired,
+  optionsExcludedFromShowingSelectedMarkup: PropTypes.arrayOf(PropTypes.string),
   SelectedMarkup: PropTypes.oneOfType([PropTypes.node, PropTypes.any]), // we're doing partial application so this component can supply the selectedMarkup the optionId. Proptype complains about it being a function.
   shouldAddOtherOptionWithClarification: PropTypes.bool,
   shouldReturnEvent: PropTypes.bool,
@@ -176,14 +183,6 @@ CheckboxGroup.propTypes = {
     otherValue: PropTypes.string,
     isOtherChecked: PropTypes.bool
   })
-}
-
-CheckboxGroup.defaultProps = {
-  onBlur: () => {},
-  value: [],
-  SelectedMarkup: undefined,
-  shouldAddOtherOptionWithClarification: false,
-  shouldReturnEvent: false
 }
 
 export default CheckboxGroup

--- a/mrtt-ui/src/components/CheckboxGroup/CheckboxGroup.stories.js
+++ b/mrtt-ui/src/components/CheckboxGroup/CheckboxGroup.stories.js
@@ -50,3 +50,29 @@ export const WithNestedMarkupForSelected = () => (
     SelectedMarkup={() => <>Youve selected ME</>}
   />
 )
+
+export const WithNestedMarkupForSelectedIncludingExceptionsThatWontShowNestedMarkup = () => (
+  <CheckboxGroup
+    options={[
+      { label: 'Show nested when selected 1', value: 'Show nested when selected 1' },
+      { label: 'Show nested when selected 2', value: 'Show nested when selected 2' },
+      { label: 'Dont show nested when selected 1', value: 'Dont show nested when selected 1' },
+      { label: 'Dont show nested when selected 2', value: 'Dont show nested when selected 2' }
+    ]}
+    value={{
+      selectedValues: [
+        'Show nested when selected 1',
+        'Show nested when selected 2',
+        'Dont show nested when selected 1',
+        'Dont show nested when selected 2'
+      ]
+    }}
+    onChange={action('onChange')}
+    id='cuddlyKittens'
+    SelectedMarkup={() => <>Youve selected ME</>}
+    optionsExcludedFromShowingSelectedMarkup={[
+      'Dont show nested when selected 1',
+      'Dont show nested when selected 2'
+    ]}
+  />
+)

--- a/mrtt-ui/src/components/RestorationAimsForm/RestorationAimsCheckboxGroupWithLabel.js
+++ b/mrtt-ui/src/components/RestorationAimsForm/RestorationAimsCheckboxGroupWithLabel.js
@@ -61,6 +61,7 @@ const RestorationAimsCheckboxGroupWithLabel = ({
               {...field}
               onChange={handleAimChangeAndResetStakeholdersIfAppropriate}
               options={optionsValueLabels}
+              optionsExcludedFromShowingSelectedMarkup={['Unknown', 'None']}
               aria-labelledby={id}
               shouldAddOtherOptionWithClarification={true}
               shouldReturnEvent={true}


### PR DESCRIPTION
…tions for section 3 

Fixes #247 

Steps for testing:
- log in
- create a new site, fill out a couple of stakeholders (section 2)
- go do section 3/restoration aims
- select an aim. See that the stakeholder benefits section shows for all options, but not for 'Unknown' or 'None'