### PR TITLE
Feature update: restructure 6.1 to have checked items + select drop down

### DIFF
--- a/mrtt-ui/src/components/SiteInterventions/SiteInterventions.js
+++ b/mrtt-ui/src/components/SiteInterventions/SiteInterventions.js
@@ -288,6 +288,9 @@ function SiteInterventionsForm() {
   const getBiophysicalIntervention = (intervention) =>
     biophysicalInterventionsFields.find((field) => field.interventionType === intervention)
 
+  const getWhichStakeholderInvolved = (stakeholder) =>
+    whichStakeholdersInvolvedFields.find((field) => field.stakeholder === stakeholder)
+
   const handleMangroveSpeciesUsedOnChange = (event, specie) => {
     const mangroveSpeciesUsedCheckedCopy = [...mangroveSpeciesUsedChecked]
 
@@ -392,6 +395,35 @@ function SiteInterventionsForm() {
                         handleWhichStakeholdersInvolvedOnChange(event, stakeholder)
                       }></Checkbox>
                     <Typography variant='subtitle'>{stakeholder}</Typography>
+                  </Box>
+                  <Box>
+                    {getWhichStakeholderInvolved(stakeholder) && (
+                      <Box>
+                        <InnerFormDiv>
+                          <Controller
+                            name={`whichStakeholdersInvolved.${whichStakeholdersInvolvedFields.findIndex(
+                              (field) => field.stakeholder === stakeholder
+                            )}.stakeholderType`}
+                            control={control}
+                            defaultValue=''
+                            render={({ field }) => (
+                              <TextField
+                                {...field}
+                                select
+                                value={field.value}
+                                label='select'
+                                sx={{ width: '10em' }}>
+                                {['Paid', 'Voluntary'].map((item, index) => (
+                                  <MenuItem key={index} value={item}>
+                                    {item}
+                                  </MenuItem>
+                                ))}
+                              </TextField>
+                            )}
+                          />
+                        </InnerFormDiv>
+                      </Box>
+                    )}
                   </Box>
                 </Box>
               </ListItem>


### PR DESCRIPTION
- restructure 6.1 completely from using grouped checked items to fields array with object properties
- when an item is checked, a select box appears with two options: paid or voluntary

to test, check items in 6.1, use select dropdown, refresh