### PR TITLE
feat: [318] update new org user error and page text.

### DIFF
--- a/mrtt-ui/src/language.js
+++ b/mrtt-ui/src/language.js
@@ -175,18 +175,12 @@ const pages = {
   },
   newOrganizationUser: {
     backToUsers: 'Back to users',
-    description: (
-      <>
-        If the new user is already a member, they will be added to this organization. If the user is
-        not a member, they will be added automatically after they register at{' '}
-        <a href='#'>PLACEHOLDER</a>
-      </>
-    ),
+    description: 'Only users that have signed up can be added to organizations.',
     email: "New user's email address",
     getTitle: (organization) => `New User for ${organization}`,
     getUserAdded: ({ userName, organizationName }) =>
       `The user, ${userName}, has been added to ${organizationName}`,
-    getUserDoesntExist: (userName) => `The user, ${userName}, does not exist.`,
+    getUserDoesntExist: (userName) => `The user, ${userName}, is not registered.`,
     orgAdmin: 'Admin',
     orgUser: 'User',
     role: 'Role'

--- a/mrtt-ui/src/views/NewOrganizationUser.js
+++ b/mrtt-ui/src/views/NewOrganizationUser.js
@@ -75,7 +75,7 @@ const NewOrganizationUser = () => {
         if (error.response.data.error === 'Record not found') {
           setFormError('email', {
             type: 'custom',
-            message: pageLanguage.error.getUserDoesntExist(formData.email)
+            message: pageLanguage.getUserDoesntExist(formData.email)
           })
         }
       })


### PR DESCRIPTION
**To Test: ** 
- go to new org user form (organizations, manage users, new user). User2 will have orgs they can manage
- make up an email that definitely isnt registeres and enter it
- click submit
- if working, there should be error text under the input saying that user isnt registered.

Also the text under role instructs that an unregistered user cant be added.
