### PR TITLE
Feature/75 delete monitoring form

### DIFF
--- a/mrtt-ui/src/components/ButtonDeleteForm.js
+++ b/mrtt-ui/src/components/ButtonDeleteForm.js
@@ -1,0 +1,31 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { styled } from '@mui/system'
+import language from '../language'
+import themeMui from '../styles/themeMui'
+import ButtonSecondaryWithLoader from './ButtonSecondaryWithLoader'
+
+const StyledButton = styled(ButtonSecondaryWithLoader)`
+  margin-top: ${themeMui.spacing(3)};
+`
+
+const ButtonDeleteForm = ({ isDeleting, ...restOfProps }) => {
+  return (
+    <StyledButton
+      isHolding={isDeleting}
+      holdingContent={language.buttons.deleting}
+      {...restOfProps}>
+      {language.form.deleteForm}
+    </StyledButton>
+  )
+}
+
+ButtonDeleteForm.propTypes = {
+  isDeleting: PropTypes.bool
+}
+
+ButtonDeleteForm.defaultProps = {
+  isDeleting: false
+}
+
+export default ButtonDeleteForm

--- a/mrtt-ui/src/components/ButtonDeleteForm.js
+++ b/mrtt-ui/src/components/ButtonDeleteForm.js
@@ -3,9 +3,9 @@ import PropTypes from 'prop-types'
 import { styled } from '@mui/system'
 import language from '../language'
 import themeMui from '../styles/themeMui'
-import ButtonSecondaryWithLoader from './ButtonSecondaryWithLoader'
+import { ButtonCaution } from '../styles/buttons'
 
