### PR TITLE
Feature/162 generic form validation message

### DIFF
--- a/mrtt-ui/src/components/CausesOfDeclineForm.js
+++ b/mrtt-ui/src/components/CausesOfDeclineForm.js
@@ -31,9 +31,11 @@ import { ContentWrapper } from '../styles/containers'
 import { ErrorText, PageSubtitle, PageTitle } from '../styles/typography'
 import { mapDataForApi } from '../library/mapDataForApi'
 import { questionMapping } from '../data/questionMapping'
+import FormValidationMessageIfErrors from './FormValidationMessageIfErrors'
 import language from '../language'
 import LoadingIndicator from './LoadingIndicator'
 import QuestionNav from './QuestionNav'
+import RequiredIndicator from './RequiredIndicator'
 import useInitializeQuestionMappedForm from '../library/useInitializeQuestionMappedForm'
 import useSiteInfo from '../library/useSiteInfo'
 
@@ -283,6 +285,7 @@ function CausesOfDeclineForm() {
         onFormSave={handleSubmit(onSubmit)}
         currentSection='causes-of-decline'
       />
+      <FormValidationMessageIfErrors formErrors={errors} />
       <Form>
         <FormQuestionDiv>
           <StickyFormLabel>{causesOfDecline.lossKnown.question}</StickyFormLabel>
@@ -304,7 +307,9 @@ function CausesOfDeclineForm() {
         </FormQuestionDiv>
         {lossKnownWatcher === 'true' ? (
           <FormQuestionDiv>
-            <StickyFormLabel>{causesOfDecline.causesOfDecline.question}</StickyFormLabel>
+            <StickyFormLabel>
+              {causesOfDecline.causesOfDecline.question} <RequiredIndicator />
+            </StickyFormLabel>
             {causesOfDeclineOptions.map((mainCause, mainCauseIndex) => {
               return (
                 <Box key={mainCauseIndex} sx={{ marginTop: '0.75em', marginBottom: '1.5em' }}>

--- a/mrtt-ui/src/components/Costs/CostsForm.js
+++ b/mrtt-ui/src/components/Costs/CostsForm.js
@@ -32,6 +32,7 @@ import BreakdownOfCostRow from './BreakdownOfCostRow'
 import PercentageSplitOfActivitiesRow from './PercentageSplitOfActivitiesRow'
 import { currencies } from '../../data/currencies'
 import { findDataItem } from '../../library/findDataItem'
+import FormValidationMessageIfErrors from '../FormValidationMessageIfErrors'
 
 const getEndDate = (registrationAnswersFromServer) =>
   findDataItem(registrationAnswersFromServer, '1.1b') ?? ''
@@ -275,6 +276,7 @@ const CostsForm = () => {
         onFormSave={validateInputs(handleSubmit)}
         currentSection='costs'
       />
+      <FormValidationMessageIfErrors formErrors={errors} />
       <Form>
         <FormQuestionDiv>
           <CheckboxGroupWithLabelAndController

--- a/mrtt-ui/src/components/FormValidationMessageIfErrors.js
+++ b/mrtt-ui/src/components/FormValidationMessageIfErrors.js
@@ -1,0 +1,20 @@
+import { Alert, AlertTitle } from '@mui/material'
+import PropTypes from 'prop-types'
+import React from 'react'
+
+import language from '../language'
+
+const FormValidationMessageIfErrors = ({ formErrors = {} }) => {
+  const formHasErrors = !!Object.keys(formErrors).length
+
+  return formHasErrors ? (
+    <Alert variant='outlined' severity='error'>
+      <AlertTitle>{language.form.validationAlert.title}</AlertTitle>
+      <p>{language.form.validationAlert.description}</p>
+    </Alert>
+  ) : null
+}
+
+FormValidationMessageIfErrors.propTypes = { formErrors: PropTypes.shape({}) }
+
+export default FormValidationMessageIfErrors

--- a/mrtt-ui/src/components/ManagementStatusAndEffectiveness/ManagementStatusAndEffectivenessForm.js
+++ b/mrtt-ui/src/components/ManagementStatusAndEffectiveness/ManagementStatusAndEffectivenessForm.js
@@ -23,6 +23,7 @@ import { ErrorText, PageSubtitle, PageTitle } from '../../styles/typography'
 import language from '../../language'
 import { mapDataForApi } from '../../library/mapDataForApi'
 import { questionMapping } from '../../data/questionMapping'
+import FormValidationMessageIfErrors from '../FormValidationMessageIfErrors'
 
 const ManagementStatusAndEffectivenessForm = () => {
   const { site_name } = useSiteInfo()
@@ -101,11 +102,13 @@ const ManagementStatusAndEffectivenessForm = () => {
         <PageSubtitle>{site_name}</PageSubtitle>
       </FormPageHeader>
       <QuestionNav
-        isSaving={isSubmitting}
-        isSaveError={isSubmitError}
-        onSave={validateInputs(handleSubmit)}
+        isFormSaving={isSubmitting}
+        isFormSaveError={isSubmitError}
+        onFormSave={validateInputs(handleSubmit)}
         currentSection='management-status-and-effectiveness'
       />
+      <FormValidationMessageIfErrors formErrors={errors} />
+
       <Form>
         <FormQuestionDiv>
           <StickyFormLabel>{questions.dateOfAssessment.question}</StickyFormLabel>

--- a/mrtt-ui/src/components/PreRestorationAssessment/PreRestorationAssessmentForm.js
+++ b/mrtt-ui/src/components/PreRestorationAssessment/PreRestorationAssessmentForm.js
@@ -42,6 +42,8 @@ import QuestionNav from '../QuestionNav'
 import PhysicalMeasurementRow from './PhysicalMeasurementRow'
 import useInitializeQuestionMappedForm from '../../library/useInitializeQuestionMappedForm'
 import useSiteInfo from '../../library/useSiteInfo'
+import RequiredIndicator from '../RequiredIndicator'
+import FormValidationMessageIfErrors from '../FormValidationMessageIfErrors'
 
 const getSiteCountries = (registrationAnswersFromServer) =>
   findDataItem(registrationAnswersFromServer, '1.2') ?? []
@@ -285,6 +287,8 @@ function PreRestorationAssessmentForm() {
         onFormSave={validateInputs(handleSubmit)}
         currentSection='pre-restoration-assessment'
       />
+      <FormValidationMessageIfErrors formErrors={errors} />
+
       <Form>
         <FormQuestionDiv>
           <StickyFormLabel>{questions.mangrovesPreviouslyOccured.question}</StickyFormLabel>
@@ -325,7 +329,10 @@ function PreRestorationAssessmentForm() {
         {mangroveRestorationAttemptedWatcher === 'Yes' ? (
           <>
             <FormQuestionDiv>
-              <StickyFormLabel>{questions.lastRestorationAttemptYear.question}</StickyFormLabel>
+              <StickyFormLabel>
+                {questions.lastRestorationAttemptYear.question}
+                <RequiredIndicator />
+              </StickyFormLabel>
               <Controller
                 name='lastRestorationAttemptYear'
                 control={control}
@@ -393,7 +400,9 @@ function PreRestorationAssessmentForm() {
               <ErrorText>{errors.siteAssessmentType?.selectedValues?.message}</ErrorText>
             </FormQuestionDiv>
             <FormQuestionDiv>
-              <StickyFormLabel>{questions.referenceSite.question}</StickyFormLabel>
+              <StickyFormLabel>
+                {questions.referenceSite.question} <RequiredIndicator />
+              </StickyFormLabel>
               <Controller
                 name='referenceSite'
                 control={control}
@@ -411,7 +420,10 @@ function PreRestorationAssessmentForm() {
               <ErrorText>{errors.referenceSite?.message}</ErrorText>
             </FormQuestionDiv>
             <FormQuestionDiv>
-              <StickyFormLabel>{questions.lostMangrovesYear.question}</StickyFormLabel>
+              <StickyFormLabel>
+                {questions.lostMangrovesYear.question}
+                <RequiredIndicator />
+              </StickyFormLabel>
               <Controller
                 name='lostMangrovesYear'
                 control={control}
@@ -423,7 +435,10 @@ function PreRestorationAssessmentForm() {
               <ErrorText>{errors.lostMangrovesYear?.message}</ErrorText>
             </FormQuestionDiv>
             <FormQuestionDiv>
-              <StickyFormLabel>{questions.naturalRegenerationAtSite.question}</StickyFormLabel>
+              <StickyFormLabel>
+                {questions.naturalRegenerationAtSite.question}
+                <RequiredIndicator />
+              </StickyFormLabel>
               <Controller
                 name='naturalRegenerationAtSite'
                 control={control}

--- a/mrtt-ui/src/components/ProjectDetailsForm.js
+++ b/mrtt-ui/src/components/ProjectDetailsForm.js
@@ -12,21 +12,23 @@ import turfConvex from '@turf/convex'
 import turfBbox from '@turf/bbox'
 import turfBboxPolygon from '@turf/bbox-polygon'
 
+import { ContentWrapper } from '../styles/containers'
 import { ErrorText, PageSubtitle, PageTitle } from '../styles/typography'
-import { StickyFormLabel, FormPageHeader, FormQuestionDiv, Form } from '../styles/forms'
 import { mapDataForApi } from '../library/mapDataForApi'
 import { projectDetails as questions } from '../data/questions'
 import { questionMapping } from '../data/questionMapping'
+import { StickyFormLabel, FormPageHeader, FormQuestionDiv, Form } from '../styles/forms'
 import { toast } from 'react-toastify'
 import { useParams } from 'react-router-dom'
 import emptyFeatureCollection from '../data/emptyFeatureCollection'
+import FormValidationMessageIfErrors from './FormValidationMessageIfErrors'
 import language from '../language'
 import LoadingIndicator from './LoadingIndicator'
 import mangroveCountries from '../data/mangrove_countries.json'
 import ProjectAreaMap from './ProjectAreaMap'
-import useInitializeQuestionMappedForm from '../library/useInitializeQuestionMappedForm'
-import { ContentWrapper } from '../styles/containers'
 import QuestionNav from './QuestionNav'
+import RequiredIndicator from './RequiredIndicator'
+import useInitializeQuestionMappedForm from '../library/useInitializeQuestionMappedForm'
 import useSiteInfo from '../library/useSiteInfo'
 
 const sortCountries = (a, b) => {
@@ -167,11 +169,13 @@ function ProjectDetailsForm() {
         onFormSave={validateInputs(handleSubmit)}
         currentSection='project-details'
       />
+      <FormValidationMessageIfErrors formErrors={errors} />
       <Form>
         {/* Start Date */}
         <FormQuestionDiv>
           <StickyFormLabel id='project-start-date-label'>
-            {questions.projectStartDate.question}*
+            {questions.projectStartDate.question}
+            <RequiredIndicator />
           </StickyFormLabel>
           <Controller
             name='projectStartDate'
@@ -198,7 +202,8 @@ function ProjectDetailsForm() {
         {/* Has project end date radio group */}
         <FormQuestionDiv>
           <StickyFormLabel id='has-project-end-date-label'>
-            {questions.hasProjectEndDate.question}*
+            {questions.hasProjectEndDate.question}
+            <RequiredIndicator />
           </StickyFormLabel>
           <Controller
             name='hasProjectEndDate'
@@ -219,7 +224,8 @@ function ProjectDetailsForm() {
         {showEndDateInput && (
           <FormQuestionDiv>
             <StickyFormLabel id='project-end-date-label'>
-              {questions.projectEndDate.question}*
+              {questions.projectEndDate.question}
+              <RequiredIndicator />
             </StickyFormLabel>
             <Controller
               name='projectEndDate'
@@ -245,7 +251,9 @@ function ProjectDetailsForm() {
         )}
         {/* Countries selector */}
         <FormQuestionDiv>
-          <StickyFormLabel htmlFor='countries'>{questions.countries.question}*</StickyFormLabel>
+          <StickyFormLabel htmlFor='countries'>
+            {questions.countries.question} <RequiredIndicator />
+          </StickyFormLabel>
           <Controller
             name='countries'
             control={control}
@@ -271,7 +279,9 @@ function ProjectDetailsForm() {
         </FormQuestionDiv>
         {/* Draw or upload site area */}
         <FormQuestionDiv>
-          <StickyFormLabel>{questions.siteArea.question}*</StickyFormLabel>
+          <StickyFormLabel>
+            {questions.siteArea.question} <RequiredIndicator />
+          </StickyFormLabel>
           <Controller
             name='siteArea'
             control={control}

--- a/mrtt-ui/src/components/QuestionNav.js
+++ b/mrtt-ui/src/components/QuestionNav.js
@@ -98,7 +98,7 @@ const QuestionNav = ({ isFormSaving, isFormSaveError, onFormSave, currentSection
       // https://github.com/globalmangrovewatch/gmw-users/issues/260
       axios.get(siteUrl).then(({ data }) => {
         setSiteFromApi(data)
-        setSectionPrivacy(data.section_data_visibility[sectionIdForApi])
+        setSectionPrivacy(data.section_data_visibility?.[sectionIdForApi])
       })
     },
     [siteUrl, sectionIdForApi]
@@ -157,9 +157,10 @@ const QuestionNav = ({ isFormSaving, isFormSaveError, onFormSave, currentSection
           <NavSubWrapper>
             <PrivacySelect
               id='form-privacy'
+              defaultValue={''}
               value={sectionPrivacy}
               onChange={handleOnPrivacyChange}>
-              <option value={undefined} disabled selected>
+              <option value={''} disabled>
                 {componentLanguage.privacySelectUndefined}
               </option>
               <option value={'private'}>{componentLanguage.private}</option>

--- a/mrtt-ui/src/components/RequiredIndicator.js
+++ b/mrtt-ui/src/components/RequiredIndicator.js
@@ -1,0 +1,20 @@
+import React from 'react'
+import language from '../language'
+import { styled } from '@mui/system'
+import theme from '../styles/theme'
+import themeMui from '../styles/themeMui'
+
+const RequiredIndicatorWrapper = styled('span')`
+  color: ${theme.form.requiredIndicatorColor};
+  padding: 0 ${themeMui.spacing(1)};
+`
+
+const RequiredIndicator = () => {
+  return (
+    <RequiredIndicatorWrapper aria-label={language.form.requiredIndicator}>
+      *
+    </RequiredIndicatorWrapper>
+  )
+}
+
+export default RequiredIndicator

--- a/mrtt-ui/src/components/RestorationAimsForm/RestorationAimsCheckboxGroupWithLabel.js
+++ b/mrtt-ui/src/components/RestorationAimsForm/RestorationAimsCheckboxGroupWithLabel.js
@@ -6,6 +6,7 @@ import React from 'react'
 import CheckboxGroup from '../CheckboxGroup/CheckboxGroup'
 import getOptionsValuesAndLabels from '../../library/getOptionsValuesAndLabels'
 import StakeholderBenefitsInputs, { stakeholdersPropType } from './StakeholderBenefitsInputs'
+import RequiredIndicator from '../RequiredIndicator'
 
 const RestorationAimsCheckboxGroupWithLabel = ({
   fieldName,
@@ -50,7 +51,7 @@ const RestorationAimsCheckboxGroupWithLabel = ({
     <>
       <StickyFormLabel id={id}>
         {question}
-        {showAsterisk ? <>*</> : null}
+        {showAsterisk ? <RequiredIndicator /> : null}
       </StickyFormLabel>
       <Controller
         name={fieldName}

--- a/mrtt-ui/src/components/RestorationAimsForm/RestorationAimsForm.js
+++ b/mrtt-ui/src/components/RestorationAimsForm/RestorationAimsForm.js
@@ -9,13 +9,14 @@ import {
   multiselectWithOtherValidation,
   multiselectWithOtherValidationNoMinimum
 } from '../../validation/multiSelectWithOther'
-import { Form, FormPageHeader, FormQuestionDiv } from '../../styles/forms'
 import { ContentWrapper } from '../../styles/containers'
 import { ErrorText, PageSubtitle, PageTitle } from '../../styles/typography'
+import { Form, FormPageHeader, FormQuestionDiv } from '../../styles/forms'
 import { mapDataForApi } from '../../library/mapDataForApi'
 import { questionMapping } from '../../data/questionMapping'
 import { restorationAims as questions } from '../../data/questions'
 import { toast } from 'react-toastify'
+import FormValidationMessageIfErrors from '../FormValidationMessageIfErrors'
 import language from '../../language'
 import LoadingIndicator from '../LoadingIndicator'
 import QuestionNav from '../QuestionNav'
@@ -95,6 +96,7 @@ const RestorationAimsForm = () => {
         onFormSave={validateInputs(handleSubmit)}
         currentSection='restoration-aims'
       />
+      <FormValidationMessageIfErrors formErrors={errors} />
       <Form onSubmit={validateInputs(handleSubmit)}>
         <FormQuestionDiv>
           <RestorationAimsCheckboxGroupWithLabel

--- a/mrtt-ui/src/components/SiteBackgroundForm.js
+++ b/mrtt-ui/src/components/SiteBackgroundForm.js
@@ -7,17 +7,19 @@ import { yupResolver } from '@hookform/resolvers/yup'
 import * as yup from 'yup'
 import axios from 'axios'
 
-import { Form, FormPageHeader, FormQuestionDiv, StickyFormLabel } from '../styles/forms'
 import { ContentWrapper } from '../styles/containers'
 import { ErrorText, PageSubtitle, PageTitle } from '../styles/typography'
+import { Form, FormPageHeader, FormQuestionDiv, StickyFormLabel } from '../styles/forms'
 import { mapDataForApi } from '../library/mapDataForApi'
 import { multiselectWithOtherValidation } from '../validation/multiSelectWithOther'
 import { questionMapping } from '../data/questionMapping'
 import { siteBackground } from '../data/questions'
 import CheckboxGroupWithLabelAndController from './CheckboxGroupWithLabelAndController'
+import FormValidationMessageIfErrors from './FormValidationMessageIfErrors'
 import language from '../language'
 import LoadingIndicator from './LoadingIndicator'
 import QuestionNav from './QuestionNav'
+import RequiredIndicator from './RequiredIndicator'
 import useInitializeQuestionMappedForm from '../library/useInitializeQuestionMappedForm'
 import useSiteInfo from '../library/useSiteInfo'
 
@@ -142,10 +144,14 @@ const SiteBackgroundForm = () => {
         onFormSave={validateInputs(handleSubmit)}
         currentSection='site-background'
       />
+      <FormValidationMessageIfErrors formErrors={errors} />
+
       {/* Select Stakeholders */}
       <Form>
         <FormQuestionDiv>
-          <StickyFormLabel>{siteBackground.stakeholders.question}</StickyFormLabel>
+          <StickyFormLabel>
+            {siteBackground.stakeholders.question} <RequiredIndicator />
+          </StickyFormLabel>
           <List>
             {siteBackground.stakeholders.options.map((stakeholder, index) => (
               <ListItem key={index}>
@@ -239,7 +245,12 @@ const SiteBackgroundForm = () => {
             fieldName='protectionStatus'
             reactHookFormInstance={reactHookFormInstance}
             options={siteBackground.protectionStatus.options}
-            question={siteBackground.protectionStatus.question}
+            question={
+              <>
+                {siteBackground.protectionStatus.question}
+                <RequiredIndicator />
+              </>
+            }
             shouldAddOtherOptionWithClarification={true}
           />
           <ErrorText>{errors.protectionStatus?.selectedValues?.message}</ErrorText>
@@ -271,7 +282,12 @@ const SiteBackgroundForm = () => {
             fieldName='governmentArrangement'
             reactHookFormInstance={reactHookFormInstance}
             options={siteBackground.governmentArrangement.options}
-            question={siteBackground.governmentArrangement.question}
+            question={
+              <>
+                {siteBackground.governmentArrangement.question}
+                <RequiredIndicator />
+              </>
+            }
             shouldAddOtherOptionWithClarification={true}
           />
           <ErrorText>{errors.governmentArrangement?.selectedValues?.message}</ErrorText>
@@ -282,7 +298,12 @@ const SiteBackgroundForm = () => {
             fieldName='landTenure'
             reactHookFormInstance={reactHookFormInstance}
             options={siteBackground.landTenure.options}
-            question={siteBackground.landTenure.question}
+            question={
+              <>
+                {siteBackground.landTenure.question}
+                <RequiredIndicator />
+              </>
+            }
             shouldAddOtherOptionWithClarification={true}
           />
           <ErrorText>{errors.landTenure?.selectedValues?.message}</ErrorText>

--- a/mrtt-ui/src/components/SiteInterventions/SiteInterventions.js
+++ b/mrtt-ui/src/components/SiteInterventions/SiteInterventions.js
@@ -22,24 +22,25 @@ import { yupResolver } from '@hookform/resolvers/yup'
 import * as yup from 'yup'
 import axios from 'axios'
 
-import { Form, FormPageHeader, FormQuestionDiv, StickyFormLabel } from '../../styles/forms'
 import { ContentWrapper } from '../../styles/containers'
 import { ErrorText, PageSubtitle, PageTitle } from '../../styles/typography'
 import { findDataItem } from '../../library/findDataItem'
+import { Form, FormPageHeader, FormQuestionDiv, StickyFormLabel } from '../../styles/forms'
+import { mangroveSpeciesPerCountryList } from '../../data/mangroveSpeciesPerCountry'
 import { mapDataForApi } from '../../library/mapDataForApi'
 import { multiselectWithOtherValidationNoMinimum } from '../../validation/multiSelectWithOther'
+import { propaguleOptions, seedlingOptions } from '../../data/siteInterventionOptions'
 import { questionMapping } from '../../data/questionMapping'
 import { siteInterventions as questions } from '../../data/questions'
+import AddMangroveAssociatedSpeciesRow from './AddMangroveAssociatedSpeciesRow'
 import CheckboxGroupWithLabelAndController from '../CheckboxGroupWithLabelAndController'
-import { mangroveSpeciesPerCountryList } from '../../data/mangroveSpeciesPerCountry'
-import { propaguleOptions, seedlingOptions } from '../../data/siteInterventionOptions'
+import FormValidationMessageIfErrors from '../FormValidationMessageIfErrors'
 import language from '../../language'
 import LoadingIndicator from '../LoadingIndicator'
+import MangroveAssociatedSpeciesRow from './MangroveAssociatedSpeciesRow'
 import QuestionNav from '../QuestionNav'
 import useInitializeQuestionMappedForm from '../../library/useInitializeQuestionMappedForm'
 import useSiteInfo from '../../library/useSiteInfo'
-import AddMangroveAssociatedSpeciesRow from './AddMangroveAssociatedSpeciesRow'
-import MangroveAssociatedSpeciesRow from './MangroveAssociatedSpeciesRow'
 
 const getBiophysicalInterventions = (registrationAnswersFromServer) =>
   findDataItem(registrationAnswersFromServer, '6.2a') ?? []
@@ -318,6 +319,8 @@ function SiteInterventionsForm() {
         onFormSave={validateInputs(handleSubmit)}
         currentSection='site-interventions'
       />
+      <FormValidationMessageIfErrors formErrors={errors} />
+
       <Form>
         <FormQuestionDiv>
           <CheckboxGroupWithLabelAndController

--- a/mrtt-ui/src/language.js
+++ b/mrtt-ui/src/language.js
@@ -21,8 +21,13 @@ const form = {
     yearTooLow: 'Year must be greater than 1900',
     noYearProvided: 'You must specifiy a year',
     yearTooHigh: 'Year must less than or equal to the current year'
+  },
+  validationAlert: {
+    title: 'The form was not saved',
+    description: 'Please check the form below for validation errors'
   }
 }
+
 const multiselectWithOtherFormQuestion = {
   validation: {
     selectAtleastOneItem: 'Please select at least one item.',

--- a/mrtt-ui/src/styles/forms.js
+++ b/mrtt-ui/src/styles/forms.js
@@ -38,13 +38,10 @@ export const Form = styled('form')`
   flex-direction: column;
   padding-bottom: ${theme.layout.footerHeight};
   gap: ${themeMui.spacing(3)};
+  margin-top: ${themeMui.spacing(2)};
   @media (min-width: ${theme.layout.mediaQueryDesktop}) {
     padding-bottom: 0;
   }
-`
-export const RequiredIndicator = styled('span')`
-  color: ${theme.form.requiredIndicatorColor};
-  padding: 0 ${themeMui.spacing(1)};
 `
 export const NestedLabel1 = styled('label')`
   text-transform: uppercase;

--- a/mrtt-ui/src/views/LandscapeForm.js
+++ b/mrtt-ui/src/views/LandscapeForm.js
@@ -8,15 +8,16 @@ import axios from 'axios'
 import PropTypes from 'prop-types'
 import React, { useEffect, useState } from 'react'
 
-import { ButtonContainer, PaddedSection, RowFlexEnd, ContentWrapper } from '../styles/containers'
 import { ButtonCancel, ButtonSubmit } from '../styles/buttons'
+import { ButtonContainer, PaddedSection, RowFlexEnd, ContentWrapper } from '../styles/containers'
 import { ErrorText, PageTitle } from '../styles/typography'
-import { Form, RequiredIndicator } from '../styles/forms'
+import { Form } from '../styles/forms'
 import ButtonSecondaryWithLoader from '../components/ButtonSecondaryWithLoader'
 import ConfirmPrompt from '../components/ConfirmPrompt/ConfirmPrompt'
 import ItemDoesntExist from '../components/ItemDoesntExist'
 import language from '../language'
 import LoadingIndicator from '../components/LoadingIndicator'
+import RequiredIndicator from '../components/RequiredIndicator'
 import SubmitErrorWithExtraErrorContent from '../components/SubmitErrorWithExtraErrorContent'
 
 const validationSchema = yup.object({
@@ -178,7 +179,7 @@ const LandscapeForm = ({ isNewLandscape }) => {
         <Form onSubmit={validateInputs(handleSubmit)}>
           <FormLabel htmlFor='name'>
             {language.pages.landscapeForm.labelName}
-            <RequiredIndicator>*</RequiredIndicator>{' '}
+            <RequiredIndicator />
           </FormLabel>
           <Controller
             name='landscape_name'
@@ -188,7 +189,7 @@ const LandscapeForm = ({ isNewLandscape }) => {
           <ErrorText>{errors?.landscape_name?.message}</ErrorText>
           <FormLabel htmlFor='organizations'>
             {language.pages.landscapeForm.labelOrganizations}
-            <RequiredIndicator>*</RequiredIndicator>
+            <RequiredIndicator />
           </FormLabel>
           <Controller
             name='selectedOrganizations'

--- a/mrtt-ui/src/views/NewOrganizationUser.js
+++ b/mrtt-ui/src/views/NewOrganizationUser.js
@@ -10,10 +10,11 @@ import { ButtonCancel, ButtonSubmit } from '../styles/buttons'
 import { ButtonContainer, ContentWrapper, RowFlexEnd } from '../styles/containers'
 import { Controller, useForm } from 'react-hook-form'
 import { ErrorText, Link, PageTitle } from '../styles/typography'
-import { Form, RequiredIndicator } from '../styles/forms'
+import { Form } from '../styles/forms'
 import { FormControlLabel, FormLabel, Radio, RadioGroup, TextField } from '@mui/material'
 import language from '../language'
 import LoadingIndicator from '../components/LoadingIndicator'
+import RequiredIndicator from '../components/RequiredIndicator'
 
 const pageLanguage = language.pages.newOrganizationUser
 
@@ -92,7 +93,7 @@ const NewOrganizationUser = () => {
       <Form onSubmit={validateInputs(handleSubmit)}>
         <FormLabel htmlFor='email'>
           {pageLanguage.email}
-          <RequiredIndicator>*</RequiredIndicator>
+          <RequiredIndicator />
         </FormLabel>
         <Controller
           name='email'
@@ -102,7 +103,7 @@ const NewOrganizationUser = () => {
         <ErrorText>{errors?.email?.message}</ErrorText>
         <FormLabel id={'role-label'}>
           {pageLanguage.role}
-          <RequiredIndicator>*</RequiredIndicator>
+          <RequiredIndicator />
         </FormLabel>
         <Controller
           name='role'

--- a/mrtt-ui/src/views/OrganizationForm.js
+++ b/mrtt-ui/src/views/OrganizationForm.js
@@ -8,13 +8,14 @@ import axios from 'axios'
 import PropTypes from 'prop-types'
 import React, { useEffect, useState } from 'react'
 
-import { ButtonContainer, ContentWrapper, RowFlexEnd } from '../styles/containers'
 import { ButtonCancel, ButtonSubmit } from '../styles/buttons'
+import { ButtonContainer, ContentWrapper, RowFlexEnd } from '../styles/containers'
 import { ErrorText, PageTitle } from '../styles/typography'
-import { Form, RequiredIndicator } from '../styles/forms'
+import { Form } from '../styles/forms'
 import ItemDoesntExist from '../components/ItemDoesntExist'
 import language from '../language'
 import LoadingIndicator from '../components/LoadingIndicator'
+import RequiredIndicator from '../components/RequiredIndicator'
 import SubmitErrorWithExtraErrorContent from '../components/SubmitErrorWithExtraErrorContent'
 
 const validationSchema = yup.object({
@@ -124,7 +125,7 @@ const OrganizationForm = ({ isNewOrganization }) => {
         <Form onSubmit={validateInputs(handleSubmit)}>
           <FormLabel htmlFor='name'>
             {language.pages.organizationForm.labelName}
-            <RequiredIndicator>*</RequiredIndicator>{' '}
+            <RequiredIndicator />
           </FormLabel>
           <Controller
             name='organization_name'

--- a/mrtt-ui/src/views/SiteForm.js
+++ b/mrtt-ui/src/views/SiteForm.js
@@ -8,13 +8,14 @@ import axios from 'axios'
 import PropTypes from 'prop-types'
 
 import { ButtonCancel, ButtonSubmit } from '../styles/buttons'
-import { QuestionWrapper, ButtonContainer, ContentWrapper, RowFlexEnd } from '../styles/containers'
 import { ErrorText, PageTitle } from '../styles/typography'
-import { Form, RequiredIndicator } from '../styles/forms'
+import { Form } from '../styles/forms'
 import { FormLabel, MenuItem, Select, TextField } from '@mui/material'
+import { QuestionWrapper, ButtonContainer, ContentWrapper, RowFlexEnd } from '../styles/containers'
 import ItemDoesntExist from '../components/ItemDoesntExist'
 import language from '../language'
 import LoadingIndicator from '../components/LoadingIndicator'
+import RequiredIndicator from '../components/RequiredIndicator'
 
 const validationSchema = yup.object({
   site_name: yup.string().required(language.pages.siteform.validation.nameRequired),
@@ -128,9 +129,7 @@ const SiteForm = ({ isNewSite }) => {
         <QuestionWrapper>
           <FormLabel htmlFor='name'>
             {language.pages.siteform.labelName}
-            <RequiredIndicator aria-label={language.form.requiredIndicator}>
-              *
-            </RequiredIndicator>{' '}
+            <RequiredIndicator />
           </FormLabel>
           <Controller
             name='site_name'
@@ -143,9 +142,7 @@ const SiteForm = ({ isNewSite }) => {
         <QuestionWrapper>
           <FormLabel htmlFor='landscape'>
             {language.pages.siteform.labelLandscape}
-            <RequiredIndicator aria-label={language.form.requiredIndicator}>
-              *
-            </RequiredIndicator>{' '}
+            <RequiredIndicator />
           </FormLabel>
           <Controller
             name='landscape_id'


### PR DESCRIPTION
# Description

- fixed warning about using selected for a select option instead of defaultValue
- made `RequiredIndicator` component for red asterisks, applied where Yup complains (may be wrong, but we have #265  to audit whats required)
- Added validation message at top of question/section forms. There is a ticket to make it sticky, thats out of scope here (see #271 )

Fixes # #162 

# Steps to test:
- create new site, go through sections, saving empty untouched forms. 
- Save edited form
Does the message show and hide at the top of the form when expected?

<img width="1787" alt="Screen Shot 2022-08-31 at 4 16 08 PM" src="https://user-images.githubusercontent.com/1740152/187794926-95c7c979-b5bf-426b-a18d-ee8b95cbf247.png">


