### PR TITLE
feat: [259] when creating a new site, have the user choose a default …

### DIFF
--- a/mrtt-ui/src/components/QuestionNav.js
+++ b/mrtt-ui/src/components/QuestionNav.js
@@ -117,7 +117,8 @@ const QuestionNav = ({ isFormSaving, isFormSaveError, onFormSave, currentSection
       }
       axios
         .put(siteUrl, siteWithUpdatedSectionPrivacy)
-        .then(() => {
+        .then((response) => {
+          setSectionPrivacy(response.data.section_data_visibility[sectionIdForApi])
           setIsPrivacySaving(false)
           toast.success(componentLanguage.privacySavingSuccess)
         })
@@ -163,8 +164,8 @@ const QuestionNav = ({ isFormSaving, isFormSaveError, onFormSave, currentSection
               <option value={''} disabled>
                 {componentLanguage.privacySelectUndefined}
               </option>
-              <option value={'private'}>{componentLanguage.private}</option>
-              <option value={'public'}>{componentLanguage.public}</option>
+              <option value={'private'}>{language.sectionPrivacy.private}</option>
+              <option value={'public'}>{language.sectionPrivacy.public}</option>
             </PrivacySelect>
             <ButtonSave isSaving={isFormSaving} onClick={onFormSave} />
           </NavSubWrapper>

--- a/mrtt-ui/src/language.js
+++ b/mrtt-ui/src/language.js
@@ -93,6 +93,7 @@ const pages = {
     titleNewSite: 'Create a site',
     labelName: 'Site Name',
     labelLandscape: 'Landscape',
+    labelDefaultSectionPrivacy: 'Default Data Privacy',
     site: 'site',
     validation: {
       nameRequired: 'Please enter a name',
@@ -210,9 +211,12 @@ const questionNav = {
   privacySaveError: "Saving this section's privacy failed. Please try again.",
   privacySavingSuccess: success.getEditThingSuccessMessage("This section's privacy"),
   privacySelectUndefined: 'Select Privacy',
-  private: 'Private',
-  public: 'Public',
   returnToSite: 'Return to Site Form Overview'
+}
+
+const sectionPrivacy = {
+  private: 'Private',
+  public: 'Public'
 }
 
 export default {
@@ -224,5 +228,6 @@ export default {
   pages,
   projectAreaMap,
   questionNav,
+  sectionPrivacy,
   success
 }

--- a/mrtt-ui/src/views/SiteForm.js
+++ b/mrtt-ui/src/views/SiteForm.js
@@ -19,10 +19,11 @@ import RequiredIndicator from '../components/RequiredIndicator'
 
 const validationSchema = yup.object({
   site_name: yup.string().required(language.pages.siteform.validation.nameRequired),
-  landscape_id: yup.string().required(language.pages.siteform.validation.landscapeRequired)
+  landscape_id: yup.string().required(language.pages.siteform.validation.landscapeRequired),
+  defaultSectionPrivacy: yup.string() // skipping requiring this since input hidden for when isNewSite = false / its a select with an initial value / time constraints
 })
 
-const formDefaultValues = { site_name: '', landscape_id: '' }
+const formDefaultValues = { site_name: '', landscape_id: '', defaultSectionPrivacy: 'public' }
 
 const SiteForm = ({ isNewSite }) => {
   const [doesItemExist, setDoesItemExist] = useState(true)
@@ -75,9 +76,25 @@ const SiteForm = ({ isNewSite }) => {
     [siteId, resetForm, sitesUrl, isNewSite, landscapesUrl, siteUrl]
   )
 
-  const postNewSite = (formData) => {
+  const postNewSite = ({ site_name, landscape_id, defaultSectionPrivacy }) => {
+    const siteDataToSubmit = {
+      site_name,
+      landscape_id,
+      section_data_visibility: {
+        1: defaultSectionPrivacy,
+        2: defaultSectionPrivacy,
+        3: defaultSectionPrivacy,
+        4: defaultSectionPrivacy,
+        5: defaultSectionPrivacy,
+        6: defaultSectionPrivacy,
+        7: defaultSectionPrivacy,
+        8: defaultSectionPrivacy,
+        9: defaultSectionPrivacy,
+        10: defaultSectionPrivacy
+      }
+    }
     axios
-      .post(sitesUrl, formData)
+      .post(sitesUrl, siteDataToSubmit)
       .then(({ data: { site_name } }) => {
         setIsSubmitting(false)
         toast.success(language.success.getCreateThingSuccessMessage(site_name))
@@ -160,6 +177,30 @@ const SiteForm = ({ isNewSite }) => {
           />
           <ErrorText>{errors?.landscape_id?.message}</ErrorText>
         </QuestionWrapper>
+        {isNewSite ? (
+          <QuestionWrapper>
+            <FormLabel htmlFor='defaultSectionPrivacy'>
+              {language.pages.siteform.labelDefaultSectionPrivacy}
+              <RequiredIndicator />
+            </FormLabel>
+            <Controller
+              name='defaultSectionPrivacy'
+              required='true'
+              control={formControl}
+              render={({ field }) => (
+                <Select
+                  {...field}
+                  id='defaultSectionPrivacy'
+                  label={language.pages.siteform.labelDefaultSectionPrivacy}>
+                  <MenuItem value='private'>{language.sectionPrivacy.private}</MenuItem>
+                  <MenuItem value='public'>{language.sectionPrivacy.public}</MenuItem>
+                </Select>
+              )}
+            />
+            <ErrorText>{errors?.landscape_id?.message}</ErrorText>
+          </QuestionWrapper>
+        ) : null}
+
         <RowFlexEnd>{isSubmitError && <ErrorText>{language.error.submit}</ErrorText>}</RowFlexEnd>
         <ButtonContainer>
           <ButtonCancel onClick={handleCancelClick} />


### PR DESCRIPTION
…privacy setting for their data.

default data privacy input for create new site. Note: cant view default privacy setting for edit site form.

Steps to test:
- create a new site
- set default data privacy
- view sections look at privacy setting in question nav. Make sure is initially set to default. 
- change section privacy. Refresh to make sure saved.