### PR TITLE
Feature/298 make dates display utc

### DIFF
--- a/mrtt-ui/README.md
+++ b/mrtt-ui/README.md
@@ -33,6 +33,7 @@ The project board for this work can be found [here](https://github.com/Vizzualit
 - a convienience custom hook is used to load _most_ data for a given form.
   - for forms 1-7, `mrtt-ui/src/library/useInitializeQuestionMappedFormjs`. This hook calls a provided callback function with the server response for supplimental form data parsing.
   - for forms 8-10, `mrtt-ui/src/library/useInitializeMonitoringForm.js`. This hook to-date does not include a callback because those forms happened not to need it.
+- A date picker was created using MUI and Luxon to display and save all dates in UTC. Any timestamps saved should be ignored as false precision. `mrtt-ui/src/components/DatePickerUtcMui.js`
 
 ## Setting Up and Running a Development Environment
 

--- a/mrtt-ui/package-lock.json
+++ b/mrtt-ui/package-lock.json
@@ -31,6 +31,7 @@
         "axios": "^0.27.2",
         "date-fns": "^2.28.0",
         "geojson-prop-types": "^0.2.0",
+        "luxon": "^2.5.0",
         "mapbox-gl": "^2.8.2",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
@@ -24333,6 +24334,14 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.5.0.tgz",
+      "integrity": "sha512-IDkEPB80Rb6gCAU+FEib0t4FeJ4uVOuX1CQ9GsvU3O+JAGIgu0J7sf1OarXKaKDygTZIoJyU6YdZzTFRu+YR0A==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/lz-string": {
@@ -52506,6 +52515,11 @@
       "requires": {
         "yallist": "^4.0.0"
       }
+    },
+    "luxon": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-2.5.0.tgz",
+      "integrity": "sha512-IDkEPB80Rb6gCAU+FEib0t4FeJ4uVOuX1CQ9GsvU3O+JAGIgu0J7sf1OarXKaKDygTZIoJyU6YdZzTFRu+YR0A=="
     },
     "lz-string": {
       "version": "1.4.4",

--- a/mrtt-ui/package.json
+++ b/mrtt-ui/package.json
@@ -26,6 +26,7 @@
     "axios": "^0.27.2",
     "date-fns": "^2.28.0",
     "geojson-prop-types": "^0.2.0",
+    "luxon": "^2.5.0",
     "mapbox-gl": "^2.8.2",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/mrtt-ui/src/components/DatePickerUtcMui.js
+++ b/mrtt-ui/src/components/DatePickerUtcMui.js
@@ -6,11 +6,15 @@ import { Stack, TextField } from '@mui/material'
 import PropTypes from 'prop-types'
 import React from 'react'
 
+import { TextSmall } from '../styles/typography'
+import language from '../language'
+
 const DatePickerUtcMui = (props) => {
   const value = props.field?.value ? DateTime.fromISO(props.field?.value).setZone('UTC+0') : null
   return (
     <LocalizationProvider dateAdapter={AdapterLuxon}>
       <Stack spacing={3}>
+        <TextSmall>{language.form.dateUtc}</TextSmall>
         <MobileDatePicker
           inputFormat='yyyy/MM/dd'
           onChange={(luxonDate) => {

--- a/mrtt-ui/src/components/DatePickerUtcMui.js
+++ b/mrtt-ui/src/components/DatePickerUtcMui.js
@@ -1,0 +1,32 @@
+import { AdapterLuxon } from '@mui/x-date-pickers/AdapterLuxon'
+import { DateTime } from 'luxon'
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider'
+import { MobileDatePicker } from '@mui/x-date-pickers/MobileDatePicker'
+import { Stack, TextField } from '@mui/material'
+import PropTypes from 'prop-types'
+import React from 'react'
+
+const DatePickerUtcMui = (props) => {
+  const value = props.field?.value ? DateTime.fromISO(props.field?.value).setZone('UTC+0') : null
+  return (
+    <LocalizationProvider dateAdapter={AdapterLuxon}>
+      <Stack spacing={3}>
+        <MobileDatePicker
+          inputFormat='yyyy/MM/dd'
+          onChange={(luxonDate) => {
+            props.field?.onChange(luxonDate?.toISO())
+          }}
+          renderInput={(params) => <TextField {...params} />}
+          value={value}
+          {...props}
+        />
+      </Stack>
+    </LocalizationProvider>
+  )
+}
+
+DatePickerUtcMui.propTypes = {
+  field: PropTypes.shape({ onChange: PropTypes.func, value: PropTypes.string })
+}
+
+export default DatePickerUtcMui

--- a/mrtt-ui/src/components/EcologicalStatusAndOutcomes/EcologicalStatusAndOutcomesForm.js
+++ b/mrtt-ui/src/components/EcologicalStatusAndOutcomes/EcologicalStatusAndOutcomesForm.js
@@ -4,19 +4,8 @@ import { yupResolver } from '@hookform/resolvers/yup'
 import * as yup from 'yup'
 import axios from 'axios'
 import { toast } from 'react-toastify'
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns'
-import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider'
-import { MobileDatePicker } from '@mui/x-date-pickers/MobileDatePicker'
 import { Controller, useForm, useFieldArray } from 'react-hook-form'
-import {
-  Box,
-  Checkbox,
-  FormControlLabel,
-  ListItem,
-  MenuItem,
-  Stack,
-  TextField
-} from '@mui/material'
+import { Box, Checkbox, FormControlLabel, ListItem, MenuItem, TextField } from '@mui/material'
 
 import {
   Form,
@@ -45,6 +34,7 @@ import { monitoringIndicators } from '../../data/monitoringIndicators'
 import ButtonDeleteForm from '../ButtonDeleteForm'
 import ConfirmPrompt from '../ConfirmPrompt/ConfirmPrompt'
 import EcologicalOutcomesRow from './EcologicalOutcomesRow'
+import DatePickerUtcMui from '../DatePickerUtcMui'
 
 const getEcologicalAims = (registrationAnswersFromServer) =>
   findDataItem(registrationAnswersFromServer, '3.1') ?? []
@@ -303,19 +293,11 @@ const EcologicalStatusAndOutcomesForm = () => {
             control={control}
             defaultValue={null}
             render={({ field }) => (
-              <LocalizationProvider dateAdapter={AdapterDateFns} {...field} ref={null}>
-                <Stack spacing={3}>
-                  <MobileDatePicker
-                    id='monitoring-start-date'
-                    label='Monitoring start date'
-                    value={field.value}
-                    onChange={(newValue) => {
-                      field.onChange(newValue?.toISOString())
-                    }}
-                    renderInput={(params) => <TextField {...params} />}
-                  />
-                </Stack>
-              </LocalizationProvider>
+              <DatePickerUtcMui
+                id='monitoring-start-date'
+                label='Monitoring start date'
+                field={field}
+              />
             )}
           />
           <ErrorText>{errors.monitoringStartDate?.message}</ErrorText>
@@ -325,19 +307,11 @@ const EcologicalStatusAndOutcomesForm = () => {
               control={control}
               defaultValue={null}
               render={({ field }) => (
-                <LocalizationProvider dateAdapter={AdapterDateFns} {...field} ref={null}>
-                  <Stack spacing={3}>
-                    <MobileDatePicker
-                      id='monitoring-end-date'
-                      label='Monitoring end date'
-                      value={field.value}
-                      onChange={(newValue) => {
-                        field.onChange(newValue?.toISOString())
-                      }}
-                      renderInput={(params) => <TextField {...params} />}
-                    />
-                  </Stack>
-                </LocalizationProvider>
+                <DatePickerUtcMui
+                  id='monitoring-end-date'
+                  label='Monitoring end date'
+                  field={field}
+                />
               )}
             />
             <ErrorText>{errors.monitoringEndDate?.message}</ErrorText>

--- a/mrtt-ui/src/components/ManagementStatusAndEffectiveness/ManagementStatusAndEffectivenessForm.js
+++ b/mrtt-ui/src/components/ManagementStatusAndEffectiveness/ManagementStatusAndEffectivenessForm.js
@@ -5,10 +5,7 @@ import * as yup from 'yup'
 import axios from 'axios'
 import { toast } from 'react-toastify'
 import { Controller, useForm } from 'react-hook-form'
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns'
-import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider'
-import { MobileDatePicker } from '@mui/x-date-pickers/MobileDatePicker'
-import { Box, MenuItem, Stack, TextField } from '@mui/material'
+import { Box, MenuItem, TextField } from '@mui/material'
 
 import { Form, FormPageHeader, FormQuestionDiv, StickyFormLabel } from '../../styles/forms'
 import { ContentWrapper } from '../../styles/containers'
@@ -27,6 +24,7 @@ import FormValidationMessageIfErrors from '../FormValidationMessageIfErrors'
 import MONITORING_FORM_CONSTANTS from '../../constants/monitoringFormConstants'
 import ButtonDeleteForm from '../ButtonDeleteForm'
 import ConfirmPrompt from '../ConfirmPrompt/ConfirmPrompt'
+import DatePickerUtcMui from '../DatePickerUtcMui'
 
 const formType = MONITORING_FORM_CONSTANTS.managementStatusAndEffectiveness.payloadType
 
@@ -177,19 +175,7 @@ const ManagementStatusAndEffectivenessForm = () => {
             control={control}
             defaultValue={''}
             render={({ field }) => (
-              <LocalizationProvider dateAdapter={AdapterDateFns} {...field} ref={null}>
-                <Stack spacing={3}>
-                  <MobileDatePicker
-                    id='date-of-assessment'
-                    label='date'
-                    value={field.value}
-                    onChange={(newValue) => {
-                      field.onChange(newValue?.toISOString())
-                    }}
-                    renderInput={(params) => <TextField {...params} />}
-                  />
-                </Stack>
-              </LocalizationProvider>
+              <DatePickerUtcMui id='date-of-assessment' label='date' field={field} />
             )}
           />
           <ErrorText>{errors.dateOfAssessment?.message}</ErrorText>

--- a/mrtt-ui/src/components/ProjectDetailsForm.js
+++ b/mrtt-ui/src/components/ProjectDetailsForm.js
@@ -1,16 +1,13 @@
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns'
-import { FormControlLabel, Radio, RadioGroup, Stack, TextField } from '@mui/material'
-import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider'
-import { MobileDatePicker } from '@mui/x-date-pickers/MobileDatePicker'
+import { FormControlLabel, Radio, RadioGroup, TextField } from '@mui/material'
 import { useForm, Controller } from 'react-hook-form'
 import { useState } from 'react'
 import { yupResolver } from '@hookform/resolvers/yup'
 import * as yup from 'yup'
 import Autocomplete from '@mui/material/Autocomplete'
 import axios from 'axios'
-import turfConvex from '@turf/convex'
 import turfBbox from '@turf/bbox'
 import turfBboxPolygon from '@turf/bbox-polygon'
+import turfConvex from '@turf/convex'
 
 import { ContentWrapper } from '../styles/containers'
 import { ErrorText, PageSubtitle, PageTitle } from '../styles/typography'
@@ -30,6 +27,7 @@ import QuestionNav from './QuestionNav'
 import RequiredIndicator from './RequiredIndicator'
 import useInitializeQuestionMappedForm from '../library/useInitializeQuestionMappedForm'
 import useSiteInfo from '../library/useSiteInfo'
+import DatePickerUtcMui from './DatePickerUtcMui'
 
 const sortCountries = (a, b) => {
   const textA = a.properties.country.toUpperCase()
@@ -81,8 +79,8 @@ function ProjectDetailsForm() {
     resolver: yupResolver(validationSchema),
     defaultValues: {
       hasProjectEndDate: false,
-      projectStartDate: undefined,
-      projectEndDate: undefined,
+      projectStartDate: null,
+      projectEndDate: null,
       countries: undefined,
       siteArea: emptyFeatureCollection
     }
@@ -180,22 +178,7 @@ function ProjectDetailsForm() {
           <Controller
             name='projectStartDate'
             control={control}
-            defaultValue={new Date().toISOString()}
-            render={({ field }) => (
-              <LocalizationProvider dateAdapter={AdapterDateFns} {...field} ref={null}>
-                <Stack spacing={3}>
-                  <MobileDatePicker
-                    id='start-date'
-                    label='date'
-                    value={field.value}
-                    onChange={(newValue) => {
-                      field.onChange(newValue?.toISOString())
-                    }}
-                    renderInput={(params) => <TextField {...params} />}
-                  />
-                </Stack>
-              </LocalizationProvider>
-            )}
+            render={({ field }) => <DatePickerUtcMui id='start-date' label='date' field={field} />}
           />
           <ErrorText>{errors.projectStartDate?.message}</ErrorText>
         </FormQuestionDiv>
@@ -230,21 +213,7 @@ function ProjectDetailsForm() {
             <Controller
               name='projectEndDate'
               control={control}
-              render={({ field }) => (
-                <LocalizationProvider dateAdapter={AdapterDateFns} {...field} ref={null}>
-                  <Stack spacing={3}>
-                    <MobileDatePicker
-                      id='end-date'
-                      label='date'
-                      value={field.value}
-                      onChange={(newValue) => {
-                        field.onChange(newValue?.toISOString())
-                      }}
-                      renderInput={(params) => <TextField {...params} />}
-                    />
-                  </Stack>
-                </LocalizationProvider>
-              )}
+              render={({ field }) => <DatePickerUtcMui id='end-date' label='date' field={field} />}
             />
             <ErrorText>{errors.projectEndDate?.message}</ErrorText>
           </FormQuestionDiv>

--- a/mrtt-ui/src/components/SiteInterventions/SiteInterventionsForm.js
+++ b/mrtt-ui/src/components/SiteInterventions/SiteInterventionsForm.js
@@ -8,14 +8,10 @@ import {
   ListItemText,
   MenuItem,
   Select,
-  Stack,
   TextField,
   Typography
 } from '@mui/material'
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns'
 import { Controller, useForm, useFieldArray } from 'react-hook-form'
-import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider'
-import { MobileDatePicker } from '@mui/x-date-pickers/MobileDatePicker'
 import { styled } from '@mui/material/styles'
 import { toast } from 'react-toastify'
 import { useParams } from 'react-router-dom'
@@ -43,6 +39,7 @@ import QuestionNav from '../QuestionNav'
 import useInitializeQuestionMappedForm from '../../library/useInitializeQuestionMappedForm'
 import useSiteInfo from '../../library/useSiteInfo'
 import organizeMangroveSpeciesList from '../../library/organizeMangroveSpeciesList'
+import DatePickerUtcMui from '../DatePickerUtcMui'
 
 const getWhichStakeholdersInvolved = (registrationAnswersFromServer) =>
   findDataItem(registrationAnswersFromServer, '6.1') ?? []
@@ -390,19 +387,11 @@ function SiteInterventionsForm() {
                   control={control}
                   defaultValue={null}
                   render={({ field }) => (
-                    <LocalizationProvider dateAdapter={AdapterDateFns} {...field} ref={null}>
-                      <Stack spacing={3}>
-                        <MobileDatePicker
-                          id='start-date'
-                          label='Intervention start date'
-                          value={field.value}
-                          onChange={(newValue) => {
-                            field.onChange(newValue?.toISOString())
-                          }}
-                          renderInput={(params) => <TextField {...params} />}
-                        />
-                      </Stack>
-                    </LocalizationProvider>
+                    <DatePickerUtcMui
+                      id='start-date'
+                      label='Intervention start date'
+                      field={field}
+                    />
                   )}
                 />
               </InnerFormDiv>
@@ -412,19 +401,7 @@ function SiteInterventionsForm() {
                   control={control}
                   defaultValue={null}
                   render={({ field }) => (
-                    <LocalizationProvider dateAdapter={AdapterDateFns} {...field} ref={null}>
-                      <Stack spacing={3}>
-                        <MobileDatePicker
-                          id='end-date'
-                          label='Intervention end date'
-                          value={field.value}
-                          onChange={(newValue) => {
-                            field.onChange(newValue?.toISOString())
-                          }}
-                          renderInput={(params) => <TextField {...params} />}
-                        />
-                      </Stack>
-                    </LocalizationProvider>
+                    <DatePickerUtcMui id='end-date' label='Intervention end date' field={field} />
                   )}
                 />
               </InnerFormDiv>

--- a/mrtt-ui/src/components/SocioeconomicAndGovernance/SocioeconomicAndGovernanceStatusAndOutcomesForm.js
+++ b/mrtt-ui/src/components/SocioeconomicAndGovernance/SocioeconomicAndGovernanceStatusAndOutcomesForm.js
@@ -4,19 +4,9 @@ import { yupResolver } from '@hookform/resolvers/yup'
 import * as yup from 'yup'
 import axios from 'axios'
 import { toast } from 'react-toastify'
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns'
-import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider'
-import { MobileDatePicker } from '@mui/x-date-pickers/MobileDatePicker'
+
 import { Controller, useForm, useFieldArray } from 'react-hook-form'
-import {
-  Box,
-  Checkbox,
-  FormControlLabel,
-  ListItem,
-  MenuItem,
-  Stack,
-  TextField
-} from '@mui/material'
+import { Box, Checkbox, FormControlLabel, ListItem, MenuItem, TextField } from '@mui/material'
 
 import {
   Form,
@@ -44,6 +34,7 @@ import useInitializeMonitoringForm from '../../library/useInitializeMonitoringFo
 import MONITORING_FORM_CONSTANTS from '../../constants/monitoringFormConstants'
 import ButtonDeleteForm from '../ButtonDeleteForm'
 import ConfirmPrompt from '../ConfirmPrompt/ConfirmPrompt'
+import DatePickerUtcMui from '../DatePickerUtcMui'
 
 const getSocioeconomicAims = (registrationAnswersFromServer) =>
   findDataItem(registrationAnswersFromServer, '3.2') ?? []
@@ -290,19 +281,7 @@ const SocioeconomicAndGovernanceStatusAndOutcomesForm = () => {
             control={control}
             defaultValue={null}
             render={({ field }) => (
-              <LocalizationProvider dateAdapter={AdapterDateFns} {...field} ref={null}>
-                <Stack spacing={3}>
-                  <MobileDatePicker
-                    id='date-of-outcomes-assessment'
-                    label='date'
-                    value={field.value}
-                    onChange={(newValue) => {
-                      field.onChange(newValue?.toISOString())
-                    }}
-                    renderInput={(params) => <TextField {...params} />}
-                  />
-                </Stack>
-              </LocalizationProvider>
+              <DatePickerUtcMui id='date-of-outcomes-assessment' label='date' field={field} />
             )}
           />
           <ErrorText>{errors.dateOfOutcomesAssessment?.message}</ErrorText>

--- a/mrtt-ui/src/language.js
+++ b/mrtt-ui/src/language.js
@@ -39,7 +39,8 @@ const form = {
     title: 'Delete Form: ',
     promptText: 'Are you sure you want to delete this form?',
     buttonText: 'Yes, delete this form'
-  }
+  },
+  dateUtc: 'Dates are UTC'
 }
 
 const multiselectWithOtherFormQuestion = {

--- a/mrtt-ui/src/styles/typography.js
+++ b/mrtt-ui/src/styles/typography.js
@@ -39,6 +39,9 @@ export const XSmallUpperCase = styled('div')`
   text-transform: uppercase;
   font-size: ${theme.typography.xsmallFontSize};
 `
+export const TextSmall = styled('div')`
+  font-size: ${theme.typography.smallFontSize};
+`
 
 export const ItemTitle = styled('h3')`
   margin: 0;


### PR DESCRIPTION
**Background:** MUI detects a UTC time stamp (or time stamp with no time) and tries to show it in browser local time. So if you look at the same date from Japan or California, it will render as different days. See original ticket for more examples: https://github.com/globalmangrovewatch/gmw-users/issues/298

Big thanks to @ghelobytes for unblocking this!!!! 🎉 

~~There is no way to tell MUI date pickers not to do that and to show the date/time in the original form.~~

~~**Description of hack to make MUI date picker display UTC:**~~
- ~~Date comes from server in timeless ISO format (yyyy-mm-dd)~~
- ~~MUI wants to show that date in local time so removes whatever the offset for the browser timezone is. So the ui adds some fake offset for MUI to feel good about removing, and remaining date is displayed in the ui as the same date on the server.~~
- ~~User edits date.~~
- ~~User saves form. We need to remove the added offset again so the server gets UTC. Here we also remove the time component from the date.~~


~~**Question for devs:**
- ~~while this code technically works with my dev QA, _should_ we use it? Is it worth the complexity/maintenance/future bug costs?~~


~~If we proceed, I would update the rest of the dates in the app to behave similarly.~~
