### PR TITLE
feat: [274] add info/warning text for questions the rely on the answers to other form's questions

### DIFF
--- a/mrtt-ui/src/App.js
+++ b/mrtt-ui/src/App.js
@@ -116,7 +116,7 @@ function App() {
             <Route path='/auth/signup' element={<SignupForm />} />
             <Route path='/auth/login' element={<LoginForm />} />
             <Route path='/auth/login/newUser' element={<LoginForm isUserNew={true} />} />
-            <Route path='auth/forgot-password' element={<ForgotPasswordForm />} />
+            <Route path='auth/password/forgot-password' element={<ForgotPasswordForm />} />
             <Route path='auth/password/reset/' element={<ResetPasswordForm />} />
           </Routes>
         </GlobalLayout>

--- a/mrtt-ui/src/components/Costs/CostsForm.js
+++ b/mrtt-ui/src/components/Costs/CostsForm.js
@@ -5,7 +5,7 @@ import * as yup from 'yup'
 import axios from 'axios'
 import { toast } from 'react-toastify'
 import { Controller, useForm, useFieldArray } from 'react-hook-form'
-import { Box, Button, MenuItem, TextField } from '@mui/material'
+import { Alert, Box, Button, MenuItem, TextField } from '@mui/material'
 
 import {
   Form,
@@ -406,7 +406,7 @@ const CostsForm = () => {
                     updateItem={updatePercentageSplitOfActivities}></PercentageSplitOfActivitiesRow>
                 ))
               ) : (
-                <ErrorText>{`No interventions selected in 6.2a & 6.4`}</ErrorText>
+                <Alert severity='info'>{language.pages.costs.missingInterventionsWarning}</Alert>
               )}
             </FormQuestionDiv>
           </div>

--- a/mrtt-ui/src/components/RestorationAimsForm/RestorationAimsForm.js
+++ b/mrtt-ui/src/components/RestorationAimsForm/RestorationAimsForm.js
@@ -23,6 +23,7 @@ import QuestionNav from '../QuestionNav'
 import RestorationAimsCheckboxGroupWithLabel from './RestorationAimsCheckboxGroupWithLabel'
 import useInitializeQuestionMappedForm from '../../library/useInitializeQuestionMappedForm'
 import useSiteInfo from '../../library/useSiteInfo'
+import { Alert } from '@mui/material'
 
 const getStakeholders = (registrationAnswersFromServer) =>
   registrationAnswersFromServer?.data.find((dataItem) => dataItem.question_id === '2.1')
