### PR TITLE
Feature/303 304 list monitoring forms and link to edit form

### DIFF
--- a/mrtt-ui/src/components/EcologicalStatusAndOutcomes/EcologicalStatusAndOutcomesForm.js
+++ b/mrtt-ui/src/components/EcologicalStatusAndOutcomes/EcologicalStatusAndOutcomesForm.js
@@ -31,10 +31,11 @@ import useInitializeMonitoringForm from '../../library/useInitializeMonitoringFo
 import CheckboxGroupWithLabelAndController from '../CheckboxGroupWithLabelAndController'
 import { multiselectWithOtherValidationNoMinimum } from '../../validation/multiSelectWithOther'
 import { findDataItem } from '../../library/findDataItem'
-import MONITORING_FORM_TYPES from '../../constants/monitoringFormTypes'
+import MONITORING_FORM_CONSTANTS from '../../constants/monitoringFormConstants'
 
 const getBiophysicalInterventions = (registrationAnswersFromServer) =>
   findDataItem(registrationAnswersFromServer, '6.2') ?? []
+const formType = MONITORING_FORM_CONSTANTS.ecologicalStatusAndOutcomes.payloadType
 
 const EcologicalStatusAndOutcomesForm = () => {
   const { site_name } = useSiteInfo()
@@ -105,10 +106,11 @@ const EcologicalStatusAndOutcomesForm = () => {
 
   useInitializeMonitoringForm({
     apiUrl: monitoringFormSingularUrl,
+    formType,
+    isEditMode,
     questionMapping: questionMapping.ecologicalStatusAndOutcomes,
     resetForm,
-    setIsLoading: setIsMainFormDataLoading,
-    isEditMode
+    setIsLoading: setIsMainFormDataLoading
   })
 
   const createNewMonitoringForm = (payload) => {
@@ -145,7 +147,7 @@ const EcologicalStatusAndOutcomesForm = () => {
     setIsSubmitError(false)
 
     const payload = {
-      form_type: MONITORING_FORM_TYPES.ecologicalStatusAndOutcomes,
+      form_type: formType,
       answers: mapDataForApi('ecologicalStatusAndOutcomes', formData)
     }
 

--- a/mrtt-ui/src/components/ManagementStatusAndEffectiveness/ManagementStatusAndEffectivenessForm.js
+++ b/mrtt-ui/src/components/ManagementStatusAndEffectiveness/ManagementStatusAndEffectivenessForm.js
@@ -24,7 +24,9 @@ import language from '../../language'
 import { mapDataForApi } from '../../library/mapDataForApi'
 import { questionMapping } from '../../data/questionMapping'
 import FormValidationMessageIfErrors from '../FormValidationMessageIfErrors'
-import MONITORING_FORM_TYPES from '../../constants/monitoringFormTypes'
+import MONITORING_FORM_CONSTANTS from '../../constants/monitoringFormConstants'
+
+const formType = MONITORING_FORM_CONSTANTS.managementStatusAndEffectiveness.payloadType
 
 const ManagementStatusAndEffectivenessForm = () => {
   const { monitoringFormId } = useParams()
@@ -74,6 +76,7 @@ const ManagementStatusAndEffectivenessForm = () => {
 
   useInitializeMonitoringForm({
     apiUrl: monitoringFormSingularUrl,
+    formType,
     isEditMode,
     questionMapping: questionMapping.managementStatusAndEffectiveness,
     resetForm,
@@ -114,7 +117,7 @@ const ManagementStatusAndEffectivenessForm = () => {
     setIsSubmitError(false)
 
     const payload = {
-      form_type: MONITORING_FORM_TYPES.managementStatusAndEffectiveness,
+      form_type: formType,
       answers: mapDataForApi('managementStatusAndEffectiveness', formData)
     }
 

--- a/mrtt-ui/src/components/SocioeconomicAndGovernance/SocioeconomicAndGovernanceStatusAndOutcomesForm.js
+++ b/mrtt-ui/src/components/SocioeconomicAndGovernance/SocioeconomicAndGovernanceStatusAndOutcomesForm.js
@@ -40,11 +40,13 @@ import { multiselectWithOtherValidationNoMinimum } from '../../validation/multiS
 import { socioIndicators } from '../../data/socio_indicator'
 import { findDataItem } from '../../library/findDataItem'
 import SocioeconomicOutcomesRow from './socioeconomicOutcomesRow'
-import MONITORING_FORM_TYPES from '../../constants/monitoringFormTypes'
 import useInitializeMonitoringForm from '../../library/useInitializeMonitoringForm'
+import MONITORING_FORM_CONSTANTS from '../../constants/monitoringFormConstants'
 
 const getSocioeconomicAims = (registrationAnswersFromServer) =>
   findDataItem(registrationAnswersFromServer, '3.2') ?? []
+
+const formType = MONITORING_FORM_CONSTANTS.socioeconomicGovernanceStatusAndOutcomes.payloadType
 
 const SocioeconomicAndGovernanceStatusAndOutcomesForm = () => {
   const navigate = useNavigate()
@@ -141,11 +143,13 @@ const SocioeconomicAndGovernanceStatusAndOutcomesForm = () => {
 
   useInitializeMonitoringForm({
     apiUrl: monitoringFormSingularUrl,
+    formType,
     isEditMode,
     questionMapping: questionMapping.socioeconomicAndGovernanceStatusAndOutcomes,
     resetForm,
     setIsLoading: setIsMainFormDataLoading
   })
+
   const createNewMonitoringForm = (payload) => {
     axios
       .post(monitoringFormsUrl, payload)
@@ -166,7 +170,6 @@ const SocioeconomicAndGovernanceStatusAndOutcomesForm = () => {
       .put(monitoringFormSingularUrl, payload)
       .then(() => {
         setIsSubmitting(false)
-        toast.success(language.success.submit)
         toast.success(language.success.getEditThingSuccessMessage('This form'))
       })
       .catch(() => {
@@ -181,7 +184,7 @@ const SocioeconomicAndGovernanceStatusAndOutcomesForm = () => {
     setIsSubmitError(false)
 
     const payload = {
-      form_type: MONITORING_FORM_TYPES.socioeconomicGovernanceStatusAndOutcomes,
+      form_type: formType,
       answers: mapDataForApi('socioeconomicAndGovernanceStatusAndOutcomes', formData)
     }
 

--- a/mrtt-ui/src/constants/monitoringFormConstants.js
+++ b/mrtt-ui/src/constants/monitoringFormConstants.js
@@ -1,0 +1,25 @@
+import language from '../language'
+
+const { formName: formNames } = language.pages.siteQuestionsOverview
+
+const MONITORING_FORM_CONSTANTS = {
+  ecologicalStatusAndOutcomes: {
+    payloadType: 'ecologicalStatusAndOutcomes',
+    label: formNames.ecologicalStatusOutcomes,
+    urlSegment: 'ecological-status-and-outcomes'
+  },
+  managementStatusAndEffectiveness: {
+    payloadType: 'managementStatusAndEffectiveness',
+    label: formNames.managementStatusAndEffectiveness,
+    urlSegment: 'management-status-and-effectiveness'
+  },
+  socioeconomicGovernanceStatusAndOutcomes: {
+    payloadType: 'socioeconomicGovernanceStatusAndOutcomes',
+    label: formNames.socioeconomicGovernanceStatusOutcomes,
+    urlSegment: 'socioeconomic-and-governance-status'
+  }
+}
+
+Object.freeze(MONITORING_FORM_CONSTANTS)
+
+export default MONITORING_FORM_CONSTANTS

--- a/mrtt-ui/src/constants/monitoringFormTypes.js
+++ b/mrtt-ui/src/constants/monitoringFormTypes.js
@@ -1,8 +1,0 @@
-const MONITORING_FORM_TYPES = {
-  ecologicalStatusAndOutcomes: 'ecologicalStatusAndOutcomes',
-  managementStatusAndEffectiveness: 'managementStatusAndEffectiveness',
-  socioeconomicGovernanceStatusAndOutcomes: 'socioeconomicGovernanceStatusAndOutcomes'
-}
-
-Object.freeze(MONITORING_FORM_TYPES)
-export default MONITORING_FORM_TYPES

--- a/mrtt-ui/src/language.js
+++ b/mrtt-ui/src/language.js
@@ -159,7 +159,8 @@ const pages = {
       socioeconomicGovernanceStatusOutcomes: 'Socioeconomic and Governance Status and Outcomes',
       ecologicalStatusOutcomes: 'Ecological Status and Outcomes'
     },
-    addMonitoringSectionButton: 'Add Monitoring Section'
+    addMonitoringSectionButton: 'Add Monitoring Section',
+    noMonitoringSections: "You don't have any monitoring sections for this site yet."
   }
 }
 

--- a/mrtt-ui/src/library/useInitializeMonitoringForm.js
+++ b/mrtt-ui/src/library/useInitializeMonitoringForm.js
@@ -7,10 +7,11 @@ import language from '../language'
 
 const useInitializeMonitoringForm = ({
   apiUrl,
+  formType,
+  isEditMode = false,
   questionMapping,
   resetForm,
-  setIsLoading,
-  isEditMode = false
+  setIsLoading
 }) => {
   useEffect(
     function initializeFormWithApiData() {
@@ -18,10 +19,16 @@ const useInitializeMonitoringForm = ({
         setIsLoading(true)
         axios
           .get(apiUrl)
-          .then((response) => {
+          .then(({ data }) => {
+            const formTypeInResponse = data.form_type
+            if (formType !== formTypeInResponse) {
+              throw new Error(
+                'Monitoring data is being accessed with the wrong form component for the form type'
+              )
+            }
             setIsLoading(false)
             const initialValuesForForm = formatApiAnswersForForm({
-              apiAnswers: response.data.answers,
+              apiAnswers: data.answers,
               questionMapping
             })
             resetForm(initialValuesForForm)
@@ -32,7 +39,7 @@ const useInitializeMonitoringForm = ({
           })
       }
     },
-    [apiUrl, isEditMode, questionMapping, resetForm, setIsLoading]
+    [apiUrl, isEditMode, questionMapping, resetForm, setIsLoading, formType]
   )
 }
 

--- a/mrtt-ui/src/styles/table.js
+++ b/mrtt-ui/src/styles/table.js
@@ -25,3 +25,6 @@ export const TdCenter = styled('td')`
 export const ThCenter = styled('th')`
   text-align: center;
 `
+export const WideTh = styled('th')`
+  width: 100%;
+`

--- a/mrtt-ui/src/views/SiteQuestionsOverview/AddMonitoringSectionMenu.js
+++ b/mrtt-ui/src/views/SiteQuestionsOverview/AddMonitoringSectionMenu.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Menu, MenuItem, Stack } from '@mui/material'
+import { Menu, MenuItem, Stack, styled } from '@mui/material'
 import { ButtonPrimary } from '../../styles/buttons'
 import language from '../../language'
 import { ArrowDropDown } from '@mui/icons-material'
@@ -7,6 +7,10 @@ import { Link } from '../../styles/typography'
 import PropTypes from 'prop-types'
 
 const pageLanguage = language.pages.siteQuestionsOverview
+
+const StackWithMarginBottom = styled(Stack)`
+  margin-bottom: 1em;
+`
 
 const AddMonitoringSectionMenu = ({ siteId }) => {
   const [menuAnchorElement, setMenuAnchorElement] = React.useState(null)
@@ -19,7 +23,7 @@ const AddMonitoringSectionMenu = ({ siteId }) => {
   }
 
   return (
-    <Stack>
+    <StackWithMarginBottom>
       <ButtonPrimary
         id='add-monitoring-section-button'
         aria-controls={isMenuOpen ? 'add-monitoring-section-menu' : undefined}
@@ -53,7 +57,7 @@ const AddMonitoringSectionMenu = ({ siteId }) => {
           </Link>
         </MenuItem>
       </Menu>
-    </Stack>
+    </StackWithMarginBottom>
   )
 }
 

--- a/mrtt-ui/src/views/SiteQuestionsOverview/MonitoringFormsList.js
+++ b/mrtt-ui/src/views/SiteQuestionsOverview/MonitoringFormsList.js
@@ -1,0 +1,43 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import MONITORING_FORM_CONSTANTS from '../../constants/monitoringFormConstants'
+import { RowSpaceBetween } from '../../styles/containers'
+import { TableAlertnatingRows, WideTh } from '../../styles/table'
+import { Link, SmallUpperCase } from '../../styles/typography'
+
+const MonitoringFormsList = ({ monitoringFormsSortedByDate, siteId }) => {
+  return (
+    <TableAlertnatingRows>
+      <tbody>
+        {monitoringFormsSortedByDate.map(({ id: formId, form_type, monitoring_date }) => {
+          const formLabel = MONITORING_FORM_CONSTANTS[form_type].label
+          const formUrl = `/sites/${siteId}/form/${MONITORING_FORM_CONSTANTS[form_type].urlSegment}/${formId}`
+          return (
+            <tr key={formId}>
+              <WideTh>
+                <RowSpaceBetween>
+                  <Link to={formUrl}>{formLabel}</Link>
+                  <SmallUpperCase>{monitoring_date}</SmallUpperCase>
+                </RowSpaceBetween>
+              </WideTh>
+            </tr>
+          )
+        })}
+      </tbody>
+    </TableAlertnatingRows>
+  )
+}
+
+MonitoringFormsList.propTypes = {
+  monitoringFormsSortedByDate: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string,
+      form_type: PropTypes.string,
+      monitoring_date: PropTypes.string
+    })
+  ).isRequired,
+  siteId: PropTypes.string.isRequired
+}
+
+export default MonitoringFormsList


### PR DESCRIPTION
-  shows a list of monitoring forms in the site summary page sorted by date
- clicking on a monitoring form link brings you to the form page to edit it.

to test:
- create a new site
- go to site summary
- under the monitoring form button, there is a message saying that there are no forms yet
- create a bunch of forms
- go back to the site summary page, see the forms
- click on them to edit them.

