### PR TITLE
fix: [294] section summary groupings

### DIFF
--- a/mrtt-ui/src/views/SiteQuestionsOverview/AddMonitoringSectionMenu.js
+++ b/mrtt-ui/src/views/SiteQuestionsOverview/AddMonitoringSectionMenu.js
@@ -3,8 +3,12 @@ import { Menu, MenuItem, Stack } from '@mui/material'
 import { ButtonPrimary } from '../../styles/buttons'
 import language from '../../language'
 import { ArrowDropDown } from '@mui/icons-material'
+import { Link } from '../../styles/typography'
+import PropTypes from 'prop-types'
 
-const AddMonitoringSectionMenu = () => {
+const pageLanguage = language.pages.siteQuestionsOverview
+
+const AddMonitoringSectionMenu = ({ siteId }) => {
   const [menuAnchorElement, setMenuAnchorElement] = React.useState(null)
   const isMenuOpen = Boolean(menuAnchorElement)
   const handleMenuButtonClick = (event) => {
@@ -33,18 +37,26 @@ const AddMonitoringSectionMenu = () => {
         MenuListProps={{
           'aria-labelledby': 'add-monitoring-section-button'
         }}>
-        <MenuItem>{language.pages.siteQuestionsOverview.formName.managementStatus}</MenuItem>
         <MenuItem>
-          {language.pages.siteQuestionsOverview.formName.socioeconomicGovernanceStatusOutcomes}
+          <Link to={`/sites/${siteId}/form/management-status-and-effectiveness`}>
+            {pageLanguage.formName.managementStatusAndEffectiveness}
+          </Link>
         </MenuItem>
         <MenuItem>
-          {language.pages.siteQuestionsOverview.formName.ecologicalStatusOutcomes}
+          <Link to={`/sites/${siteId}/form/socioeconomic-and-governance-status`}>
+            {pageLanguage.formName.socioeconomicGovernanceStatusOutcomes}
+          </Link>
+        </MenuItem>
+        <MenuItem>
+          <Link to={`/sites/${siteId}/form/ecological-status-and-outcomes`}>
+            {pageLanguage.formName.ecologicalStatusOutcomes}
+          </Link>
         </MenuItem>
       </Menu>
     </Stack>
   )
 }
 
-AddMonitoringSectionMenu.propTypes = {}
+AddMonitoringSectionMenu.propTypes = { siteId: PropTypes.string.isRequired }
 
 export default AddMonitoringSectionMenu

--- a/mrtt-ui/src/views/SiteQuestionsOverview/SiteQuestionsOverview.js
+++ b/mrtt-ui/src/views/SiteQuestionsOverview/SiteQuestionsOverview.js
@@ -112,6 +112,11 @@ const SiteOverview = () => {
                 </Link>
               </WideTh>
             </tr>
+          </tbody>
+        </TableAlertnatingRows>
+        <StyledSectionHeader>{pageLanguage.formGroupTitle.intervention}</StyledSectionHeader>
+        <TableAlertnatingRows>
+          <tbody>
             <tr>
               <WideTh>
                 <Link to={`/sites/${siteId}/form/site-interventions`}>
@@ -124,42 +129,10 @@ const SiteOverview = () => {
                 <Link to={`/sites/${siteId}/form/costs`}>{pageLanguage.formName.costs}</Link>
               </WideTh>
             </tr>
-            <tr>
-              <WideTh>
-                <Link to={`/sites/${siteId}/form/management-status-and-effectiveness`}>
-                  {pageLanguage.formName.managementStatusAndEffectiveness}
-                </Link>
-              </WideTh>
-            </tr>
-            <tr>
-              <WideTh>
-                <Link to={`/sites/${siteId}/form/socioeconomic-and-governance-status`}>
-                  {pageLanguage.formName.socioeconomicGovernanceStatusOutcomes}
-                </Link>
-              </WideTh>
-            </tr>
-            <tr>
-              <WideTh>
-                <Link to={`/sites/${siteId}/form/ecological-status-and-outcomes`}>
-                  {pageLanguage.formName.ecologicalStatusOutcomes}
-                </Link>
-              </WideTh>
-            </tr>
-          </tbody>
-        </TableAlertnatingRows>
-        <StyledSectionHeader>{pageLanguage.formGroupTitle.intervention}</StyledSectionHeader>
-        <TableAlertnatingRows>
-          <tbody>
-            <tr>
-              <WideTh>{pageLanguage.formName.siteInterventions}</WideTh>
-            </tr>
-            <tr>
-              <WideTh>{pageLanguage.formName.costs}</WideTh>
-            </tr>
           </tbody>
         </TableAlertnatingRows>
         <StyledSectionHeader>{pageLanguage.formGroupTitle.monitoring}</StyledSectionHeader>
-        <AddMonitoringSectionMenu />
+        <AddMonitoringSectionMenu siteId={siteId} />
       </ContentWrapper>
     </>
   )


### PR DESCRIPTION
To test:

does section summary page match mockups in terms of groupings?
![Screen Shot 2022-09-15 at 2 43 14 PM](https://user-images.githubusercontent.com/1740152/190504939-c61493fc-8c0d-485d-ad17-3f0390ac9e04.png)