@@ -35,6 +36,7 @@ const RestorationAimsForm = () => {
   const { site_name } = useSiteInfo()
   const { siteId } = useParams()
   const apiAnswersUrl = `${process.env.REACT_APP_API_URL}/sites/${siteId}/registration_intervention_answers`
+  const areThereStakeholders = !!stakeholders.length
   const validationSchema = yup.object({
     ecologicalAims: multiselectWithOtherValidation,
     socioEconomicAims: multiselectWithOtherValidation,
@@ -82,6 +84,10 @@ const RestorationAimsForm = () => {
       })
   }
 
+  const noStakeholdersWarning = (
+    <Alert severity='info'>{language.pages.restorationAims.missingStakeholdersWarning}</Alert>
+  )
+
   return isLoading ? (
     <LoadingIndicator />
   ) : (
@@ -99,6 +105,7 @@ const RestorationAimsForm = () => {
       <FormValidationMessageIfErrors formErrors={errors} />
       <Form onSubmit={validateInputs(handleSubmit)}>
         <FormQuestionDiv>
+          {!areThereStakeholders ? noStakeholdersWarning : null}
           <RestorationAimsCheckboxGroupWithLabel
             stakeholders={stakeholders}
             fieldName='ecologicalAims'
@@ -110,6 +117,7 @@ const RestorationAimsForm = () => {
           <ErrorText>{errors.ecologicalAims?.selectedValues?.message}</ErrorText>
         </FormQuestionDiv>
         <FormQuestionDiv>
+          {!areThereStakeholders ? noStakeholdersWarning : null}
           <RestorationAimsCheckboxGroupWithLabel
             stakeholders={stakeholders}
             fieldName='socioEconomicAims'
@@ -121,6 +129,7 @@ const RestorationAimsForm = () => {
           <ErrorText>{errors.socioEconomicAims?.selectedValues?.message}</ErrorText>
         </FormQuestionDiv>
         <FormQuestionDiv>
+          {!areThereStakeholders ? noStakeholdersWarning : null}
           <RestorationAimsCheckboxGroupWithLabel
             stakeholders={stakeholders}
             fieldName='otherAims'

--- a/mrtt-ui/src/components/SocioeconomicAndGovernance/SocioeconomicOutcomesRow.js
+++ b/mrtt-ui/src/components/SocioeconomicAndGovernance/SocioeconomicOutcomesRow.js
@@ -1,6 +1,15 @@
 import { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
-import { Box, Checkbox, List, ListItem, MenuItem, TextField, Typography } from '@mui/material'
+import {
+  Alert,
+  Box,
+  Checkbox,
+  List,
+  ListItem,
+  MenuItem,
+  TextField,
+  Typography
+} from '@mui/material'
 
 import { TabularSectionDiv, TabularLabel, TabularInputSection } from '../../styles/forms'
 import {
@@ -8,7 +17,7 @@ import {
   TrendOptions,
   TypeOptions
 } from '../../data/socioeconomicOutcomesOptions'
-import { ErrorText } from '../../styles/typography'
+import language from '../../language'
 
 const SocioeconomicOutcomesRow = ({
   outcome,
@@ -214,7 +223,9 @@ const SocioeconomicOutcomesRow = ({
               ))}
             </List>
           ) : (
-            <ErrorText>Please select aims in 3.2</ErrorText>
+            <Alert severity='info'>
+              {language.pages.socioeconomicGovernanceStatusOutcomes.missingSocioeconomicAims}
+            </Alert>
           )}
         </TabularInputSection>
       </Box>

--- a/mrtt-ui/src/language.js
+++ b/mrtt-ui/src/language.js
@@ -57,6 +57,17 @@ const pages = {
     signUp: 'Sign Up',
     forgotPassowrd: 'Forgot Password'
   },
+  socioeconomicGovernanceStatusOutcomes: {
+    missingSocioeconomicAims: 'Please select aims from question 3.2 in the Restoration Aims form'
+  },
+  costs: {
+    missingInterventionsWarning:
+      'Please select interventions from question 6.2a and 6.4 in the Site Interventions form'
+  },
+  restorationAims: {
+    missingStakeholdersWarning:
+      'In order to rank the importance of aims, questions 2.1 will need to be filled out in the Site Background form.'
+  },
   userSignUp: {
     confirmPassword: 'Re-type password',
     email: 'Email',

--- a/mrtt-ui/src/views/Auth/LoginForm.js
+++ b/mrtt-ui/src/views/Auth/LoginForm.js
@@ -86,7 +86,7 @@ const LoginForm = ({ isUserNew }) => {
           </Alert>
         ) : null}
         <RowFlexEnd>
-          <LinkLooksLikeButtonSecondary to='/auth/forgot-password'>
+          <LinkLooksLikeButtonSecondary to='/auth/password/forgot-password'>
             {pageLanguage.forgotPassowrd}
           </LinkLooksLikeButtonSecondary>
         </RowFlexEnd>

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "husky": "^7.0.0"
       },
       "engines": {
-        "node": ">=16.15.0"
+        "node": "~16.15.0"
       }
     },
     "node_modules/husky": {


### PR DESCRIPTION
To test:

- Create a new site. 
- Go to Restoration Aims. Note each question has blue alert text.
- Go to Costs form. Check monetary in 7.1. Scroll to 7.5a. Note the blue alert text.
- Go to Socioeconomic ... form , check something in 9.4. Note blue alert text in 9.4a

