### PR TITLE
feat: [237] forgot password and reset password workflow

### DIFF
--- a/mrtt-ui/src/App.js
+++ b/mrtt-ui/src/App.js
@@ -28,6 +28,8 @@ import SocioeconomicAndGovernanceStatusAndOutcomesForm from './components/Socioe
 import EcologicalStatusAndOutcomesForm from './components/EcologicalStatusAndOutcomes/EcologicalStatusAndOutcomesForm'
 import ManageOrganizationUsers from './views/ManageOrganizationUsers'
 import NewOrganizationUser from './views/NewOrganizationUser'
+import ForgotPasswordForm from './views/Auth/ForgotPasswordForm'
+import ResetPasswordForm from './views/Auth/ResetPasswordForm'
 
 function App() {
   return (
@@ -114,6 +116,8 @@ function App() {
             <Route path='/auth/signup' element={<SignupForm />} />
             <Route path='/auth/login' element={<LoginForm />} />
             <Route path='/auth/login/newUser' element={<LoginForm isUserNew={true} />} />
+            <Route path='auth/forgot-password' element={<ForgotPasswordForm />} />
+            <Route path='auth/password/reset/' element={<ResetPasswordForm />} />
           </Routes>
         </GlobalLayout>
       </Router>

--- a/mrtt-ui/src/language.js
+++ b/mrtt-ui/src/language.js
@@ -50,17 +50,40 @@ const multiselectWithOtherFormQuestion = {
 }
 
 const pages = {
+  login: {
+    title: 'Login',
+    email: 'Email',
+    password: 'Password',
+    signUp: 'Sign Up',
+    forgotPassowrd: 'Forgot Password'
+  },
   userSignUp: {
     confirmPassword: 'Re-type password',
     email: 'Email',
     name: 'Name',
     password: 'Password',
-    title: 'SIGN-UP',
+    title: 'Sign Up',
     validation: {
       emailValid: 'Must be a valid email',
       passwordMinimumCharacters: 'Password must be at the minimum 8 characters long',
       passwordsMustMatch: 'Passwords must match'
     }
+  },
+  resetPassword: {
+    confirmPassword: 'Re-type  new password',
+    password: ' New password',
+    success: 'Your password has been reset. Please use it to log in.',
+    title: 'Reset Password',
+    validation: {
+      passwordMinimumCharacters: 'Password must be at the minimum 8 characters long',
+      passwordsMustMatch: 'Passwords must match'
+    }
+  },
+  forgotPassword: {
+    title: 'Forgot Password',
+    email: 'Email',
+    success:
+      'Your request has been submitted. If you have an account with that email address, you will receive an email with further instructions.'
   },
   organizations: {
     manageUsers: 'Manage users',

--- a/mrtt-ui/src/views/Auth/ForgotPasswordForm.js
+++ b/mrtt-ui/src/views/Auth/ForgotPasswordForm.js
@@ -1,0 +1,79 @@
+import { Controller, useForm } from 'react-hook-form'
+import { FormLabel, TextField } from '@mui/material'
+import { toast } from 'react-toastify'
+import { useState } from 'react'
+import { yupResolver } from '@hookform/resolvers/yup'
+import * as yup from 'yup'
+import axios from 'axios'
+
+import { ButtonContainer, ContentWrapper, RowFlexEnd } from '../../styles/containers'
+import { ButtonSubmit } from '../../styles/buttons'
+import { ErrorText, LinkLooksLikeButtonSecondary, PageTitle } from '../../styles/typography'
+import { Form } from '../../styles/forms'
+import language from '../../language'
+import RequiredIndicator from '../../components/RequiredIndicator'
+
+const validationSchema = yup.object({
+  email: yup.string().email().required(language.form.required)
+})
+
+const formDefaultValues = { email: '' }
+
+const passwordUrl = `${process.env.REACT_APP_AUTH_URL}/users/password`
+
+const pageLanguage = language.pages.forgotPassword
+
+const ForgotPasswordForm = () => {
+  const [isSubmitError, setIsSubmitError] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const {
+    control: formControl,
+    handleSubmit: validateInputs,
+    formState: { errors }
+  } = useForm({ resolver: yupResolver(validationSchema), defaultValues: formDefaultValues })
+
+  const handleSubmit = (formData) => {
+    setIsSubmitting(true)
+    setIsSubmitError(false)
+
+    axios
+      .post(passwordUrl, { user: formData })
+      .then(() => {
+        setIsSubmitting(false)
+        toast.success(pageLanguage.success)
+      })
+      .catch(() => {
+        setIsSubmitting(false)
+        setIsSubmitError(true)
+        toast.error(language.error.generic)
+      })
+  }
+
+  return (
+    <ContentWrapper>
+      <PageTitle>{pageLanguage.title}</PageTitle>
+      <Form onSubmit={validateInputs(handleSubmit)}>
+        <FormLabel htmlFor='email'>
+          {pageLanguage.email}
+          <RequiredIndicator />
+        </FormLabel>
+        <Controller
+          name='email'
+          control={formControl}
+          render={({ field }) => <TextField {...field} id='email' />}
+        />
+        <ErrorText>{errors?.email?.message}</ErrorText>
+        <RowFlexEnd>{isSubmitError && <ErrorText>{language.error.submit}</ErrorText>}</RowFlexEnd>
+        <ButtonContainer>
+          <LinkLooksLikeButtonSecondary to={-1}>
+            {language.buttons.cancel}
+          </LinkLooksLikeButtonSecondary>
+          <ButtonSubmit isSubmitting={isSubmitting} />
+        </ButtonContainer>
+      </Form>
+    </ContentWrapper>
+  )
+}
+
+export default ForgotPasswordForm

--- a/mrtt-ui/src/views/Auth/LoginForm.js
+++ b/mrtt-ui/src/views/Auth/LoginForm.js
@@ -10,13 +10,12 @@ import PropTypes from 'prop-types'
 import { Alert, FormLabel, TextField } from '@mui/material'
 import { ButtonCancel, ButtonSubmit } from '../../styles/buttons'
 import { ButtonContainer, PagePadding, RowFlexEnd } from '../../styles/containers'
-import { ErrorText, PageTitle } from '../../styles/typography'
+import { ErrorText, LinkLooksLikeButtonSecondary, PageTitle } from '../../styles/typography'
 import { Form, MainFormDiv } from '../../styles/forms'
-import Button from '@mui/material/Button'
+import { useAuth } from '../../hooks/useAuth'
 import language from '../../language'
 import LoadingIndicator from '../../components/LoadingIndicator'
-
-import { useAuth } from '../../hooks/useAuth'
+import RequiredIndicator from '../../components/RequiredIndicator'
 
 const validationSchema = yup.object({
   email: yup.string().required('Email required'),
@@ -24,6 +23,8 @@ const validationSchema = yup.object({
 })
 
 const formDefaultValues = { email: '', password: '' }
+
+const pageLanguage = language.pages.login
 
 const LoginForm = ({ isUserNew }) => {
   const [isLoading] = useState(false)
@@ -75,21 +76,25 @@ const LoginForm = ({ isUserNew }) => {
     navigate(-1)
   }
 
-  const handleSignUpOnClick = () => {
-    navigate('/auth/signup')
-  }
-
   const form = (
     <MainFormDiv>
       <PagePadding>
-        <PageTitle>Login</PageTitle>
+        <PageTitle>{pageLanguage.title}</PageTitle>
         {isUserNew ? (
           <Alert variant='outlined' severity='success'>
             {language.success.signup}
           </Alert>
         ) : null}
+        <RowFlexEnd>
+          <LinkLooksLikeButtonSecondary to='/auth/forgot-password'>
+            {pageLanguage.forgotPassowrd}
+          </LinkLooksLikeButtonSecondary>
+        </RowFlexEnd>
         <Form onSubmit={validateInputs(handleSubmit)}>
-          <FormLabel htmlFor='email'>Email* </FormLabel>
+          <FormLabel htmlFor='email'>
+            {pageLanguage.email}
+            <RequiredIndicator />
+          </FormLabel>
           <Controller
             name='email'
             control={formControl}
@@ -97,7 +102,10 @@ const LoginForm = ({ isUserNew }) => {
           />
           <ErrorText>{errors?.email?.message}</ErrorText>
 
-          <FormLabel htmlFor='password'>Password* </FormLabel>
+          <FormLabel htmlFor='password'>
+            {pageLanguage.password}
+            <RequiredIndicator />
+          </FormLabel>
           <Controller
             name='password'
             control={formControl}
@@ -106,9 +114,9 @@ const LoginForm = ({ isUserNew }) => {
           <ErrorText>{errors?.password?.message}</ErrorText>
           <RowFlexEnd>{isSubmitError && <ErrorText>{language.error.submit}</ErrorText>}</RowFlexEnd>
           <ButtonContainer>
-            <Button variant='text' onClick={handleSignUpOnClick}>
-              Sign Up
-            </Button>
+            <LinkLooksLikeButtonSecondary to='/auth/signup'>
+              {pageLanguage.signUp}
+            </LinkLooksLikeButtonSecondary>
             <ButtonCancel onClick={handleCancelClick} />
             <ButtonSubmit isSubmitting={isSubmitting} />
           </ButtonContainer>

--- a/mrtt-ui/src/views/Auth/ResetPasswordForm.js
+++ b/mrtt-ui/src/views/Auth/ResetPasswordForm.js
@@ -1,0 +1,107 @@
+import { Controller, useForm } from 'react-hook-form'
+import { FormLabel, TextField } from '@mui/material'
+import { toast } from 'react-toastify'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+import { useState } from 'react'
+import { yupResolver } from '@hookform/resolvers/yup'
+import * as yup from 'yup'
+import axios from 'axios'
+
+import { ButtonContainer, RowFlexEnd, ContentWrapper } from '../../styles/containers'
+import { ButtonSubmit } from '../../styles/buttons'
+import { ErrorText, PageTitle } from '../../styles/typography'
+import { Form } from '../../styles/forms'
+import language from '../../language'
+import RequiredIndicator from '../../components/RequiredIndicator'
+
+const pageLanguage = language.pages.resetPassword
+
+const validationSchema = yup.object({
+  password: yup
+    .string()
+    .required(language.form.required)
+    .min(8, pageLanguage.validation.passwordMinimumCharacters),
+  confirmationPassword: yup
+    .string()
+    .required(language.form.required)
+    .oneOf([yup.ref('password')], pageLanguage.validation.passwordsMustMatch)
+})
+
+const formDefaultValues = { password: '', confirmationPassword: '' }
+
+const passwordUrl = `${process.env.REACT_APP_AUTH_URL}/users/password`
+
+const ResetPasswordForm = () => {
+  const [searchParams] = useSearchParams()
+  const [isSubmitError, setIsSubmitError] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const navigate = useNavigate()
+
+  const {
+    control: formControl,
+    handleSubmit: validateInputs,
+    formState: { errors }
+  } = useForm({ resolver: yupResolver(validationSchema), defaultValues: formDefaultValues })
+
+  const handleSubmit = ({ password, confirmationPassword }) => {
+    axios
+      .put(passwordUrl, {
+        user: {
+          password,
+          password_confirmation: confirmationPassword,
+          reset_password_token: searchParams.get('token')
+        }
+      })
+      .then((response) => {
+        if (response.data.message === 'The password was reset successfully') {
+          setIsSubmitting(false)
+          toast.success(pageLanguage.success)
+          navigate('/auth/login')
+        } else {
+          throw new Error('This didnt work. Your token probably expired.')
+        }
+      })
+      .catch(() => {
+        setIsSubmitting(false)
+        setIsSubmitError(true)
+        toast.error(language.error.generic)
+      })
+  }
+
+  return (
+    <ContentWrapper>
+      <PageTitle>{pageLanguage.title}</PageTitle>
+      <Form onSubmit={validateInputs(handleSubmit)}>
+        <FormLabel htmlFor='password'>
+          {pageLanguage.password}
+          <RequiredIndicator />
+        </FormLabel>
+        <Controller
+          name='password'
+          control={formControl}
+          render={({ field }) => <TextField {...field} id='password' type='password' />}
+        />
+        <ErrorText>{errors?.password?.message}</ErrorText>
+
+        <FormLabel htmlFor='confirmation-password'>
+          {pageLanguage.confirmPassword}
+          <RequiredIndicator />
+        </FormLabel>
+        <Controller
+          name='confirmationPassword'
+          control={formControl}
+          render={({ field }) => (
+            <TextField {...field} id='confirmation-password' type='password' />
+          )}
+        />
+        <ErrorText>{errors?.confirmationPassword?.message}</ErrorText>
+        <RowFlexEnd>{isSubmitError && <ErrorText>{language.error.submit}</ErrorText>}</RowFlexEnd>
+        <ButtonContainer>
+          <ButtonSubmit isSubmitting={isSubmitting} />
+        </ButtonContainer>
+      </Form>
+    </ContentWrapper>
+  )
+}
+
+export default ResetPasswordForm


### PR DESCRIPTION
# Description

2 Pages:
- forgot password
- reset password

closes # (246)



How to test:
- click the forgot password link on the sign in page

Forgot Password Page:
- leave the email input in the reset password form blank. Hit submit. There should be a validation message saying the input is required.
- fill out the reset password form with something that is not an email. Click submit. There should be a validation message blocking submit.
- fill out the reset password form with an email you actually have access too and have signed up to MRTT with. Click submit
- The app should show a toast saying stuff about checking your email.

Reset Password Page:
- click the link in the email. It will link to a url to a served app somewhere. Change the base url to your localhost in the url bar. 
- click the submit button with empty fields. both inputs should have 'required' validation messages
- click submit with each field having different text. there should be a validation message that the passwords dont match. 
- fill out the passwords to be less than 8 chars. Hit submit. See validation message for that.
- change the token in the url to anything (http://localhost:3000/auth/password/reset?token=bstoken), fill out the fields to match. There should be a error toast and an error message above the submit button
- fill out the passwords to be valid and matching. Click submit.
-  the app should show a success toast and navigate to the login page.

Post Reset Login
- try logging in with the new password. It shoudl suceed. 
- if it doesnt and the error message in your browser console mentions email verification, you may need to search your email for an email from previous times for that. (I found mine on Sep 16, if that helps). Click the verification link in your email. 


