### PR TITLE
fix: [299] dont show name input for question 2.1 when 'Unknown' selected

### DIFF
--- a/mrtt-ui/src/components/SiteBackgroundForm.js
+++ b/mrtt-ui/src/components/SiteBackgroundForm.js
@@ -169,7 +169,7 @@ const SiteBackgroundForm = () => {
                     <Typography variant='subtitle'>{stakeholder}</Typography>
                   </Box>
                   <Box>
-                    {getStakeholder(stakeholder) && (
+                    {getStakeholder(stakeholder) && stakeholder !== 'Unknown' ? (
                       <Controller
                         name={`stakeholders.${stakeholdersFields.findIndex(
                           (field) => field.stakeholderType === stakeholder
@@ -185,7 +185,7 @@ const SiteBackgroundForm = () => {
                           />
                         )}
                       />
-                    )}
+                    ) : null}
                   </Box>
                 </Box>
               </ListItem>


### PR DESCRIPTION
# to test:
- go to question 2.1
- select any option other than 'Unknown'. You should see a 'Name' input below the checkbox
- select 'Unknown'. You should not see a name
