### PR TITLE
Chore: feedback cleanup

### DIFF
--- a/mrtt-ui/src/App.js
+++ b/mrtt-ui/src/App.js
@@ -17,7 +17,7 @@ import RestorationAimsForm from './components/RestorationAimsForm/RestorationAim
 import PreRestorationAssessmentForm from './components/PreRestorationAssessment/PreRestorationAssessmentForm'
 import SignupForm from './views/Auth/SignupForm'
 import SiteBackgroundForm from './components/SiteBackgroundForm'
-import SiteInterventionsForm from './components/SiteInterventions/SiteInterventions'
+import SiteInterventionsForm from './components/SiteInterventions/SiteInterventionsForm'
 import SiteForm from './views/SiteForm'
 import SiteQuestionsOverview from './views/SiteQuestionsOverview/SiteQuestionsOverview'
 import Sites from './views/Sites'

--- a/mrtt-ui/src/components/Costs/CostsForm.js
+++ b/mrtt-ui/src/components/Costs/CostsForm.js
@@ -5,7 +5,7 @@ import * as yup from 'yup'
 import axios from 'axios'
 import { toast } from 'react-toastify'
 import { Controller, useForm, useFieldArray } from 'react-hook-form'
-import { Alert, Box, Button, MenuItem, TextField } from '@mui/material'
+import { Alert, Box, Button, MenuItem, TextField, Typography } from '@mui/material'
 
 import {
   Form,
@@ -136,6 +136,8 @@ const CostsForm = () => {
   const supportForActivitiesWatcher = watchForm('supportForActivities')
   const [showAddTabularInputRow, setShowAddTabularInputRow] = useState(false)
   const [hasEndDate, setHasEndDate] = useState(false)
+  const costOfProjectActivitiesWatcher = watchForm('costOfProjectActivities')
+  const breakdownOfCostWatcher = watchForm('breakdownOfCost')
 
   const loadServerData = useCallback(
     (serverResponse) => {
@@ -143,12 +145,12 @@ const CostsForm = () => {
       if (endDateResponse) setHasEndDate(true)
 
       const defaultProjectActivities = [
-        { costType: 'Project planning & management' },
-        { costType: 'Biophysical interventions' },
-        { costType: 'Community activities' },
-        { costType: 'Site maintenance' },
-        { costType: 'Monitoring' },
-        { costType: 'Other costs' }
+        { costType: 'Project planning & management', cost: 0 },
+        { costType: 'Biophysical interventions', cost: 0 },
+        { costType: 'Community activities', cost: 0 },
+        { costType: 'Site maintenance', cost: 0 },
+        { costType: 'Monitoring', cost: 0 },
+        { costType: 'Other costs', cost: 0 }
       ]
 
       const breakdownOfCostInitialVal = getBreakdownOfCost(serverResponse)
@@ -256,6 +258,20 @@ const CostsForm = () => {
     const currentItem = percentageSplitOfActivitiesFields[index]
     currentItem.percentage = percentage
     percentageSplitOfActivitiesUpdate(index, currentItem)
+  }
+
+  const isSumOfBreakdownLessOrEqualToTotalCost = () => {
+    const totalCost = Number(costOfProjectActivitiesWatcher?.cost)
+    const costs = breakdownOfCostWatcher.map((item) => Number(item.cost))
+    const sum = costs.reduce((previousValue, currentValue) => previousValue + currentValue, 0)
+    return sum <= totalCost ? true : false
+  }
+
+  const sumOfBreakdownActivties = () => {
+    const costs = breakdownOfCostWatcher.map((item) => Number(item.cost))
+    return costs
+      .reduce((previousValue, currentValue) => previousValue + currentValue, 0)
+      .toLocaleString()
   }
 
   return isLoading ? (
@@ -393,6 +409,10 @@ const CostsForm = () => {
                       updateItem={updateBreakdownOfCostItem}></BreakdownOfCostRow>
                   ))
                 : null}
+              <Typography>Total: {sumOfBreakdownActivties()}</Typography>
+              {isSumOfBreakdownLessOrEqualToTotalCost() ? null : (
+                <ErrorText>Breakdown of activities must not exceed total cost in 7.4</ErrorText>
+              )}
             </FormQuestionDiv>
             <FormQuestionDiv>
               <StickyFormLabel>{questions.percentageSplitOfActivities.question}</StickyFormLabel>

--- a/mrtt-ui/src/components/Costs/CostsForm.js
+++ b/mrtt-ui/src/components/Costs/CostsForm.js
@@ -41,7 +41,7 @@ const getBreakdownOfCost = (registrationAnswersFromServer) =>
   findDataItem(registrationAnswersFromServer, '7.5') ?? []
 
 const getBiophysicalInterventions = (registrationAnswersFromServer) =>
-  findDataItem(registrationAnswersFromServer, '6.2a') ?? []
+  findDataItem(registrationAnswersFromServer, '6.2') ?? []
 
 const getOtherActivitiesImplemented = (registrationAnswersFromServer) =>
   findDataItem(registrationAnswersFromServer, '6.4') ?? []
@@ -168,10 +168,8 @@ const CostsForm = () => {
         let otherInterventionActivities = []
         let combinedInterventions = []
 
-        if (biophysicalInterventionsInitialVal.length) {
-          interventionTypes = biophysicalInterventionsInitialVal.map(
-            (item) => item.interventionType
-          )
+        if (biophysicalInterventionsInitialVal.selectedValues.length) {
+          interventionTypes = biophysicalInterventionsInitialVal.selectedValues
         }
         if (otherActivitiesImplementedInitialVal.selectedValues?.length) {
           otherInterventionActivities = otherActivitiesImplementedInitialVal.selectedValues

--- a/mrtt-ui/src/components/PreRestorationAssessment/PhysicalMeasurementRow.js
+++ b/mrtt-ui/src/components/PreRestorationAssessment/PhysicalMeasurementRow.js
@@ -6,11 +6,12 @@ import ConfirmPrompt from '../ConfirmPrompt/ConfirmPrompt'
 import language from '../../language'
 
 import {
+  HorizontalTabularBox,
   LeftColumnDiv,
   RowTextField,
+  TabularInputSection,
   TabularLabel,
-  VerticalTabularBox,
-  VerticalTabularInputSection
+  VerticalTabularBox
 } from '../../styles/forms'
 
 const PhysicalMeasurementRow = ({ label, value, unit, index, deleteItem, updateItem }) => {
@@ -46,7 +47,7 @@ const PhysicalMeasurementRow = ({ label, value, unit, index, deleteItem, updateI
   }
 
   return (
-    <VerticalTabularInputSection>
+    <TabularInputSection>
       <VerticalTabularBox>
         <LeftColumnDiv>
           <TabularLabel>{label}</TabularLabel>
@@ -60,20 +61,21 @@ const PhysicalMeasurementRow = ({ label, value, unit, index, deleteItem, updateI
             onConfirm={handleDelete}
           />
         </LeftColumnDiv>
-        <VerticalTabularBox>
+        <HorizontalTabularBox>
           <RowTextField
             value={currentValue}
             label='value'
             onBlur={handleUpdate}
             onChange={(e) => setCurrentValue(e.target.value)}></RowTextField>
           <RowTextField
+            sx={{ marginLeft: '0.5em', width: '7em' }}
             value={currentUnit}
             label='unit'
             onBlur={handleUpdate}
             onChange={(e) => setCurrentUnit(e.target.value)}></RowTextField>
-        </VerticalTabularBox>
+        </HorizontalTabularBox>
       </VerticalTabularBox>
-    </VerticalTabularInputSection>
+    </TabularInputSection>
   )
 }
 

--- a/mrtt-ui/src/components/PreRestorationAssessment/PreRestorationAssessmentForm.js
+++ b/mrtt-ui/src/components/PreRestorationAssessment/PreRestorationAssessmentForm.js
@@ -28,7 +28,7 @@ import {
 import { ContentWrapper } from '../../styles/containers'
 import { ErrorText, PageSubtitle, PageTitle } from '../../styles/typography'
 import { findDataItem } from '../../library/findDataItem'
-import { mangroveSpeciesPerCountryList } from '../../data/mangroveSpeciesPerCountry'
+// import { mangroveSpeciesPerCountryList } from '../../data/mangroveSpeciesPerCountry'
 import { mapDataForApi } from '../../library/mapDataForApi'
 import { multiselectWithOtherValidationNoMinimum } from '../../validation/multiSelectWithOther'
 import { preRestorationAssessment as questions } from '../../data/questions'
@@ -43,6 +43,7 @@ import useInitializeQuestionMappedForm from '../../library/useInitializeQuestion
 import useSiteInfo from '../../library/useSiteInfo'
 import RequiredIndicator from '../RequiredIndicator'
 import FormValidationMessageIfErrors from '../FormValidationMessageIfErrors'
+import organizeMangroveSpeciesList from '../../library/organizeMangroveSpeciesList'
 
 const getSiteCountries = (registrationAnswersFromServer) =>
   findDataItem(registrationAnswersFromServer, '1.2') ?? []
@@ -161,36 +162,9 @@ function PreRestorationAssessmentForm() {
       const siteCountriesResponse = getSiteCountries(serverResponse)
 
       if (siteCountriesResponse.length) {
-        const countriesList = siteCountriesResponse.map(
-          (countryItem) => countryItem.properties.country
-        )
-        // mangroveSpeciesPresent list should display country specific species at the top, with all
-        // species below the country specific list, removing duplicates from the second list
-        const allSpecies = []
-        const countrySelectedSpecies = []
-        let countrySelectedSpeciesWithAllSpecies = []
-        countriesList.forEach((countrySelected) => {
-          mangroveSpeciesPerCountryList.forEach((countryItem) => {
-            if (countryItem.country.name === countrySelected) {
-              countrySelectedSpecies.push(...countryItem.species)
-            }
-            allSpecies.push(...countryItem.species)
-          })
-        })
-        const uniqueCountrySelectedSpecies = [...new Set(countrySelectedSpecies)]
-        uniqueCountrySelectedSpecies.sort()
-        const uniqueAllSpecies = [...new Set(allSpecies)]
-        const filteredUniqueAllSpecies = uniqueAllSpecies.filter(
-          (specie) => !uniqueCountrySelectedSpecies.includes(specie)
-        )
-        filteredUniqueAllSpecies.sort()
+        const organizedSpecies = organizeMangroveSpeciesList(siteCountriesResponse)
 
-        countrySelectedSpeciesWithAllSpecies = [
-          ...uniqueCountrySelectedSpecies,
-          ...filteredUniqueAllSpecies
-        ]
-
-        setMangroveSpeciesList(countrySelectedSpeciesWithAllSpecies)
+        setMangroveSpeciesList(organizedSpecies)
       }
       setMangroveSpeciesTypesChecked(getMangroveSpecies(serverResponse))
 

--- a/mrtt-ui/src/components/PreRestorationAssessment/PreRestorationAssessmentForm.js
+++ b/mrtt-ui/src/components/PreRestorationAssessment/PreRestorationAssessmentForm.js
@@ -23,8 +23,7 @@ import {
   FormPageHeader,
   FormQuestionDiv,
   StickyFormLabel,
-  SelectedInputSection,
-  TabularLabel
+  SelectedInputSection
 } from '../../styles/forms'
 import { ContentWrapper } from '../../styles/containers'
 import { ErrorText, PageSubtitle, PageTitle } from '../../styles/typography'
@@ -230,6 +229,8 @@ function PreRestorationAssessmentForm() {
         toast.error(language.error.submit)
       })
   }
+
+  console.log(mangroveSpeciesList.length ? 'nothing' : 'something')
 
   const handleMangroveSpeciesPresentOnChange = (event, specie) => {
     const mangroveSpeciesTypesCheckedCopy = [...mangroveSpeciesTypesChecked]
@@ -459,30 +460,29 @@ function PreRestorationAssessmentForm() {
               <StickyFormLabel>{questions.mangroveSpeciesPresent.question}</StickyFormLabel>
               {mangroveSpeciesList.length ? (
                 <List>
-                  {mangroveSpeciesList.length ? (
-                    mangroveSpeciesList.map((specie, index) => (
-                      <ListItem key={index}>
-                        <Box>
-                          <Box sx={{ fontStyle: 'italic' }}>
-                            <Checkbox
-                              value={specie}
-                              checked={mangroveSpeciesTypesChecked.includes(specie)}
-                              onChange={(event) =>
-                                handleMangroveSpeciesPresentOnChange(event, specie)
-                              }></Checkbox>
-                            <Typography variant='subtitle'>{specie}</Typography>
+                  {mangroveSpeciesList.length
+                    ? mangroveSpeciesList.map((specie, index) => (
+                        <ListItem key={index}>
+                          <Box>
+                            <Box sx={{ fontStyle: 'italic' }}>
+                              <Checkbox
+                                value={specie}
+                                checked={mangroveSpeciesTypesChecked.includes(specie)}
+                                onChange={(event) =>
+                                  handleMangroveSpeciesPresentOnChange(event, specie)
+                                }></Checkbox>
+                              <Typography variant='subtitle'>{specie}</Typography>
+                            </Box>
                           </Box>
-                        </Box>
-                      </ListItem>
-                    ))
-                  ) : (
-                    <ErrorText>
-                      No items to display. Please select countries in Site Details and Location
-                      (1.2).
-                    </ErrorText>
-                  )}
+                        </ListItem>
+                      ))
+                    : null}
                 </List>
-              ) : null}
+              ) : (
+                <ErrorText>
+                  No items to display. Please select countries in Site Details and Location (1.2).
+                </ErrorText>
+              )}
               <ErrorText>{errors.mangroveSpeciesPresent?.message}</ErrorText>
             </FormQuestionDiv>
           </>
@@ -520,7 +520,7 @@ function PreRestorationAssessmentForm() {
         ) : null}
         {siteAssessmentBeforeProjectWatcher === 'Yes' ? (
           <FormQuestionDiv>
-            <TabularLabel>{questions.physicalMeasurementsTaken.question}</TabularLabel>
+            <StickyFormLabel>{questions.physicalMeasurementsTaken.question}</StickyFormLabel>
             {physicalMeasurementsTakenFields.length > 0
               ? physicalMeasurementsTakenFields.map((measurementItem, measurementItemIndex) => (
                   <PhysicalMeasurementRow

--- a/mrtt-ui/src/components/PreRestorationAssessment/PreRestorationAssessmentForm.js
+++ b/mrtt-ui/src/components/PreRestorationAssessment/PreRestorationAssessmentForm.js
@@ -230,8 +230,6 @@ function PreRestorationAssessmentForm() {
       })
   }
 
-  console.log(mangroveSpeciesList.length ? 'nothing' : 'something')
-
   const handleMangroveSpeciesPresentOnChange = (event, specie) => {
     const mangroveSpeciesTypesCheckedCopy = [...mangroveSpeciesTypesChecked]
     if (event.target.checked) {
@@ -270,6 +268,13 @@ function PreRestorationAssessmentForm() {
     if (value) currentItem.measurementValue = value
     if (unit) currentItem.measurementUnit = unit
     physicalMeasurementsTakenUpdate(measurementIndex, currentItem)
+  }
+
+  const speciesCompositionPercentageTotal = () => {
+    const percentages = speciesCompositionWatcher.map((specie) =>
+      Number(specie.percentageComposition)
+    )
+    return percentages.reduce((previousValue, currentValue) => previousValue + currentValue, 0)
   }
 
   return isLoading ? (
@@ -483,7 +488,6 @@ function PreRestorationAssessmentForm() {
                   No items to display. Please select countries in Site Details and Location (1.2).
                 </ErrorText>
               )}
-              <ErrorText>{errors.mangroveSpeciesPresent?.message}</ErrorText>
             </FormQuestionDiv>
           </>
         ) : null}
@@ -516,6 +520,10 @@ function PreRestorationAssessmentForm() {
                 </SelectedInputSection>
               )
             })}
+            {speciesCompositionPercentageTotal() > 100 ? (
+              <ErrorText>Percentage totals must not equal more than 100</ErrorText>
+            ) : null}
+            <ErrorText>{errors.mangroveSpeciesPresent?.message}</ErrorText>
           </FormQuestionDiv>
         ) : null}
         {siteAssessmentBeforeProjectWatcher === 'Yes' ? (

--- a/mrtt-ui/src/components/PreRestorationAssessment/PreRestorationAssessmentForm.js
+++ b/mrtt-ui/src/components/PreRestorationAssessment/PreRestorationAssessmentForm.js
@@ -28,7 +28,6 @@ import {
 import { ContentWrapper } from '../../styles/containers'
 import { ErrorText, PageSubtitle, PageTitle } from '../../styles/typography'
 import { findDataItem } from '../../library/findDataItem'
-// import { mangroveSpeciesPerCountryList } from '../../data/mangroveSpeciesPerCountry'
 import { mapDataForApi } from '../../library/mapDataForApi'
 import { multiselectWithOtherValidationNoMinimum } from '../../validation/multiSelectWithOther'
 import { preRestorationAssessment as questions } from '../../data/questions'

--- a/mrtt-ui/src/components/SiteBackgroundForm.js
+++ b/mrtt-ui/src/components/SiteBackgroundForm.js
@@ -11,7 +11,10 @@ import { ContentWrapper } from '../styles/containers'
 import { ErrorText, PageSubtitle, PageTitle } from '../styles/typography'
 import { Form, FormPageHeader, FormQuestionDiv, StickyFormLabel } from '../styles/forms'
 import { mapDataForApi } from '../library/mapDataForApi'
-import { multiselectWithOtherValidation } from '../validation/multiSelectWithOther'
+import {
+  multiselectWithOtherValidation,
+  multiselectWithOtherValidationNoMinimum
+} from '../validation/multiSelectWithOther'
 import { questionMapping } from '../data/questionMapping'
 import { siteBackground } from '../data/questions'
 import CheckboxGroupWithLabelAndController from './CheckboxGroupWithLabelAndController'
@@ -46,7 +49,7 @@ const SiteBackgroundForm = () => {
     managementStatus: yup.string(),
     lawStatus: yup.string(),
     managementArea: yup.string(),
-    protectionStatus: multiselectWithOtherValidation,
+    protectionStatus: multiselectWithOtherValidationNoMinimum,
     areStakeholdersInvolved: yup.string().nullable(),
     governmentArrangement: multiselectWithOtherValidation,
     landTenure: multiselectWithOtherValidation,
@@ -245,12 +248,7 @@ const SiteBackgroundForm = () => {
             fieldName='protectionStatus'
             reactHookFormInstance={reactHookFormInstance}
             options={siteBackground.protectionStatus.options}
-            question={
-              <>
-                {siteBackground.protectionStatus.question}
-                <RequiredIndicator />
-              </>
-            }
+            question={siteBackground.protectionStatus.question}
             shouldAddOtherOptionWithClarification={true}
           />
           <ErrorText>{errors.protectionStatus?.selectedValues?.message}</ErrorText>

--- a/mrtt-ui/src/components/SiteInterventions/SiteInterventionsForm.js
+++ b/mrtt-ui/src/components/SiteInterventions/SiteInterventionsForm.js
@@ -3,7 +3,6 @@ import {
   Button,
   Checkbox,
   Chip,
-  FormLabel,
   List,
   ListItem,
   ListItemText,
@@ -616,7 +615,7 @@ function SiteInterventionsForm() {
           </FormQuestionDiv>
         ) : null}
         <FormQuestionDiv>
-          <FormLabel>{questions.localParticipantTraining.question}</FormLabel>
+          <StickyFormLabel>{questions.localParticipantTraining.question}</StickyFormLabel>
           <Controller
             name='localParticipantTraining'
             control={control}

--- a/mrtt-ui/src/components/SiteInterventions/SiteInterventionsForm.js
+++ b/mrtt-ui/src/components/SiteInterventions/SiteInterventionsForm.js
@@ -29,7 +29,6 @@ import { ContentWrapper } from '../../styles/containers'
 import { ErrorText, PageSubtitle, PageTitle } from '../../styles/typography'
 import { findDataItem } from '../../library/findDataItem'
 import { Form, FormPageHeader, FormQuestionDiv, StickyFormLabel } from '../../styles/forms'
-import { mangroveSpeciesPerCountryList } from '../../data/mangroveSpeciesPerCountry'
 import { mapDataForApi } from '../../library/mapDataForApi'
 import { multiselectWithOtherValidationNoMinimum } from '../../validation/multiSelectWithOther'
 import { propaguleOptions, seedlingOptions } from '../../data/siteInterventionOptions'
@@ -44,6 +43,7 @@ import MangroveAssociatedSpeciesRow from './MangroveAssociatedSpeciesRow'
 import QuestionNav from '../QuestionNav'
 import useInitializeQuestionMappedForm from '../../library/useInitializeQuestionMappedForm'
 import useSiteInfo from '../../library/useSiteInfo'
+import organizeMangroveSpeciesList from '../../library/organizeMangroveSpeciesList'
 
 const getWhichStakeholdersInvolved = (registrationAnswersFromServer) =>
   findDataItem(registrationAnswersFromServer, '6.1') ?? []
@@ -166,20 +166,9 @@ function SiteInterventionsForm() {
     const siteCountriesResponse = getSiteCountries(serverResponse)
 
     if (siteCountriesResponse.length) {
-      const countriesList = siteCountriesResponse.map(
-        (countryItem) => countryItem.properties.country
-      )
-      const species = []
-      countriesList.forEach((countrySelected) => {
-        mangroveSpeciesPerCountryList.forEach((countryItem) => {
-          if (countryItem.country.name === countrySelected) {
-            species.push(...countryItem.species)
-          }
-        })
-      })
-      const uniqueSpecies = [...new Set(species)]
+      const organizedSpecies = organizeMangroveSpeciesList(siteCountriesResponse)
 
-      setMangroveSpeciesForCountriesSelected(uniqueSpecies)
+      setMangroveSpeciesForCountriesSelected(organizedSpecies)
     }
 
     const getMangroveSpeciesUsedFrom6_2b = getMangroveSpeciesUsed(serverResponse)

--- a/mrtt-ui/src/library/organizeMangroveSpeciesList.js
+++ b/mrtt-ui/src/library/organizeMangroveSpeciesList.js
@@ -1,0 +1,36 @@
+import { mangroveSpeciesPerCountryList } from '../data/mangroveSpeciesPerCountry'
+
+// mangroveSpeciesPresent list should display country specific species at the top, with all
+// species below the country specific list, removing duplicates from the second list
+
+const organizeMangroveSpeciesList = (siteCountriesResponse) => {
+  const countriesList = siteCountriesResponse.map((countryItem) => countryItem.properties.country)
+  const allSpecies = []
+  const countrySelectedSpecies = []
+  let countrySelectedSpeciesWithAllSpecies = []
+
+  countriesList.forEach((countrySelected) => {
+    mangroveSpeciesPerCountryList.forEach((countryItem) => {
+      if (countryItem.country.name === countrySelected) {
+        countrySelectedSpecies.push(...countryItem.species)
+      }
+      allSpecies.push(...countryItem.species)
+    })
+  })
+  const uniqueCountrySelectedSpecies = [...new Set(countrySelectedSpecies)]
+  uniqueCountrySelectedSpecies.sort()
+  const uniqueAllSpecies = [...new Set(allSpecies)]
+  const filteredUniqueAllSpecies = uniqueAllSpecies.filter(
+    (specie) => !uniqueCountrySelectedSpecies.includes(specie)
+  )
+  filteredUniqueAllSpecies.sort()
+
+  countrySelectedSpeciesWithAllSpecies = [
+    ...uniqueCountrySelectedSpecies,
+    ...filteredUniqueAllSpecies
+  ]
+
+  return countrySelectedSpeciesWithAllSpecies
+}
+
+export default organizeMangroveSpeciesList


### PR DESCRIPTION
**Changes based on feedback:**
Q2.5 Is marked as mandatory in the tool but shouldn’t be
-  removed required indicator

Q5.3f Percentages shouldn’t be able to total more than 100%
- There is now error text that appears if percentages equal more than 100%
- Setting a custom error for a fields array (instead of individual field items) with react hook form ended up being more complex than expected. For now, users can still submit answers that equal more than 100%, but a warning also displays

Q5.3g Can the table rows be orientated horizontally
- set horizontal rows since there are only two row items, still mobile friendly

Q6.2b Can the species be organized as in Q5.3e (in case people plant non-native species or our species ranges are wrong)
- added `organizeMangroveSpeciesList` to library

Q6.3 Bold typeface on question needed
- fixed

Q7.5: The sum of these totals should not be greater than the value in Q7.4
- warning text appears if sum of totals exceeds value in 7.4

Q7.5a: This question needs to pull the activities from both Q6.2 and Q6.4
- fixed (previously it was only loading answers from 6.4)

