### PR TITLE
feat: [245] Update user signup success and error messages

### DIFF
--- a/mrtt-ui/src/App.js
+++ b/mrtt-ui/src/App.js
@@ -101,6 +101,7 @@ function App() {
 
             <Route path='/auth/signup' element={<SignupForm />} />
             <Route path='/auth/login' element={<LoginForm />} />
+            <Route path='/auth/login/newUser' element={<LoginForm isUserNew={true} />} />
           </Routes>
         </GlobalLayout>
       </Router>

--- a/mrtt-ui/src/language.js
+++ b/mrtt-ui/src/language.js
@@ -2,14 +2,16 @@ const error = {
   apiLoad: 'Loading data from the api failed. Please try again.',
   delete: 'Deleting that item failed. Please try again.',
   getItemDoesntExistMessage: (item) => `That ${item} doesnt exist.`,
+  generic: 'Something went wrong. Please try again.',
   submit: 'Saving failed. Please try again.'
 }
 
 const success = {
-  submit: 'The data has been saved.',
-  getEditThingSuccessMessage: (thing) => `${thing} has been edited.`,
   getCreateThingSuccessMessage: (thing) => `${thing}, has been created.`,
-  getDeleteThingSuccessMessage: (thing) => `${thing} has been deleted.`
+  getDeleteThingSuccessMessage: (thing) => `${thing} has been deleted.`,
+  getEditThingSuccessMessage: (thing) => `${thing} has been edited.`,
+  signup: 'Please check your email for verification instructions.',
+  submit: 'The data has been saved.'
 }
 const form = {
   checkboxGroupOtherInputPlaceholder: 'If other, please state.',

--- a/mrtt-ui/src/views/Auth/LoginForm.js
+++ b/mrtt-ui/src/views/Auth/LoginForm.js
@@ -1,16 +1,17 @@
 import { Controller, useForm } from 'react-hook-form'
 import { toast } from 'react-toastify'
-import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { useState } from 'react'
 import { yupResolver } from '@hookform/resolvers/yup'
 import * as yup from 'yup'
 import axios from 'axios'
+import PropTypes from 'prop-types'
 
+import { Alert, FormLabel, TextField } from '@mui/material'
 import { ButtonCancel, ButtonSubmit } from '../../styles/buttons'
 import { ButtonContainer, PagePadding, RowFlexEnd } from '../../styles/containers'
 import { ErrorText, PageTitle } from '../../styles/typography'
 import { Form, MainFormDiv } from '../../styles/forms'
-import { FormLabel, TextField } from '@mui/material'
 import Button from '@mui/material/Button'
 import language from '../../language'
 import LoadingIndicator from '../../components/LoadingIndicator'
@@ -24,7 +25,7 @@ const validationSchema = yup.object({
 
 const formDefaultValues = { email: '', password: '' }
 
-const LoginForm = () => {
+const LoginForm = ({ isUserNew }) => {
   const [isLoading] = useState(false)
   const [isSubmitError, setIsSubmitError] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -82,6 +83,11 @@ const LoginForm = () => {
     <MainFormDiv>
       <PagePadding>
         <PageTitle>Login</PageTitle>
+        {isUserNew ? (
+          <Alert variant='outlined' severity='success'>
+            {language.success.signup}
+          </Alert>
+        ) : null}
         <Form onSubmit={validateInputs(handleSubmit)}>
           <FormLabel htmlFor='email'>Email* </FormLabel>
           <Controller
@@ -112,6 +118,14 @@ const LoginForm = () => {
   )
 
   return isLoading ? <LoadingIndicator /> : form
+}
+
+LoginForm.propTypes = {
+  isUserNew: PropTypes.bool
+}
+
+LoginForm.defaultValues = {
+  isUserNew: false
 }
 
 export default LoginForm

--- a/mrtt-ui/src/views/Auth/SignupForm.js
+++ b/mrtt-ui/src/views/Auth/SignupForm.js
@@ -41,15 +41,15 @@ const SignupForm = () => {
   const signUp = (formData) => {
     axios
       .post(authUrl, { user: formData })
-      .then(({ data }) => {
+      .then(() => {
         setIsSubmitting(false)
-        toast.success(data.message)
+        toast.success(language.success.signup)
         navigate('/auth/login')
       })
-      .catch((error) => {
+      .catch(() => {
         setIsSubmitting(false)
         setIsSubmitError(true)
-        toast.error(error.response.data.error)
+        toast.error(language.error.generic)
       })
   }
 

--- a/mrtt-ui/src/views/Auth/SignupForm.js
+++ b/mrtt-ui/src/views/Auth/SignupForm.js
@@ -44,7 +44,7 @@ const SignupForm = () => {
       .then(() => {
         setIsSubmitting(false)
         toast.success(language.success.signup)
-        navigate('/auth/login')
+        navigate('/auth/login/newUser')
       })
       .catch(() => {
         setIsSubmitting(false)


### PR DESCRIPTION
after a suer signs up successfully, they will see a toast  and message on the login page they are navigated to saying to check their email. 

to test:
 - go to the sign up page
 - sign up
 - see the toast and message on the login page when redirected
 
 
<img width="896" alt="Screen Shot 2022-09-16 at 12 48 23 PM" src="https://user-images.githubusercontent.com/1740152/190713471-23c3cf55-56b1-4913-8c80-b2e31459f531.png">
