### PR TITLE
Save all data whole and section

### DIFF
--- a/mrtt-ui/src/components/EcologicalStatusAndOutcomes/EcologicalStatusAndOutcomesForm.js
+++ b/mrtt-ui/src/components/EcologicalStatusAndOutcomes/EcologicalStatusAndOutcomesForm.js
@@ -29,7 +29,7 @@ import language from '../../language'
 import { ContentWrapper } from '../../styles/containers'
 import { questionMapping } from '../../data/questionMapping'
 import { ErrorText, PageSubtitle, PageTitle } from '../../styles/typography'
-import { mapDataForApi } from '../../library/mapDataForApi'
+import { mapAllDataForApi } from '../../library/mapDataForApi'
 import { ecologicalStatusOutcomes as questions } from '../../data/questions'
 import FormValidationMessageIfErrors from '../FormValidationMessageIfErrors'
 import useInitializeMonitoringForm from '../../library/useInitializeMonitoringForm'
@@ -204,7 +204,19 @@ const EcologicalStatusAndOutcomesForm = () => {
 
     const payload = {
       form_type: formType,
-      answers: mapDataForApi('ecologicalStatusAndOutcomes', formData)
+      // answers: mapDataForApi('ecologicalStatusAndOutcomes', formData)
+      answers: mapAllDataForApi({
+        projectDetails: { ...formData },
+        siteBackground: { ...formData },
+        restorationAims: { ...formData },
+        causesOfDecline: { ...formData },
+        preRestorationAssessment: { ...formData },
+        siteInterventions: { ...formData },
+        costs: { ...formData },
+        managementStatusAndEffectiveness: { ...formData },
+        socioeconomicAndGovernanceStatusAndOutcomes: { ...formData },
+        ecologicalStatusAndOutcomes: { ...formData }
+      })
     }
 
     if (isEditMode) {

--- a/mrtt-ui/src/components/RestorationAimsForm/RestorationAimsForm.js
+++ b/mrtt-ui/src/components/RestorationAimsForm/RestorationAimsForm.js
@@ -56,6 +56,7 @@ const RestorationAimsForm = () => {
   const handleSubmit = (formData) => {
     setIsSubmitting(true)
     setIsSubmitError(false)
+
     axios
       .patch(apiAnswersUrl, mapDataForApi('restorationAims', formData))
       .then(() => {

--- a/mrtt-ui/src/library/mapDataForApi.js
+++ b/mrtt-ui/src/library/mapDataForApi.js
@@ -16,3 +16,15 @@ export const mapDataForApi = (formTitle, data) => {
   }
   return preppedData
 }
+
+export const mapAllDataForApi = (formsByTitle) => {
+  const answers = []
+
+  for (const [formTitle, data] of Object.entries(formsByTitle || {})) {
+    answers.push(...mapDataForApi(formTitle, data))
+  }
+
+  const byId = new Map()
+  for (const a of answers) byId.set(a.question_id, a)
+  return Array.from(byId.values())
+}

--- a/mrtt-ui/src/views/Auth/LoginForm.js
+++ b/mrtt-ui/src/views/Auth/LoginForm.js
@@ -112,7 +112,7 @@ const LoginForm = ({ isUserNew }) => {
             secure location to hold information across restoration planning, intervention and
             monitoring.{' '}
             <ExternalLink
-              to='https://www.mangrovealliance.org/wp-content/uploads/2023/07/MRTT-Guide-v15.pdf'
+              to='https://tnc.app.box.com/s/pspea7mm2m2uldrqvhahmvp9dck6mc06'
               rel='noreferrer'
               target='_blank'
               style={{ color: 'white' }}>

--- a/mrtt-ui/src/views/SiteForm.js
+++ b/mrtt-ui/src/views/SiteForm.js
@@ -94,6 +94,7 @@ const SiteForm = ({ isNewSite }) => {
         10: defaultSectionPrivacy
       }
     }
+
     axios
       .post(sitesUrl, siteDataToSubmit)
       .then(({ data: { site_name } }) => {

--- a/mrtt-ui/src/views/Sites.js
+++ b/mrtt-ui/src/views/Sites.js
@@ -14,6 +14,7 @@ import {
 } from '../styles/containers'
 import { ItemTitle, ItemSubTitle, PageTitle } from '../styles/typography'
 import language from '../language'
+import { useForm } from 'react-hook-form'
 
 const sitesUrl = `${process.env.REACT_APP_API_URL}/sites/`
 
@@ -22,15 +23,21 @@ function Sites() {
   const [sites, setSites] = useState([])
   const [downloadOptionsAnchorEl, setDownloadOptionsAnchorEl] = React.useState(null)
 
-  useEffect(function loadSitesData() {
-    axios
-      .get(sitesUrl)
-      .then(({ data }) => {
-        setIsLoading(false)
-        setSites(data)
-      })
-      .catch(() => toast.error(language.error.apiLoad))
-  }, [])
+  const form = useForm()
+
+  useEffect(
+    function loadSitesData() {
+      axios
+        .get(sitesUrl)
+        .then(({ data }) => {
+          form.reset()
+          setIsLoading(false)
+          setSites(data)
+        })
+        .catch(() => toast.error(language.error.apiLoad))
+    },
+    [form]
+  )
 
   const handleDownloadButtonClick = (event) => {
     setDownloadOptionsAnchorEl(event.currentTarget)


### PR DESCRIPTION
This pull request introduces improvements to how form data is mapped and submitted across the application, as well as a few other minor updates. The most significant change is the introduction of `mapAllDataForApi`, which enables mapping data from multiple forms at once, ensuring that answers are deduplicated by question ID. Other changes include updating external documentation links and minor code cleanups.

**Form data mapping improvements:**

* Added the new `mapAllDataForApi` function in `mapDataForApi.js` to aggregate and deduplicate answers from multiple forms by question ID. This is now used in `EcologicalStatusAndOutcomesForm.js` to submit data for all relevant forms together, replacing the previous single-form mapping. [[1]](diffhunk://#diff-f6ea370661ec9745240a5a430d48f51438ec831cf9304f217336548d552f8733R19-R30) [[2]](diffhunk://#diff-7d9ba7abb5e0dd1419113fe2b0e50186a41e69917fe3830afacd65a21cc26fe9L32-R32) [[3]](diffhunk://#diff-7d9ba7abb5e0dd1419113fe2b0e50186a41e69917fe3830afacd65a21cc26fe9L207-R219)

**Documentation link update:**

* Updated the external link in `LoginForm.js` to point to a new Box.com URL for the MRTT Guide PDF instead of the previous mangrovealliance.org link.

**General code improvements:**

* Integrated `react-hook-form` into `Sites.js` and reset the form state when site data is loaded, improving form handling and state management. [[1]](diffhunk://#diff-46ca5b875d3aed4175a3ad4efb3c5f34e309462781fe7d21e5fb268664816424R17) [[2]](diffhunk://#diff-46ca5b875d3aed4175a3ad4efb3c5f34e309462781fe7d21e5fb268664816424L25-R40)
* Minor formatting and whitespace cleanup in `RestorationAimsForm.js` and `SiteForm.js`. [[1]](diffhunk://#diff-a5a2de75d7f8492114cf9e4f5a617f31fb18573f07b4d88f14652ebca1f92712R59) [[2]](diffhunk://#diff-dc7076fb6e2d0476dbe1d8fff6ea78a4ce6243ded307a58c477de7099f23e3bbR97)