### PR TITLE
Chore/fix missing options 10 2

### DIFF
--- a/mrtt-ui/src/components/Costs/CostsForm.js
+++ b/mrtt-ui/src/components/Costs/CostsForm.js
@@ -31,23 +31,23 @@ import ProjectFunderNamesRow from './ProjectFunderNamesRow'
 import BreakdownOfCostRow from './BreakdownOfCostRow'
 import PercentageSplitOfActivitiesRow from './PercentageSplitOfActivitiesRow'
 import { currencies } from '../../data/currencies'
-import { findDataItem } from '../../library/findDataItem'
+import { findRegistationDataItem } from '../../library/findDataItems'
 import FormValidationMessageIfErrors from '../FormValidationMessageIfErrors'
 
 const getEndDate = (registrationAnswersFromServer) =>
-  findDataItem(registrationAnswersFromServer, '1.1b') ?? ''
+  findRegistationDataItem(registrationAnswersFromServer, '1.1b') ?? ''
 
 const getBreakdownOfCost = (registrationAnswersFromServer) =>
-  findDataItem(registrationAnswersFromServer, '7.5') ?? []
+  findRegistationDataItem(registrationAnswersFromServer, '7.5') ?? []
 
 const getBiophysicalInterventions = (registrationAnswersFromServer) =>
-  findDataItem(registrationAnswersFromServer, '6.2') ?? []
+  findRegistationDataItem(registrationAnswersFromServer, '6.2') ?? []
 
 const getOtherActivitiesImplemented = (registrationAnswersFromServer) =>
-  findDataItem(registrationAnswersFromServer, '6.4') ?? []
+  findRegistationDataItem(registrationAnswersFromServer, '6.4') ?? []
 
 const getPercentageSplitOfActivities = (registrationAnswersFromServer) =>