-const StyledButton = styled(ButtonSecondaryWithLoader)`
+const StyledButton = styled(ButtonCaution)`
   margin-top: ${themeMui.spacing(3)};
 `
 

--- a/mrtt-ui/src/components/EcologicalStatusAndOutcomes/EcologicalStatusAndOutcomesForm.js
+++ b/mrtt-ui/src/components/EcologicalStatusAndOutcomes/EcologicalStatusAndOutcomesForm.js
@@ -32,6 +32,8 @@ import CheckboxGroupWithLabelAndController from '../CheckboxGroupWithLabelAndCon
 import { multiselectWithOtherValidationNoMinimum } from '../../validation/multiSelectWithOther'
 import { findDataItem } from '../../library/findDataItem'
 import MONITORING_FORM_CONSTANTS from '../../constants/monitoringFormConstants'
+import ButtonDeleteForm from '../ButtonDeleteForm'
+import ConfirmPrompt from '../ConfirmPrompt/ConfirmPrompt'
 
 const getBiophysicalInterventions = (registrationAnswersFromServer) =>
   findDataItem(registrationAnswersFromServer, '6.2') ?? []
@@ -86,6 +88,8 @@ const EcologicalStatusAndOutcomesForm = () => {
     useState(false)
   const [biophysicalInterventions, setBiophysicalInterventions] = useState([])
   const mangroveConditionImprovementWatcher = watchForm('mangroveConditionImprovement')
+  const [isDeleting, setIsDeleting] = useState(false)
+  const [isDeleteConfirmPromptOpen, setIsDeleteConfirmPromptOpen] = useState(false)
 
   useEffect(
     function loadBiophysicalInterventions() {
@@ -156,6 +160,25 @@ const EcologicalStatusAndOutcomesForm = () => {
     } else {
       createNewMonitoringForm(payload)
     }
+  }
+
+  const handleDeleteConfirm = () => {
+    setIsDeleting(true)
+    axios
+      .delete(monitoringFormSingularUrl)
+      .then(() => {
+        setIsDeleting(false)
+        toast.success(language.success.getDeleteThingSuccessMessage('That form'))
+        navigate(`/sites/${siteId}/overview`)
+      })
+      .catch(() => {
+        toast.error(language.error.delete)
+        setIsDeleting(false)
+      })
+  }
+
+  const handleDeleteClick = () => {
+    setIsDeleteConfirmPromptOpen(true)
   }
 
   return isMainFormDataLoading || areBiophysicalInterventionsLoading ? (
@@ -384,6 +407,15 @@ const EcologicalStatusAndOutcomesForm = () => {
           <ErrorText>{errors.achievementOfEcologicalAims?.message}</ErrorText>
         </FormQuestionDiv>
       </Form>
+      {isEditMode ? <ButtonDeleteForm onClick={handleDeleteClick} isDeleting={isDeleting} /> : null}
+      <ConfirmPrompt
+        isOpen={isDeleteConfirmPromptOpen}
+        setIsOpen={setIsDeleteConfirmPromptOpen}
+        title={language.form.deletePrompt.title}
+        promptText={language.form.deletePrompt.promptText}
+        confirmButtonText={language.form.deletePrompt.buttonText}
+        onConfirm={handleDeleteConfirm}
+      />
     </ContentWrapper>
   )
 }

--- a/mrtt-ui/src/components/ManagementStatusAndEffectiveness/ManagementStatusAndEffectivenessForm.js
+++ b/mrtt-ui/src/components/ManagementStatusAndEffectiveness/ManagementStatusAndEffectivenessForm.js
@@ -25,6 +25,8 @@ import { mapDataForApi } from '../../library/mapDataForApi'
 import { questionMapping } from '../../data/questionMapping'
 import FormValidationMessageIfErrors from '../FormValidationMessageIfErrors'
 import MONITORING_FORM_CONSTANTS from '../../constants/monitoringFormConstants'
+import ButtonDeleteForm from '../ButtonDeleteForm'
+import ConfirmPrompt from '../ConfirmPrompt/ConfirmPrompt'
 
 const formType = MONITORING_FORM_CONSTANTS.managementStatusAndEffectiveness.payloadType
 
@@ -73,6 +75,8 @@ const ManagementStatusAndEffectivenessForm = () => {
   const managementStatusChangesWatcher = watchForm('managementStatusChanges')
   const projectStatusChangeWatcher = watchForm('projectStatusChange')
   const financeForCiteManagementWatcher = watchForm('financeForCiteManagement')
+  const [isDeleting, setIsDeleting] = useState(false)
+  const [isDeleteConfirmPromptOpen, setIsDeleteConfirmPromptOpen] = useState(false)
 
   useInitializeMonitoringForm({
     apiUrl: monitoringFormSingularUrl,
@@ -126,6 +130,25 @@ const ManagementStatusAndEffectivenessForm = () => {
     } else {
       createNewMonitoringForm(payload)
     }
+  }
+
+  const handleDeleteConfirm = () => {
+    setIsDeleting(true)
+    axios
+      .delete(monitoringFormSingularUrl)
+      .then(() => {
+        setIsDeleting(false)
+        toast.success(language.success.getDeleteThingSuccessMessage('That form'))
+        navigate(`/sites/${siteId}/overview`)
+      })
+      .catch(() => {
+        toast.error(language.error.delete)
+        setIsDeleting(false)
+      })
+  }
+
+  const handleDeleteClick = () => {
+    setIsDeleteConfirmPromptOpen(true)
   }
 
   return isLoading ? (
@@ -408,6 +431,15 @@ const ManagementStatusAndEffectivenessForm = () => {
           <ErrorText>{errors.climateChangeAdaptation?.message}</ErrorText>
         </FormQuestionDiv>
       </Form>
+      {isEditMode ? <ButtonDeleteForm onClick={handleDeleteClick} isDeleting={isDeleting} /> : null}
+      <ConfirmPrompt
+        isOpen={isDeleteConfirmPromptOpen}
+        setIsOpen={setIsDeleteConfirmPromptOpen}
+        title={language.form.deletePrompt.title}
+        promptText={language.form.deletePrompt.promptText}
+        confirmButtonText={language.form.deletePrompt.buttonText}
+        onConfirm={handleDeleteConfirm}
+      />
     </ContentWrapper>
   )
 }

--- a/mrtt-ui/src/components/SocioeconomicAndGovernance/SocioeconomicAndGovernanceStatusAndOutcomesForm.js
+++ b/mrtt-ui/src/components/SocioeconomicAndGovernance/SocioeconomicAndGovernanceStatusAndOutcomesForm.js
@@ -42,6 +42,8 @@ import { findDataItem } from '../../library/findDataItem'
 import SocioeconomicOutcomesRow from './socioeconomicOutcomesRow'
 import useInitializeMonitoringForm from '../../library/useInitializeMonitoringForm'
 import MONITORING_FORM_CONSTANTS from '../../constants/monitoringFormConstants'
+import ButtonDeleteForm from '../ButtonDeleteForm'
+import ConfirmPrompt from '../ConfirmPrompt/ConfirmPrompt'
 
 const getSocioeconomicAims = (registrationAnswersFromServer) =>
   findDataItem(registrationAnswersFromServer, '3.2') ?? []
@@ -116,6 +118,8 @@ const SocioeconomicAndGovernanceStatusAndOutcomesForm = () => {
   const [socioeconomicAims, setSocioeconomicAims] = useState([])
   const [isMainFormDataLoading, setIsMainFormDataLoading] = useState(false)
   const [areSociologicalAimsLoading, setAreSociologicalAimsLoading] = useState(false)
+  const [isDeleting, setIsDeleting] = useState(false)
+  const [isDeleteConfirmPromptOpen, setIsDeleteConfirmPromptOpen] = useState(false)
 
   useEffect(
     function loadSocioeconomicAims() {
@@ -193,6 +197,25 @@ const SocioeconomicAndGovernanceStatusAndOutcomesForm = () => {
     } else {
       createNewMonitoringForm(payload)
     }
+  }
+
+  const handleDeleteConfirm = () => {
+    setIsDeleting(true)
+    axios
+      .delete(monitoringFormSingularUrl)
+      .then(() => {
+        setIsDeleting(false)
+        toast.success(language.success.getDeleteThingSuccessMessage('That form'))
+        navigate(`/sites/${siteId}/overview`)
+      })
+      .catch(() => {
+        toast.error(language.error.delete)
+        setIsDeleting(false)
+      })
+  }
+
+  const handleDeleteClick = () => {
+    setIsDeleteConfirmPromptOpen(true)
   }
 
   const getSocioEconomicFieldsIndex = (indicator) =>
@@ -435,6 +458,15 @@ const SocioeconomicAndGovernanceStatusAndOutcomesForm = () => {
           <ErrorText>{errors.achievementOfSocioeconomicAims?.message}</ErrorText>
         </FormQuestionDiv>
       </Form>
+      {isEditMode ? <ButtonDeleteForm onClick={handleDeleteClick} isDeleting={isDeleting} /> : null}
+      <ConfirmPrompt
+        isOpen={isDeleteConfirmPromptOpen}
+        setIsOpen={setIsDeleteConfirmPromptOpen}
+        title={language.form.deletePrompt.title}
+        promptText={language.form.deletePrompt.promptText}
+        confirmButtonText={language.form.deletePrompt.buttonText}
+        onConfirm={handleDeleteConfirm}
+      />
     </ContentWrapper>
   )
 }

--- a/mrtt-ui/src/language.js
+++ b/mrtt-ui/src/language.js
@@ -33,6 +33,12 @@ const form = {
   validationAlert: {
     title: 'The form was not saved',
     description: 'Please check the form below for validation errors'
+  },
+  deleteForm: 'Delete Form',
+  deletePrompt: {
+    title: 'Delete Form: ',
+    promptText: 'Are you sure you want to delete this form?',
+    buttonText: 'Yes, delete this form'
   }
 }
 

--- a/mrtt-ui/src/styles/buttons.js
+++ b/mrtt-ui/src/styles/buttons.js
@@ -1,7 +1,9 @@
 import { Button } from '@mui/material'
 import { styled } from '@mui/system'
 import PropTypes from 'prop-types'
+import ButtonSecondaryWithLoader from '../components/ButtonSecondaryWithLoader'
 import language from '../language'
+import theme from './theme'
 
 const ButtonPrimary = styled(Button)``
 ButtonPrimary.defaultProps = { variant: 'contained' }
@@ -17,6 +19,12 @@ const ButtonSubmit = ({ isSubmitting }) => {
   )
 }
 
+const ButtonCaution = styled(ButtonSecondaryWithLoader)`
+  background-color: ${theme.color.red};
+  &:hover {
+    background-color: ${theme.color.lightRed};
+  }
+`
 ButtonSubmit.propTypes = {
   isSubmitting: PropTypes.bool.isRequired
 }
@@ -25,4 +33,4 @@ const ButtonCancel = (props) => (
   <ButtonSecondary {...props}>{language.buttons.cancel}</ButtonSecondary>
 )
 
-export { ButtonPrimary, ButtonSubmit, ButtonSecondary, ButtonCancel }
+export { ButtonPrimary, ButtonSubmit, ButtonSecondary, ButtonCancel, ButtonCaution }

--- a/mrtt-ui/src/styles/theme.js
+++ b/mrtt-ui/src/styles/theme.js
@@ -12,7 +12,8 @@ const color = {
   slub: '#333333D9',
   text: '#000000D9',
   white: '#ffffff',
-  red: '#B20000'
+  red: '#B20000',
+  lightRed: '#D00000'
 }
 
 const form = {

--- a/mrtt-ui/src/views/LandscapeForm.js
+++ b/mrtt-ui/src/views/LandscapeForm.js
@@ -8,11 +8,10 @@ import axios from 'axios'
 import PropTypes from 'prop-types'
 import React, { useEffect, useState } from 'react'
 
-import { ButtonCancel, ButtonSubmit } from '../styles/buttons'
+import { ButtonCancel, ButtonCaution, ButtonSubmit } from '../styles/buttons'
 import { ButtonContainer, PaddedSection, RowFlexEnd, ContentWrapper } from '../styles/containers'
 import { ErrorText, PageTitle } from '../styles/typography'
 import { Form } from '../styles/forms'
-import ButtonSecondaryWithLoader from '../components/ButtonSecondaryWithLoader'
 import ConfirmPrompt from '../components/ConfirmPrompt/ConfirmPrompt'
 import ItemDoesntExist from '../components/ItemDoesntExist'
 import language from '../language'
@@ -229,13 +228,13 @@ const LandscapeForm = ({ isNewLandscape }) => {
           <p>{language.pages.landscapeForm.noAssociatedSites}</p>
         )}
         <div>
-          <ButtonSecondaryWithLoader
+          <ButtonCaution
             disabled={isAssociatedSites}
             onClick={handleDeleteClick}
             isHolding={isDeleting}
             holdingContent={language.buttons.deleting}>
             {language.pages.landscapeForm.delete}
-          </ButtonSecondaryWithLoader>
+          </ButtonCaution>
         </div>
       </PaddedSection>
       <ConfirmPrompt


### PR DESCRIPTION
delete monitoring forms

To test:
- create some forms
- delete each of three types (button in each form at bottom)
- see the confirm prompt
- notice the 'Deleting...' status text on the button (prob too fast to see)
- a success toast shows and the app is navigated back to the site overview page
