### PR TITLE
Feature/346 section1 always public

### DIFF
--- a/mrtt-ui/src/components/QuestionNav.js
+++ b/mrtt-ui/src/components/QuestionNav.js
@@ -14,6 +14,7 @@ import LoadingIndicatorOverlay from './LoadingIndicatorOverlay'
 import SECTION_NAMES from '../constants/sectionNames'
 import theme from '../styles/theme'
 import themeMui from '../styles/themeMui'
+import PRIVACY_VALUES from '../constants/privacyValues'
 
 const componentLanguage = language.questionNav
 
@@ -86,6 +87,7 @@ const QuestionNav = ({ isFormSaving, isFormSaveError, onFormSave, currentSection
   const [siteFromApi, setSiteFromApi] = useState()
   const { siteId } = useParams()
   const currentSectionNameIndex = SECTION_NAMES.indexOf(currentSection)
+  const isFormPrivacyDisabled = currentSection === 'project-details'
   const nextSection = SECTION_NAMES[currentSectionNameIndex + 1]
   const previousSection = SECTION_NAMES[currentSectionNameIndex - 1]
   const sectionIdForApi = currentSectionNameIndex + 1
@@ -107,7 +109,7 @@ const QuestionNav = ({ isFormSaving, isFormSaveError, onFormSave, currentSection
   const handleOnPrivacyChange = (event) => {
     setIsPrivacySaveError(false)
     setIsPrivacySaving(true)
-    if (siteFromApi) {
+    if (siteFromApi && !isFormPrivacyDisabled) {
       const siteWithUpdatedSectionPrivacy = {
         ...siteFromApi,
         section_data_visibility: {
@@ -160,12 +162,13 @@ const QuestionNav = ({ isFormSaving, isFormSaveError, onFormSave, currentSection
               id='form-privacy'
               defaultValue={''}
               value={sectionPrivacy}
-              onChange={handleOnPrivacyChange}>
+              onChange={handleOnPrivacyChange}
+              disabled={isFormPrivacyDisabled}>
               <option value={''} disabled>
                 {componentLanguage.privacySelectUndefined}
               </option>
-              <option value={'private'}>{language.sectionPrivacy.private}</option>
-              <option value={'public'}>{language.sectionPrivacy.public}</option>
+              <option value={PRIVACY_VALUES.private}>{language.sectionPrivacy.private}</option>
+              <option value={PRIVACY_VALUES.public}>{language.sectionPrivacy.public}</option>
             </PrivacySelect>
             <ButtonSave isSaving={isFormSaving} onClick={onFormSave} />
           </NavSubWrapper>

--- a/mrtt-ui/src/constants/privacyValues.js
+++ b/mrtt-ui/src/constants/privacyValues.js
@@ -1,0 +1,8 @@
+const PRIVACY_VALUES = {
+  private: 'private',
+  public: 'public'
+}
+
+Object.freeze(PRIVACY_VALUES)
+
+export default PRIVACY_VALUES

--- a/mrtt-ui/src/language.js
+++ b/mrtt-ui/src/language.js
@@ -146,6 +146,8 @@ const pages = {
     title: 'Landscapes'
   },
   siteform: {
+    defaultSectionPrivacyDescription:
+      "Default Data Privacy determines if the data from each form will be sharable or not. Each form's privacy can be edited individually later. An exception is that Site Details and Location form is always set to public regardless of the default selected here.",
     titleEditSite: 'Site Settings',
     titleNewSite: 'Create a site',
     labelName: 'Site Name',

--- a/mrtt-ui/src/views/SiteForm.js
+++ b/mrtt-ui/src/views/SiteForm.js
@@ -16,6 +16,7 @@ import ItemDoesntExist from '../components/ItemDoesntExist'
 import language from '../language'
 import LoadingIndicator from '../components/LoadingIndicator'
 import RequiredIndicator from '../components/RequiredIndicator'
+import PRIVACY_VALUES from '../constants/privacyValues'
 
 const validationSchema = yup.object({
   site_name: yup.string().required(language.pages.siteform.validation.nameRequired),
@@ -81,7 +82,7 @@ const SiteForm = ({ isNewSite }) => {
       site_name,
       landscape_id,
       section_data_visibility: {
-        1: defaultSectionPrivacy,
+        1: PRIVACY_VALUES.public,
         2: defaultSectionPrivacy,
         3: defaultSectionPrivacy,
         4: defaultSectionPrivacy,
@@ -192,11 +193,16 @@ const SiteForm = ({ isNewSite }) => {
                   {...field}
                   id='defaultSectionPrivacy'
                   label={language.pages.siteform.labelDefaultSectionPrivacy}>
-                  <MenuItem value='private'>{language.sectionPrivacy.private}</MenuItem>
-                  <MenuItem value='public'>{language.sectionPrivacy.public}</MenuItem>
+                  <MenuItem value={PRIVACY_VALUES.private}>
+                    {language.sectionPrivacy.private}
+                  </MenuItem>
+                  <MenuItem value={PRIVACY_VALUES.public}>
+                    {language.sectionPrivacy.public}
+                  </MenuItem>
                 </Select>
               )}
             />
+            <p>{language.pages.siteform.defaultSectionPrivacyDescription}</p>
             <ErrorText>{errors?.landscape_id?.message}</ErrorText>
           </QuestionWrapper>
         ) : null}


### PR DESCRIPTION
# Description
Section 1 should always be public regardless of the default privacy setting

- disable privacy setting for section 1 form
- show description explaining this on new site form and edit site form

# To test:
- go to the new site form -> see the new text.
- select private.
- click into the new site, go to section 1 form -> the privacy input should be set to public and disabled