-  findDataItem(registrationAnswersFromServer, '7.5a') ?? []
+  findRegistationDataItem(registrationAnswersFromServer, '7.5a') ?? []
 
 const CostsForm = () => {
   const { site_name } = useSiteInfo()

--- a/mrtt-ui/src/components/EcologicalStatusAndOutcomes/EcologicalStatusAndOutcomesForm.js
+++ b/mrtt-ui/src/components/EcologicalStatusAndOutcomes/EcologicalStatusAndOutcomesForm.js
@@ -38,7 +38,7 @@ import FormValidationMessageIfErrors from '../FormValidationMessageIfErrors'
 import useInitializeMonitoringForm from '../../library/useInitializeMonitoringForm'
 import CheckboxGroupWithLabelAndController from '../CheckboxGroupWithLabelAndController'
 import { multiselectWithOtherValidationNoMinimum } from '../../validation/multiSelectWithOther'
-import { findDataItem, findMonitoringDataItem } from '../../library/findDataItem'
+import { findRegistationDataItem, findMonitoringDataItem } from '../../library/findDataItems'
 import MONITORING_FORM_CONSTANTS from '../../constants/monitoringFormConstants'
 import { monitoringIndicators } from '../../data/monitoringIndicators'
 import ButtonDeleteForm from '../ButtonDeleteForm'
@@ -48,10 +48,10 @@ import DatePickerUtcMui from '../DatePickerUtcMui'
 import { unitOptions } from '../../data/ecologicalOptions'
 
 const getEcologicalAims = (registrationAnswersFromServer) =>
-  findDataItem(registrationAnswersFromServer, '3.1') ?? []
+  findRegistationDataItem(registrationAnswersFromServer, '3.1') ?? []
 
 const getBiophysicalInterventions = (registrationAnswersFromServer) =>
-  findDataItem(registrationAnswersFromServer, '6.2') ?? []
+  findRegistationDataItem(registrationAnswersFromServer, '6.2') ?? []
 
 const getEcologicalMonitoringStakeholders = (registrationAnswersFromServer) =>
   findMonitoringDataItem(registrationAnswersFromServer, '10.2') ?? []

--- a/mrtt-ui/src/components/EcologicalStatusAndOutcomes/EcologicalStatusAndOutcomesForm.js
+++ b/mrtt-ui/src/components/EcologicalStatusAndOutcomes/EcologicalStatusAndOutcomesForm.js
@@ -197,26 +197,30 @@ const EcologicalStatusAndOutcomesForm = () => {
 
   const _loadMonitoringAnswers = useEffect(
     function loadMonitoringServerData() {
-      setAreBiophysicalInterventionsLoading(true)
-      axios
-        .get(monitoringFormSingularUrl)
-        .then((monitoringResponse) => {
-          const ecologicalMonitoringStakeholdersInitialVal =
-            getEcologicalMonitoringStakeholders(monitoringResponse)
+      if (isEditMode) {
+        setAreBiophysicalInterventionsLoading(true)
+        axios
+          .get(monitoringFormSingularUrl)
+          .then((monitoringResponse) => {
+            setAreBiophysicalInterventionsLoading(false)
+            const ecologicalMonitoringStakeholdersInitialVal =
+              getEcologicalMonitoringStakeholders(monitoringResponse)
 
-          const initialEcologicalMonitoringStakeholdersTypesChecked =
-            ecologicalMonitoringStakeholdersInitialVal?.map(
-              (stakeholder) => stakeholder.stakeholder
+            const initialEcologicalMonitoringStakeholdersTypesChecked =
+              ecologicalMonitoringStakeholdersInitialVal?.map(
+                (stakeholder) => stakeholder.stakeholder
+              )
+            setEcologicalMonitoringStakeholdersTypesChecked(
+              initialEcologicalMonitoringStakeholdersTypesChecked
             )
-          setEcologicalMonitoringStakeholdersTypesChecked(
-            initialEcologicalMonitoringStakeholdersTypesChecked
-          )
-        })
-        .catch(() => {
-          toast.error(language.error.apiLoad)
-        })
+          })
+          .catch(() => {
+            setAreBiophysicalInterventionsLoading(false)
+            toast.error(language.error.apiLoad)
+          })
+      }
     },
-    [monitoringFormSingularUrl]
+    [monitoringFormSingularUrl, isEditMode]
   )
 
   useInitializeMonitoringForm({

--- a/mrtt-ui/src/components/PreRestorationAssessment/PreRestorationAssessmentForm.js
+++ b/mrtt-ui/src/components/PreRestorationAssessment/PreRestorationAssessmentForm.js
@@ -27,7 +27,7 @@ import {
 } from '../../styles/forms'
 import { ContentWrapper } from '../../styles/containers'
 import { ErrorText, PageSubtitle, PageTitle } from '../../styles/typography'
-import { findDataItem } from '../../library/findDataItem'
+import { findRegistationDataItem } from '../../library/findDataItems'
 import { mapDataForApi } from '../../library/mapDataForApi'
 import { multiselectWithOtherValidationNoMinimum } from '../../validation/multiSelectWithOther'
 import { preRestorationAssessment as questions } from '../../data/questions'
@@ -45,13 +45,13 @@ import FormValidationMessageIfErrors from '../FormValidationMessageIfErrors'
 import organizeMangroveSpeciesList from '../../library/organizeMangroveSpeciesList'
 
 const getSiteCountries = (registrationAnswersFromServer) =>
-  findDataItem(registrationAnswersFromServer, '1.2') ?? []
+  findRegistationDataItem(registrationAnswersFromServer, '1.2') ?? []
 
 const getMangroveSpecies = (registrationAnswersFromServer) =>
-  findDataItem(registrationAnswersFromServer, '5.3e') ?? []
+  findRegistationDataItem(registrationAnswersFromServer, '5.3e') ?? []
 
 const getPhysicalMeasurementsTaken = (registrationAnswersFromServer) =>
-  findDataItem(registrationAnswersFromServer, '5.3g') ?? []
+  findRegistationDataItem(registrationAnswersFromServer, '5.3g') ?? []
 
 function PreRestorationAssessmentForm() {
   const { site_name } = useSiteInfo()

--- a/mrtt-ui/src/components/SiteBackgroundForm.js
+++ b/mrtt-ui/src/components/SiteBackgroundForm.js
@@ -11,10 +11,7 @@ import { ContentWrapper } from '../styles/containers'
 import { ErrorText, PageSubtitle, PageTitle } from '../styles/typography'
 import { Form, FormPageHeader, FormQuestionDiv, StickyFormLabel } from '../styles/forms'
 import { mapDataForApi } from '../library/mapDataForApi'
-import {
-  multiselectWithOtherValidation,
-  multiselectWithOtherValidationNoMinimum
-} from '../validation/multiSelectWithOther'
+import { multiselectWithOtherValidationNoMinimum } from '../validation/multiSelectWithOther'
 import { questionMapping } from '../data/questionMapping'
 import { siteBackground } from '../data/questions'
 import CheckboxGroupWithLabelAndController from './CheckboxGroupWithLabelAndController'
@@ -51,8 +48,8 @@ const SiteBackgroundForm = () => {
     managementArea: yup.string(),
     protectionStatus: multiselectWithOtherValidationNoMinimum,
     areStakeholdersInvolved: yup.string().nullable(),
-    governmentArrangement: multiselectWithOtherValidation,
-    landTenure: multiselectWithOtherValidation,
+    governmentArrangement: multiselectWithOtherValidationNoMinimum,
+    landTenure: multiselectWithOtherValidationNoMinimum,
     customaryRights: yup.string()
   })
 
@@ -280,12 +277,7 @@ const SiteBackgroundForm = () => {
             fieldName='governmentArrangement'
             reactHookFormInstance={reactHookFormInstance}
             options={siteBackground.governmentArrangement.options}
-            question={
-              <>
-                {siteBackground.governmentArrangement.question}
-                <RequiredIndicator />
-              </>
-            }
+            question={<>{siteBackground.governmentArrangement.question}</>}
             shouldAddOtherOptionWithClarification={true}
           />
           <ErrorText>{errors.governmentArrangement?.selectedValues?.message}</ErrorText>
@@ -296,12 +288,7 @@ const SiteBackgroundForm = () => {
             fieldName='landTenure'
             reactHookFormInstance={reactHookFormInstance}
             options={siteBackground.landTenure.options}
-            question={
-              <>
-                {siteBackground.landTenure.question}
-                <RequiredIndicator />
-              </>
-            }
+            question={<>{siteBackground.landTenure.question}</>}
             shouldAddOtherOptionWithClarification={true}
           />
           <ErrorText>{errors.landTenure?.selectedValues?.message}</ErrorText>

--- a/mrtt-ui/src/components/SiteInterventions/SiteInterventionsForm.js
+++ b/mrtt-ui/src/components/SiteInterventions/SiteInterventionsForm.js
@@ -23,7 +23,13 @@ import axios from 'axios'
 import { ContentWrapper } from '../../styles/containers'
 import { ErrorText, PageSubtitle, PageTitle } from '../../styles/typography'
 import { findDataItem } from '../../library/findDataItem'
-import { Form, FormPageHeader, FormQuestionDiv, StickyFormLabel } from '../../styles/forms'
+import {
+  Form,
+  FormPageHeader,
+  FormQuestionDiv,
+  InnerFormDiv,
+  StickyFormLabel
+} from '../../styles/forms'
 import { mapDataForApi } from '../../library/mapDataForApi'
 import { multiselectWithOtherValidationNoMinimum } from '../../validation/multiSelectWithOther'
 import { propaguleOptions, seedlingOptions } from '../../data/siteInterventionOptions'
@@ -101,7 +107,6 @@ function SiteInterventionsForm() {
   })
   const reactHookFormInstance = useForm({
     defaultValues: {
-      whichStakeholdersInvolved: { selectedValues: [], otherValue: undefined },
       organizationsProvidingTraining: { selectedValues: [], otherValue: undefined },
       otherActivitiesImplemented: { selectedValues: [], otherValue: undefined }
     },
@@ -638,12 +643,6 @@ function SiteInterventionsForm() {
 }
 
 export default SiteInterventionsForm
-
-const InnerFormDiv = styled('div')`
-  margin-top: 1em;
-  margin-left: 0.75em;
-  max-width: 15em;
-`
 
 const SubgroupDiv = styled('div')`
   margin-left: 2.7em;

--- a/mrtt-ui/src/components/SiteInterventions/SiteInterventionsForm.js
+++ b/mrtt-ui/src/components/SiteInterventions/SiteInterventionsForm.js
@@ -22,7 +22,7 @@ import axios from 'axios'
 
 import { ContentWrapper } from '../../styles/containers'
 import { ErrorText, PageSubtitle, PageTitle } from '../../styles/typography'
-import { findDataItem } from '../../library/findDataItem'
+import { findRegistationDataItem } from '../../library/findDataItems'
 import {
   Form,
   FormPageHeader,
@@ -48,13 +48,13 @@ import organizeMangroveSpeciesList from '../../library/organizeMangroveSpeciesLi
 import DatePickerUtcMui from '../DatePickerUtcMui'
 
 const getWhichStakeholdersInvolved = (registrationAnswersFromServer) =>
-  findDataItem(registrationAnswersFromServer, '6.1') ?? []
+  findRegistationDataItem(registrationAnswersFromServer, '6.1') ?? []
 
 const getSiteCountries = (registrationAnswersFromServer) =>
-  findDataItem(registrationAnswersFromServer, '1.2') ?? []
+  findRegistationDataItem(registrationAnswersFromServer, '1.2') ?? []
 
 const getMangroveSpeciesUsed = (registrationAnswersFromServer) =>
-  findDataItem(registrationAnswersFromServer, '6.2b') ?? []
+  findRegistationDataItem(registrationAnswersFromServer, '6.2b') ?? []
 
 function SiteInterventionsForm() {
   const { site_name } = useSiteInfo()

--- a/mrtt-ui/src/components/SocioeconomicAndGovernance/SocioeconomicAndGovernanceStatusAndOutcomesForm.js
+++ b/mrtt-ui/src/components/SocioeconomicAndGovernance/SocioeconomicAndGovernanceStatusAndOutcomesForm.js
@@ -28,7 +28,7 @@ import FormValidationMessageIfErrors from '../FormValidationMessageIfErrors'
 import CheckboxGroupWithLabelAndController from '../CheckboxGroupWithLabelAndController'
 import { multiselectWithOtherValidationNoMinimum } from '../../validation/multiSelectWithOther'
 import { socioIndicators } from '../../data/socioIndicators'
-import { findDataItem } from '../../library/findDataItem'
+import { findRegistationDataItem } from '../../library/findDataItems'
 import SocioeconomicOutcomesRow from './SocioeconomicOutcomesRow'
 import useInitializeMonitoringForm from '../../library/useInitializeMonitoringForm'
 import MONITORING_FORM_CONSTANTS from '../../constants/monitoringFormConstants'
@@ -37,7 +37,7 @@ import ConfirmPrompt from '../ConfirmPrompt/ConfirmPrompt'
 import DatePickerUtcMui from '../DatePickerUtcMui'
 
 const getSocioeconomicAims = (registrationAnswersFromServer) =>
-  findDataItem(registrationAnswersFromServer, '3.2') ?? []
+  findRegistationDataItem(registrationAnswersFromServer, '3.2') ?? []
 
 const formType = MONITORING_FORM_CONSTANTS.socioeconomicGovernanceStatusAndOutcomes.payloadType
 

--- a/mrtt-ui/src/library/findDataItem.js
+++ b/mrtt-ui/src/library/findDataItem.js
@@ -1,3 +1,8 @@
 export const findDataItem = (registrationAnswersFromServer, questionId) =>
   registrationAnswersFromServer?.data.find((dataItem) => dataItem.question_id === questionId)
     ?.answer_value
+
+export const findMonitoringDataItem = (registrationAnswersFromServer, questionId) =>
+  registrationAnswersFromServer?.data.answers.find(
+    (dataItem) => dataItem.question_id === questionId
+  )?.answer_value

--- a/mrtt-ui/src/library/findDataItems.js
+++ b/mrtt-ui/src/library/findDataItems.js
@@ -1,4 +1,4 @@
-export const findDataItem = (registrationAnswersFromServer, questionId) =>
+export const findRegistationDataItem = (registrationAnswersFromServer, questionId) =>
   registrationAnswersFromServer?.data.find((dataItem) => dataItem.question_id === questionId)
     ?.answer_value
 

--- a/mrtt-ui/src/library/findDataItems.js
+++ b/mrtt-ui/src/library/findDataItems.js
@@ -3,6 +3,6 @@ export const findRegistationDataItem = (registrationAnswersFromServer, questionI
     ?.answer_value
 
 export const findMonitoringDataItem = (registrationAnswersFromServer, questionId) =>
-  registrationAnswersFromServer?.data.answers.find(
+  registrationAnswersFromServer?.data?.answers?.find(
     (dataItem) => dataItem.question_id === questionId
   )?.answer_value

--- a/mrtt-ui/src/library/useInitializeMonitoringForm.js
+++ b/mrtt-ui/src/library/useInitializeMonitoringForm.js
@@ -20,13 +20,14 @@ const useInitializeMonitoringForm = ({
         axios
           .get(apiUrl)
           .then(({ data }) => {
+            setIsLoading(false)
             const formTypeInResponse = data.form_type
             if (formType !== formTypeInResponse) {
               throw new Error(
                 'Monitoring data is being accessed with the wrong form component for the form type'
               )
             }
-            setIsLoading(false)
+
             const initialValuesForForm = formatApiAnswersForForm({
               apiAnswers: data.answers,
               questionMapping

--- a/mrtt-ui/src/styles/forms.js
+++ b/mrtt-ui/src/styles/forms.js
@@ -121,3 +121,8 @@ export const LeftColumnDiv = styled(Box)`
   display: flex;
   margin-bottom: 1em;
 `
+export const InnerFormDiv = styled('div')`
+  margin-top: 1em;
+  margin-left: 0.75em;
+  max-width: 15em;
+`


### PR DESCRIPTION
fixes[ this issue ](https://github.com/globalmangrovewatch/gmw-users/issues/361)
also combined[ this one](https://github.com/globalmangrovewatch/gmw-users/issues/356) to remove required indicator in 2.7 & 2.8 (whoops, didn't realize I was on the same branch)

- added custom checkbox group to include dropdown for paid/voluntary options in 10.2
- added findMonitoringDataItem (previously we only had it set for registration items)
- updated naming of findDataItems in other files to specify monitoring or registration

to test:
- create a site
- go to section 10
- go to 10.2
- check items and also use drop down
- save and refresh