### PR TITLE
Section 6 adjustments

### DIFF
--- a/mrtt-ui/src/components/SiteInterventions/AddMangroveAssociatedSpeciesRow.js
+++ b/mrtt-ui/src/components/SiteInterventions/AddMangroveAssociatedSpeciesRow.js
@@ -40,7 +40,7 @@ const AddMangroveAssociatedSpeciesRow = ({ saveItem, updateTabularInputDisplay }
     <TabularSectionDiv>
       <Box sx={{ width: '100%' }}>
         <TabularInputSection>
-          <TabularLabel>Species type</TabularLabel>
+          <TabularLabel>Species name</TabularLabel>
           <TextField
             value={type}
             label='type'
@@ -50,7 +50,7 @@ const AddMangroveAssociatedSpeciesRow = ({ saveItem, updateTabularInputDisplay }
           <TabularLabel>Number</TabularLabel>
           <TextField
             value={count}
-            label='count'
+            label='number'
             onChange={(e) => setNumber(e.target.value)}></TextField>
         </TabularInputSection>
         <TabularInputSection>

--- a/mrtt-ui/src/components/SiteInterventions/SiteInterventions.js
+++ b/mrtt-ui/src/components/SiteInterventions/SiteInterventions.js
@@ -2,10 +2,13 @@ import {
   Box,
   Button,
   Checkbox,
+  Chip,
   FormLabel,
   List,
   ListItem,
+  ListItemText,
   MenuItem,
+  Select,
   Stack,
   TextField,
   Typography
@@ -69,12 +72,16 @@ function SiteInterventionsForm() {
       .of(
         yup.object().shape({
           type: yup.string(),
-          seed: yup
-            .object()
-            .shape({ checked: yup.bool(), source: yup.string(), count: yup.mixed() }),
-          propagule: yup
-            .object()
-            .shape({ checked: yup.bool(), source: yup.string(), count: yup.mixed() })
+          seed: yup.object().shape({
+            checked: yup.bool(),
+            source: yup.array().of(yup.string()),
+            count: yup.mixed()
+          }),
+          propagule: yup.object().shape({
+            checked: yup.bool(),
+            source: yup.array().of(yup.string()),
+            count: yup.mixed()
+          })
         })
       )
       .default([]),
@@ -237,8 +244,8 @@ function SiteInterventionsForm() {
     if (event.target.checked) {
       mangroveSpeciesUsedAppend({
         type: specie,
-        seed: { checked: false, source: '', count: 0 },
-        propagule: { checked: false, source: '', count: 0 }
+        seed: { checked: false, source: [], count: 0 },
+        propagule: { checked: false, source: [], count: 0 }
       })
       mangroveSpeciesUsedCheckedCopy.push(specie)
     } else {
@@ -452,20 +459,27 @@ function SiteInterventionsForm() {
                                   specie
                                 )}.seed.source`}
                                 control={control}
-                                defaultValue=''
+                                defaultValue={[]}
                                 render={({ field }) => (
-                                  <TextField
+                                  <Select
                                     {...field}
-                                    select
+                                    multiple
                                     value={field.value}
                                     label='Source'
+                                    renderValue={(selected) => (
+                                      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+                                        {selected.map((value) => (
+                                          <Chip key={value} label={value} />
+                                        ))}
+                                      </Box>
+                                    )}
                                     sx={{ minWidth: '10em' }}>
                                     {seedlingOptions.map((item, index) => (
                                       <MenuItem key={index} value={item}>
                                         {item}
                                       </MenuItem>
                                     ))}
-                                  </TextField>
+                                  </Select>
                                 )}
                               />
                             </SubgroupDiv>
@@ -503,20 +517,27 @@ function SiteInterventionsForm() {
                                   specie
                                 )}.propagule.source`}
                                 control={control}
-                                defaultValue=''
+                                defaultValue={[]}
                                 render={({ field }) => (
-                                  <TextField
+                                  <Select
                                     {...field}
-                                    select
+                                    multiple
                                     value={field.value}
                                     label='Source'
+                                    renderValue={(selected) => (
+                                      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+                                        {selected.map((value) => (
+                                          <Chip key={value} label={value} />
+                                        ))}
+                                      </Box>
+                                    )}
                                     sx={{ minWidth: '10em' }}>
                                     {propaguleOptions.map((item, index) => (
                                       <MenuItem key={index} value={item}>
-                                        {item}
+                                        <ListItemText>{item}</ListItemText>
                                       </MenuItem>
                                     ))}
-                                  </TextField>
+                                  </Select>
                                 )}
                               />
                             </SubgroupDiv>

--- a/mrtt-ui/src/data/questions.js
+++ b/mrtt-ui/src/data/questions.js
@@ -399,8 +399,7 @@ const siteInterventions = {
       'Industry/Private sector',
       'Academic institute or research facility',
       'Ecotourists',
-      'Unknown',
-      'Other'
+      'Unknown'
     ]
   },
   otherActivitiesImplemented: {


### PR DESCRIPTION
**6.2b: add multiselect for seedlings and propagule sources**

to test: 
1. Go to section 1 and add a country
2. go back to section 6
3. go to 6.2a > select planting in order for 6.2b to appear
4. select an item from 6.2b
5. select more than one source item from propapagule or seedling drop down
6. save and refresh

note: this is a deeply nested item that doesn't have the best UI. Could use some design improvements but for now I think it works


**6.2c and 6.3d minor text updates**

also, there is a warning that is generated that I am aware of . I don't have a fix for it and will make a separate task to address it. It doesn't affect the functionality of section 6, so not a critical item. 

<img width="386" alt="Screen Shot 2022-08-31 at 12 52 39 PM" src="https://user-images.githubusercontent.com/26089140/187735269-1bd99797-c4e9-405f-81fe-9304a57d8f55.png">





