### PR TITLE
reset fields

### DIFF
--- a/mrtt-ui/src/components/ButtonSave.js
+++ b/mrtt-ui/src/components/ButtonSave.js
@@ -3,10 +3,10 @@ import PropTypes from 'prop-types'
 import { ButtonPrimary } from '../styles/buttons'
 import language from '../language'
 
-const ButtonSave = ({ isSaving, component, ...restOfProps }) => {
+const ButtonSave = ({ isSaving, component, hasErrors, ...restOfProps }) => {
   const ComponentToUse = component ? component : ButtonPrimary
   return (
-    <ComponentToUse disabled={isSaving} {...restOfProps}>
+    <ComponentToUse disabled={isSaving || hasErrors} {...restOfProps}>
       {isSaving ? language.buttons.saving : language.buttons.save}
     </ComponentToUse>
   )
@@ -14,7 +14,8 @@ const ButtonSave = ({ isSaving, component, ...restOfProps }) => {
 
 ButtonSave.propTypes = {
   isSaving: PropTypes.bool.isRequired,
-  component: PropTypes.any
+  component: PropTypes.any,
+  hasErrors: PropTypes.bool.isRequired
 }
 
 ButtonSave.defaultProps = {

--- a/mrtt-ui/src/components/CausesOfDeclineForm.js
+++ b/mrtt-ui/src/components/CausesOfDeclineForm.js
@@ -51,7 +51,7 @@ function CausesOfDeclineForm() {
   } = useFieldArray({ name: 'causesOfDecline', control })
   const lossKnownWatcher = watch('lossKnown')
 
-  const [isSubmitting, setisSubmitting] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
   const [isError, setIsError] = useState(false)
   const [causesOfDeclineTypesChecked, setCausesOfDeclineTypesChecked] = useState([])
   const { siteId } = useParams()
@@ -214,20 +214,27 @@ function CausesOfDeclineForm() {
   }
 
   const onSubmit = async (data) => {
-    setisSubmitting(true)
+    const fields = Object.keys(questionMapping['causesOfDecline'])
+    const ok = await form.trigger(fields, { shouldFocus: true })
+    console.log('handle')
+    if (!ok) {
+      setIsError(true)
+      toast.error(language.error.validation)
+      return
+    }
+    setIsSubmitting(true)
     setIsError(false)
-
     if (!data) return
 
     axios
       .patch(apiAnswersUrl, mapDataForApi('causesOfDecline', data))
       .then(() => {
-        setisSubmitting(false)
+        setIsSubmitting(false)
         toast.success(language.success.submit)
       })
       .catch(() => {
         setIsError(true)
-        setisSubmitting(false)
+        setIsSubmitting(false)
         toast.error(language.error.apiLoad)
       })
   }
@@ -250,7 +257,7 @@ function CausesOfDeclineForm() {
       <QuestionNav
         isFormSaving={isSubmitting}
         isFormSaveError={isError}
-        onFormSave={handleSubmit(onSubmit)}
+        onFormSave={() => onSubmit(form.getValues())}
         currentSection='causes-of-decline'
       />
       <FormValidationMessageIfErrors formErrors={errors} />

--- a/mrtt-ui/src/components/CausesOfDeclineForm.js
+++ b/mrtt-ui/src/components/CausesOfDeclineForm.js
@@ -257,7 +257,7 @@ function CausesOfDeclineForm() {
       <QuestionNav
         isFormSaving={isSubmitting}
         isFormSaveError={isError}
-        onFormSave={() => onSubmit(form.getValues())}
+        onFormSave={handleSubmit(onSubmit)}
         currentSection='causes-of-decline'
       />
       <FormValidationMessageIfErrors formErrors={errors} />

--- a/mrtt-ui/src/components/CausesOfDeclineForm.js
+++ b/mrtt-ui/src/components/CausesOfDeclineForm.js
@@ -216,7 +216,7 @@ function CausesOfDeclineForm() {
   const onSubmit = async (data) => {
     const fields = Object.keys(questionMapping['causesOfDecline'])
     const ok = await form.trigger(fields, { shouldFocus: true })
-    console.log('handle')
+
     if (!ok) {
       setIsError(true)
       toast.error(language.error.validation)

--- a/mrtt-ui/src/components/Costs/CostsForm.js
+++ b/mrtt-ui/src/components/Costs/CostsForm.js
@@ -17,7 +17,7 @@ import QuestionNav from '../QuestionNav'
 import useSiteInfo from '../../library/useSiteInfo'
 import language from '../../language'
 import { ContentWrapper } from '../../styles/containers'
-import { costs as questions } from '../../data/questions'
+import { costs as questions, siteInterventions } from '../../data/questions'
 import CheckboxGroupWithLabelAndController from '../CheckboxGroupWithLabelAndController'
 import { ErrorText, PageSubtitle, PageTitle } from '../../styles/typography'
 import { mapDataForApi } from '../../library/mapDataForApi'
@@ -76,7 +76,7 @@ const CostsForm = () => {
     replace: percentageSplitOfActivitiesReplace,
     update: percentageSplitOfActivitiesUpdate
   } = useFieldArray({ name: 'percentageSplitOfActivities', control })
-
+  console.log({ percentageSplitOfActivitiesFields })
   const { siteId } = useParams()
   const apiAnswersUrl = `${process.env.REACT_APP_API_URL}/sites/${siteId}/registration_intervention_answers`
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -218,7 +218,7 @@ const CostsForm = () => {
       .reduce((previousValue, currentValue) => previousValue + currentValue, 0)
       .toLocaleString()
   }
-
+  console.log(questions, form.getValues(), siteInterventions)
   return (
     <ContentWrapper>
       <FormPageHeader>

--- a/mrtt-ui/src/components/Costs/CostsForm.js
+++ b/mrtt-ui/src/components/Costs/CostsForm.js
@@ -76,7 +76,7 @@ const CostsForm = () => {
     replace: percentageSplitOfActivitiesReplace,
     update: percentageSplitOfActivitiesUpdate
   } = useFieldArray({ name: 'percentageSplitOfActivities', control })
-  console.log({ percentageSplitOfActivitiesFields })
+
   const { siteId } = useParams()
   const apiAnswersUrl = `${process.env.REACT_APP_API_URL}/sites/${siteId}/registration_intervention_answers`
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -218,7 +218,7 @@ const CostsForm = () => {
       .reduce((previousValue, currentValue) => previousValue + currentValue, 0)
       .toLocaleString()
   }
-  console.log(questions, form.getValues(), siteInterventions)
+
   return (
     <ContentWrapper>
       <FormPageHeader>

--- a/mrtt-ui/src/components/EcologicalStatusAndOutcomes/EcologicalStatusAndOutcomesForm.js
+++ b/mrtt-ui/src/components/EcologicalStatusAndOutcomes/EcologicalStatusAndOutcomesForm.js
@@ -29,7 +29,10 @@ import language from '../../language'
 import { ContentWrapper } from '../../styles/containers'
 import { questionMapping } from '../../data/questionMapping'
 import { ErrorText, PageSubtitle, PageTitle } from '../../styles/typography'
-import { mapAllDataForApi } from '../../library/mapDataForApi'
+import {
+  // mapAllDataForApi,
+  mapDataForApi
+} from '../../library/mapDataForApi'
 import { ecologicalStatusOutcomes as questions } from '../../data/questions'
 import FormValidationMessageIfErrors from '../FormValidationMessageIfErrors'
 import useInitializeMonitoringForm from '../../library/useInitializeMonitoringForm'
@@ -58,6 +61,7 @@ const formType = MONITORING_FORM_CONSTANTS.ecologicalStatusAndOutcomes.payloadTy
 const EcologicalStatusAndOutcomesForm = () => {
   const { site_name } = useSiteInfo()
   const { monitoringFormId } = useParams()
+
   const isEditMode = !!monitoringFormId
   const navigate = useNavigate()
 
@@ -168,13 +172,14 @@ const EcologicalStatusAndOutcomesForm = () => {
     isEditMode,
     questionMapping: questionMapping.ecologicalStatusAndOutcomes
   })
+
   const createNewMonitoringForm = (payload) => {
     axios
       .post(monitoringFormsUrl, payload)
       .then(({ data }) => {
         setIsSubmitting(false)
         toast.success(language.success.getCreateThingSuccessMessage('This form'))
-        resetForm()
+        // resetForm()
         navigate(data.id)
       })
       .catch(() => {
@@ -204,21 +209,20 @@ const EcologicalStatusAndOutcomesForm = () => {
 
     const payload = {
       form_type: formType,
-      // answers: mapDataForApi('ecologicalStatusAndOutcomes', formData)
-      answers: mapAllDataForApi({
-        projectDetails: { ...formData },
-        siteBackground: { ...formData },
-        restorationAims: { ...formData },
-        causesOfDecline: { ...formData },
-        preRestorationAssessment: { ...formData },
-        siteInterventions: { ...formData },
-        costs: { ...formData },
-        managementStatusAndEffectiveness: { ...formData },
-        socioeconomicAndGovernanceStatusAndOutcomes: { ...formData },
-        ecologicalStatusAndOutcomes: { ...formData }
-      })
+      answers: mapDataForApi('ecologicalStatusAndOutcomes', formData)
+      // answers: mapAllDataForApi({
+      //   projectDetails: { ...formData },
+      //   siteBackground: { ...formData },
+      //   restorationAims: { ...formData },
+      //   causesOfDecline: { ...formData },
+      //   preRestorationAssessment: { ...formData },
+      //   siteInterventions: { ...formData },
+      //   costs: { ...formData },
+      //   managementStatusAndEffectiveness: { ...formData },
+      //   socioeconomicAndGovernanceStatusAndOutcomes: { ...formData },
+      //   ecologicalStatusAndOutcomes: { ...formData }
+      // })
     }
-
     if (isEditMode) {
       editMonitoringForm(payload)
     } else {

--- a/mrtt-ui/src/components/EcologicalStatusAndOutcomes/EcologicalStatusAndOutcomesForm.js
+++ b/mrtt-ui/src/components/EcologicalStatusAndOutcomes/EcologicalStatusAndOutcomesForm.js
@@ -223,6 +223,19 @@ const EcologicalStatusAndOutcomesForm = () => {
       editMonitoringForm(payload)
     } else {
       createNewMonitoringForm(payload)
+      axios
+        .post(registrationInterventionFormsUrl, payload)
+        .then(({ data }) => {
+          setIsSubmitting(false)
+          toast.success(language.success.getCreateThingSuccessMessage('This form'))
+          resetForm()
+          navigate(data.id)
+        })
+        .catch(() => {
+          setIsSubmitting(false)
+          setIsSubmitError(true)
+          toast.error(language.error.submit)
+        })
     }
   }
 

--- a/mrtt-ui/src/components/FormValidationMessageIfErrors.js
+++ b/mrtt-ui/src/components/FormValidationMessageIfErrors.js
@@ -3,10 +3,30 @@ import PropTypes from 'prop-types'
 import { useEffect } from 'react'
 import { toast } from 'react-toastify'
 
+import { questionMapping } from '../data/questionMapping'
+
 import language from '../language'
+
+export function getSectionsWithErrors(questionMapping, errors) {
+  const sections = new Set()
+
+  for (const fields of Object.values(questionMapping)) {
+    for (const [fieldName, questionId] of Object.entries(fields)) {
+      if (errors[fieldName]) {
+        sections.add(questionId)
+      }
+    }
+  }
+
+  if (sections.size === 0) return ''
+
+  return `Please note the sections with errors are ${Array.from(sections).join(', ')}.`
+}
 
 const FormValidationMessageIfErrors = ({ formErrors = {} }) => {
   const formHasErrors = !!Object.keys(formErrors).length
+
+  const sectionsWithErrors = getSectionsWithErrors(questionMapping, formErrors)
 
   useEffect(() => {
     if (formHasErrors) {
@@ -20,6 +40,7 @@ const FormValidationMessageIfErrors = ({ formErrors = {} }) => {
     <Alert variant='outlined' severity='error'>
       <AlertTitle>{language.form.validationAlert.title}</AlertTitle>
       <p>{language.form.validationAlert.description}</p>
+      {sectionsWithErrors && <p>{sectionsWithErrors}</p>}
     </Alert>
   ) : null
 }

--- a/mrtt-ui/src/components/ManagementStatusAndEffectiveness/ManagementStatusAndEffectivenessForm.js
+++ b/mrtt-ui/src/components/ManagementStatusAndEffectiveness/ManagementStatusAndEffectivenessForm.js
@@ -44,7 +44,7 @@ const ManagementStatusAndEffectivenessForm = () => {
   const monitoringFormsUrl = `${process.env.REACT_APP_API_URL}/sites/${siteId}/monitoring_answers`
   const monitoringFormSingularUrl = `${monitoringFormsUrl}/${monitoringFormId}`
   const [isSubmitting, setIsSubmitting] = useState(false)
-  const [isSubmitError, setIsSubmitError] = useState(false)
+  const [isError, setIsError] = useState(false)
   const managementStatusChangesWatcher = watchForm('managementStatusChanges')
   const projectStatusChangeWatcher = watchForm('projectStatusChange')
   const financeForCiteManagementWatcher = watchForm('financeForCiteManagement')
@@ -68,7 +68,7 @@ const ManagementStatusAndEffectivenessForm = () => {
       })
       .catch(() => {
         setIsSubmitting(false)
-        setIsSubmitError(true)
+        setIsError(true)
         toast.error(language.error.submit)
       })
   }
@@ -82,20 +82,28 @@ const ManagementStatusAndEffectivenessForm = () => {
       })
       .catch(() => {
         setIsSubmitting(false)
-        setIsSubmitError(true)
+        setIsError(true)
         toast.error(language.error.submit)
       })
   }
 
-  const handleSubmit = (formData) => {
+  const handleSubmit = async (formData) => {
+    const fields = Object.keys(questionMapping['managementStatusAndEffectiveness'])
+    const ok = await form.trigger(fields, { shouldFocus: true })
+    if (!ok) {
+      setIsError(true)
+      toast.error(language.error.validation)
+      return
+    }
     setIsSubmitting(true)
-    setIsSubmitError(false)
+    setIsError(false)
+    if (!formData) return
 
     const payload = {
       form_type: formType,
       answers: mapDataForApi('managementStatusAndEffectiveness', formData)
     }
-
+    console.log(isEditMode, 'edit mode')
     if (isEditMode) {
       editMonitoringForm(payload)
     } else {
@@ -132,8 +140,8 @@ const ManagementStatusAndEffectivenessForm = () => {
       </FormPageHeader>
       <QuestionNav
         isFormSaving={isSubmitting}
-        isFormSaveError={isSubmitError}
-        onFormSave={validateInputs(handleSubmit)}
+        isFormSaveError={isError}
+        onFormSave={() => handleSubmit(form.getValues())}
         currentSection='management-status-and-effectiveness'
       />
       <FormValidationMessageIfErrors formErrors={errors} />

--- a/mrtt-ui/src/components/ManagementStatusAndEffectiveness/ManagementStatusAndEffectivenessForm.js
+++ b/mrtt-ui/src/components/ManagementStatusAndEffectiveness/ManagementStatusAndEffectivenessForm.js
@@ -103,7 +103,7 @@ const ManagementStatusAndEffectivenessForm = () => {
       form_type: formType,
       answers: mapDataForApi('managementStatusAndEffectiveness', formData)
     }
-    console.log(isEditMode, 'edit mode')
+
     if (isEditMode) {
       editMonitoringForm(payload)
     } else {

--- a/mrtt-ui/src/components/PreRestorationAssessment/PreRestorationAssessmentForm.js
+++ b/mrtt-ui/src/components/PreRestorationAssessment/PreRestorationAssessmentForm.js
@@ -132,7 +132,7 @@ function PreRestorationAssessmentForm() {
   const handleSubmit = async (formData) => {
     const fields = Object.keys(questionMapping['preRestorationAssessment'])
     const ok = await form.trigger(fields, { shouldFocus: true })
-    console.log(ok)
+
     if (!ok) {
       setIsError(true)
       toast.error(language.error.validation)

--- a/mrtt-ui/src/components/PreRestorationAssessment/PreRestorationAssessmentForm.js
+++ b/mrtt-ui/src/components/PreRestorationAssessment/PreRestorationAssessmentForm.js
@@ -83,7 +83,7 @@ function PreRestorationAssessmentForm() {
   const mangroveRestorationAttemptedWatcher = watchForm('mangroveRestorationAttempted')
   const siteAssessmentBeforeProjectWatcher = watchForm('siteAssessmentBeforeProject')
   const speciesCompositionWatcher = watchForm('speciesComposition')
-  const [isSubmitting, setisSubmitting] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
   const [isError, setIsError] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
   const [mangroveSpeciesList, setMangroveSpeciesList] = useState([])
@@ -130,20 +130,27 @@ function PreRestorationAssessmentForm() {
   })
 
   const handleSubmit = async (formData) => {
-    setisSubmitting(true)
+    const fields = Object.keys(questionMapping['preRestorationAssessment'])
+    const ok = await form.trigger(fields, { shouldFocus: true })
+    console.log(ok)
+    if (!ok) {
+      setIsError(true)
+      toast.error(language.error.validation)
+      return
+    }
+    setIsSubmitting(true)
     setIsError(false)
-
     if (!formData) return
 
     axios
       .patch(apiAnswersUrl, mapDataForApi('preRestorationAssessment', formData))
       .then(() => {
-        setisSubmitting(false)
+        setIsSubmitting(false)
         toast.success(language.success.submit)
       })
       .catch(() => {
         setIsError(true)
-        setisSubmitting(false)
+        setIsSubmitting(false)
         toast.error(language.error.submit)
       })
   }
@@ -207,7 +214,7 @@ function PreRestorationAssessmentForm() {
       <QuestionNav
         isFormSaving={isSubmitting}
         isFormSaveError={isError}
-        onFormSave={validateInputs(handleSubmit)}
+        onFormSave={() => handleSubmit(form.getValues())}
         currentSection='pre-restoration-assessment'
       />
       <FormValidationMessageIfErrors formErrors={errors} />

--- a/mrtt-ui/src/components/ProjectDetailsForm.js
+++ b/mrtt-ui/src/components/ProjectDetailsForm.js
@@ -10,7 +10,7 @@ import turfConvex from '@turf/convex'
 
 import { ContentWrapper } from '../styles/containers'
 import { ErrorText, PageSubtitle, PageTitle } from '../styles/typography'
-import { mapDataForApi } from '../library/mapDataForApi'
+import { mapDataForApi, mapAllDataForApi } from '../library/mapDataForApi'
 import { projectDetails, projectDetails as questions } from '../data/questions'
 import { questionMapping } from '../data/questionMapping'
 import { StickyFormLabel, FormPageHeader, FormQuestionDiv, FormLayout } from '../styles/forms'
@@ -52,10 +52,6 @@ function ProjectDetailsForm() {
   const { siteId } = useParams()
   const apiAnswersUrl = `${process.env.REACT_APP_API_URL}/sites/${siteId}/registration_intervention_answers`
 
-  // const holi = useRegistrationAnswers(form, apiAnswersUrl, { enabled: !!apiAnswersUrl })
-  // console.log(questionMapping.projectDetails, 'default values', form.getValues())
-  // const { defaultValues: holi } = form
-
   let watchHasProjectEndDate = form.watch('hasProjectEndDate', false)
   /* showEndDateInput is a hack because MUI follows native html and casts values to strings.
    The api casts them to boolean so we support both */
@@ -84,7 +80,7 @@ function ProjectDetailsForm() {
       console.error(e)
     }
   }
-
+  console.log('project dtails')
   const onSiteAreaFeatureCollectionChange = (field, featureCollection) => {
     field.onChange(featureCollection)
 
@@ -95,8 +91,8 @@ function ProjectDetailsForm() {
 
   const handleSubmit = async (formData) => {
     const fields = Object.keys(questionMapping['projectDetails'])
+    console.log(fields, 'fields')
     const ok = await form.trigger(fields, { shouldFocus: true })
-    console.log(ok)
     if (!ok) {
       setIsError(true)
       toast.error(language.error.validation)
@@ -104,7 +100,38 @@ function ProjectDetailsForm() {
     }
     setIsSubmitting(true)
     setIsError(false)
+    console.log(formData, 'form data')
     if (!formData) return
+
+    const payload = {
+      // answers: mapDataForApi('ecologicalStatusAndOutcomes', formData)
+      answers: mapAllDataForApi({
+        projectDetails: { ...formData },
+        siteBackground: { ...formData },
+        restorationAims: { ...formData },
+        causesOfDecline: { ...formData },
+        preRestorationAssessment: { ...formData },
+        siteInterventions: { ...formData },
+        costs: { ...formData },
+        managementStatusAndEffectiveness: { ...formData },
+        socioeconomicAndGovernanceStatusAndOutcomes: { ...formData },
+        ecologicalStatusAndOutcomes: { ...formData }
+      })
+    }
+
+    axios
+      .get(apiAnswersUrl, mapDataForApi(payload))
+      .then((data) => {
+        console.log(data, '*******')
+        setIsError(false)
+        setIsSubmitting(false)
+        toast.success(language.success.submit)
+      })
+      .catch(() => {
+        setIsError(true)
+        setIsSubmitting(false)
+        toast.error(language.error.submit)
+      })
 
     axios
       .patch(apiAnswersUrl, mapDataForApi('projectDetails', formData))
@@ -119,7 +146,7 @@ function ProjectDetailsForm() {
         toast.error(language.error.submit)
       })
   }
-  console.log(apiAnswersUrl, 'sites')
+
   return (
     <ContentWrapper>
       <FormPageHeader>
@@ -146,7 +173,6 @@ function ProjectDetailsForm() {
             name='projectStartDate'
             control={form.control}
             render={({ field }) => {
-              console.log(field.value, 'field value')
               return <DatePickerUtcMui id='start-date' label='date' field={field} />
             }}
           />

--- a/mrtt-ui/src/components/ProjectDetailsForm.js
+++ b/mrtt-ui/src/components/ProjectDetailsForm.js
@@ -1,6 +1,6 @@
 import { FormControlLabel, Radio, RadioGroup, TextField } from '@mui/material'
 import { Controller, useFormContext } from 'react-hook-form'
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 
 import Autocomplete from '@mui/material/Autocomplete'
 import axios from 'axios'
@@ -11,7 +11,7 @@ import turfConvex from '@turf/convex'
 import { ContentWrapper } from '../styles/containers'
 import { ErrorText, PageSubtitle, PageTitle } from '../styles/typography'
 import { mapDataForApi, mapAllDataForApi } from '../library/mapDataForApi'
-import { projectDetails, projectDetails as questions } from '../data/questions'
+import { projectDetails as questions } from '../data/questions'
 import { questionMapping } from '../data/questionMapping'
 import { StickyFormLabel, FormPageHeader, FormQuestionDiv, FormLayout } from '../styles/forms'
 import { toast } from 'react-toastify'
@@ -26,7 +26,7 @@ import RequiredIndicator from './RequiredIndicator'
 import { useInitializeQuestionMappedForm } from '../library/question-mapped-form/useInitializeQuestionMappedForm'
 import useSiteInfo from '../library/useSiteInfo'
 import DatePickerUtcMui from './DatePickerUtcMui'
-import { useRegistrationAnswers } from '../hooks/registrationInterventionAnswers'
+
 export const siteAreaError = 'Please provide a site area'
 
 const sortCountries = (a, b) => {
@@ -39,7 +39,6 @@ const countriesGeojson = mangroveCountries.features.sort(sortCountries)
 
 function ProjectDetailsForm() {
   const form = useFormContext()
-  const { reset } = form
   const [isLoading, setIsLoading] = useState(false)
   const errors = form.errors
 
@@ -48,7 +47,6 @@ function ProjectDetailsForm() {
   const [isSubmitting, setIsSubmitting] = useState(false)
   const { site_name } = useSiteInfo()
 
-  // const { errors } = form.formState
   const { siteId } = useParams()
   const apiAnswersUrl = `${process.env.REACT_APP_API_URL}/sites/${siteId}/registration_intervention_answers`
 
@@ -80,7 +78,7 @@ function ProjectDetailsForm() {
       console.error(e)
     }
   }
-  console.log('project dtails')
+
   const onSiteAreaFeatureCollectionChange = (field, featureCollection) => {
     field.onChange(featureCollection)
 
@@ -91,7 +89,7 @@ function ProjectDetailsForm() {
 
   const handleSubmit = async (formData) => {
     const fields = Object.keys(questionMapping['projectDetails'])
-    console.log(fields, 'fields')
+
     const ok = await form.trigger(fields, { shouldFocus: true })
     if (!ok) {
       setIsError(true)
@@ -100,7 +98,7 @@ function ProjectDetailsForm() {
     }
     setIsSubmitting(true)
     setIsError(false)
-    console.log(formData, 'form data')
+
     if (!formData) return
 
     const payload = {
@@ -121,8 +119,7 @@ function ProjectDetailsForm() {
 
     axios
       .get(apiAnswersUrl, mapDataForApi(payload))
-      .then((data) => {
-        console.log(data, '*******')
+      .then(() => {
         setIsError(false)
         setIsSubmitting(false)
         toast.success(language.success.submit)

--- a/mrtt-ui/src/components/ProjectDetailsForm.js
+++ b/mrtt-ui/src/components/ProjectDetailsForm.js
@@ -1,6 +1,6 @@
 import { FormControlLabel, Radio, RadioGroup, TextField } from '@mui/material'
 import { Controller, useFormContext } from 'react-hook-form'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 
 import Autocomplete from '@mui/material/Autocomplete'
 import axios from 'axios'
@@ -11,7 +11,7 @@ import turfConvex from '@turf/convex'
 import { ContentWrapper } from '../styles/containers'
 import { ErrorText, PageSubtitle, PageTitle } from '../styles/typography'
 import { mapDataForApi } from '../library/mapDataForApi'
-import { projectDetails as questions } from '../data/questions'
+import { projectDetails, projectDetails as questions } from '../data/questions'
 import { questionMapping } from '../data/questionMapping'
 import { StickyFormLabel, FormPageHeader, FormQuestionDiv, FormLayout } from '../styles/forms'
 import { toast } from 'react-toastify'
@@ -26,7 +26,7 @@ import RequiredIndicator from './RequiredIndicator'
 import { useInitializeQuestionMappedForm } from '../library/question-mapped-form/useInitializeQuestionMappedForm'
 import useSiteInfo from '../library/useSiteInfo'
 import DatePickerUtcMui from './DatePickerUtcMui'
-
+import { useRegistrationAnswers } from '../hooks/registrationInterventionAnswers'
 export const siteAreaError = 'Please provide a site area'
 
 const sortCountries = (a, b) => {
@@ -39,6 +39,8 @@ const countriesGeojson = mangroveCountries.features.sort(sortCountries)
 
 function ProjectDetailsForm() {
   const form = useFormContext()
+  const { reset } = form
+  const [isLoading, setIsLoading] = useState(false)
   const errors = form.errors
 
   const [mapExtent, setMapExtent] = useState()
@@ -49,6 +51,11 @@ function ProjectDetailsForm() {
   // const { errors } = form.formState
   const { siteId } = useParams()
   const apiAnswersUrl = `${process.env.REACT_APP_API_URL}/sites/${siteId}/registration_intervention_answers`
+
+  // const holi = useRegistrationAnswers(form, apiAnswersUrl, { enabled: !!apiAnswersUrl })
+  // console.log(questionMapping.projectDetails, 'default values', form.getValues())
+  // const { defaultValues: holi } = form
+
   let watchHasProjectEndDate = form.watch('hasProjectEndDate', false)
   /* showEndDateInput is a hack because MUI follows native html and casts values to strings.
    The api casts them to boolean so we support both */
@@ -87,14 +94,22 @@ function ProjectDetailsForm() {
   }
 
   const handleSubmit = async (formData) => {
+    const fields = Object.keys(questionMapping['projectDetails'])
+    const ok = await form.trigger(fields, { shouldFocus: true })
+    console.log(ok)
+    if (!ok) {
+      setIsError(true)
+      toast.error(language.error.validation)
+      return
+    }
     setIsSubmitting(true)
     setIsError(false)
-
     if (!formData) return
 
     axios
       .patch(apiAnswersUrl, mapDataForApi('projectDetails', formData))
       .then(() => {
+        setIsError(false)
         setIsSubmitting(false)
         toast.success(language.success.submit)
       })
@@ -104,7 +119,7 @@ function ProjectDetailsForm() {
         toast.error(language.error.submit)
       })
   }
-
+  console.log(apiAnswersUrl, 'sites')
   return (
     <ContentWrapper>
       <FormPageHeader>
@@ -114,7 +129,7 @@ function ProjectDetailsForm() {
       <QuestionNav
         isFormSaving={isSubmitting}
         isFormSaveError={isError}
-        onFormSave={form.handleSubmit(handleSubmit)}
+        onFormSave={() => handleSubmit(form.getValues())}
         currentSection='project-details'
       />
       <FormValidationMessageIfErrors formErrors={errors} />
@@ -131,6 +146,7 @@ function ProjectDetailsForm() {
             name='projectStartDate'
             control={form.control}
             render={({ field }) => {
+              console.log(field.value, 'field value')
               return <DatePickerUtcMui id='start-date' label='date' field={field} />
             }}
           />

--- a/mrtt-ui/src/components/RestorationAimsForm/RestorationAimsForm.js
+++ b/mrtt-ui/src/components/RestorationAimsForm/RestorationAimsForm.js
@@ -27,7 +27,7 @@ const getStakeholders = (registrationAnswersFromServer) =>
 const RestorationAimsForm = () => {
   const form = useFormContext()
   const [isLoading, setIsLoading] = useState(false)
-  const [isSubmitError, setIsSubmitError] = useState(false)
+  const [isError, setIsError] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [stakeholders, setStakeholders] = useState(form.getValues('stakeholders') || [])
   const { site_name } = useSiteInfo()
@@ -53,9 +53,17 @@ const RestorationAimsForm = () => {
     successCallback: loadStakeholdersFromServerData
   })
 
-  const handleSubmit = (formData) => {
+  const handleSubmit = async (formData) => {
+    const fields = Object.keys(questionMapping['restorationAims'])
+    const ok = await form.trigger(fields, { shouldFocus: true })
+    if (!ok) {
+      setIsError(true)
+      toast.error(language.error.validation)
+      return
+    }
     setIsSubmitting(true)
-    setIsSubmitError(false)
+    setIsError(false)
+    if (!formData) return
 
     axios
       .patch(apiAnswersUrl, mapDataForApi('restorationAims', formData))
@@ -65,7 +73,7 @@ const RestorationAimsForm = () => {
       })
       .catch(() => {
         setIsSubmitting(false)
-        setIsSubmitError(true)
+        setIsError(true)
         toast.error(language.error.submit)
       })
   }
@@ -73,6 +81,9 @@ const RestorationAimsForm = () => {
   const noStakeholdersWarning = (
     <Alert severity='info'>{language.pages.restorationAims.missingStakeholdersWarning}</Alert>
   )
+
+  const fields = Object.keys(questionMapping['restorationAims'])
+  const restorationAmisErrors = fields.filter((field) => errors[field])
 
   return isLoading ? (
     <LoadingIndicator />
@@ -84,12 +95,12 @@ const RestorationAimsForm = () => {
       </FormPageHeader>
       <QuestionNav
         isFormSaving={isSubmitting}
-        isFormSaveError={isSubmitError}
-        onFormSave={validateInputs(handleSubmit)}
+        isFormSaveError={isError}
+        onFormSave={() => handleSubmit(form.getValues())}
         currentSection='restoration-aims'
       />
       <FormValidationMessageIfErrors formErrors={errors} />
-      <FormLayout onSubmit={validateInputs(handleSubmit)}>
+      <FormLayout onSubmit={() => handleSubmit(form.getValues())}>
         <FormQuestionDiv>
           {!areThereStakeholders ? noStakeholdersWarning : null}
           <RestorationAimsCheckboxGroupWithLabel

--- a/mrtt-ui/src/components/SiteBackgroundForm.js
+++ b/mrtt-ui/src/components/SiteBackgroundForm.js
@@ -25,7 +25,9 @@ const SiteBackgroundForm = () => {
   const form = useFormContext()
   const [isError, setIsError] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
-  const [stakeholderTypesChecked, setStakeholderTypesChecked] = useState([])
+  const [stakeholderTypesChecked, setStakeholderTypesChecked] = useState(
+    form.getValues('stakeholders')?.map((s) => s.stakeholderType) || []
+  )
   const { site_name } = useSiteInfo()
   const { siteId } = useParams()
   const apiAnswersUrl = `${process.env.REACT_APP_API_URL}/sites/${siteId}/registration_intervention_answers`
@@ -54,9 +56,15 @@ const SiteBackgroundForm = () => {
   })
 
   const handleSubmit = async (formData) => {
+    const fields = Object.keys(questionMapping['siteBackground'])
+    const ok = await form.trigger(fields, { shouldFocus: true })
+    if (!ok) {
+      setIsError(true)
+      toast.error(language.error.validation)
+      return
+    }
     setIsSubmitting(true)
     setIsError(false)
-
     if (!formData) return
 
     axios
@@ -72,30 +80,27 @@ const SiteBackgroundForm = () => {
       })
   }
 
-  const handleStakeholdersOnChange = (event, stakeholder) => {
-    const stakeholderTypesCheckedCopy = [...stakeholderTypesChecked]
-    if (event.target.checked) {
-      stakeholdersAppend({ stakeholderType: stakeholder })
-      stakeholderTypesCheckedCopy.push(stakeholder)
-    } else {
-      const fieldIndex = stakeholdersFields.findIndex(
-        (field) => field.stakeholderType === stakeholder
-      )
-      const typeIndex = stakeholderTypesCheckedCopy.findIndex((type) => type === stakeholder)
-      stakeholderTypesCheckedCopy.splice(typeIndex, 1)
-      stakeholdersRemove(fieldIndex)
-    }
+  const handleStakeholdersOnChange = (_event, stakeholder) => {
+    setStakeholderTypesChecked((prev) => {
+      const isChecked = prev.includes(stakeholder)
+      const next = isChecked ? prev.filter((t) => t !== stakeholder) : [...prev, stakeholder]
 
-    setStakeholderTypesChecked(stakeholderTypesCheckedCopy)
+      if (isChecked) {
+        const fieldIndex = stakeholdersFields.findIndex(
+          (field) => field.stakeholderType === stakeholder
+        )
+        if (fieldIndex !== -1) stakeholdersRemove(fieldIndex)
+      } else {
+        const exists = stakeholdersFields.some((f) => f.stakeholderType === stakeholder)
+        if (!exists) stakeholdersAppend({ stakeholderType: stakeholder })
+      }
+
+      return next
+    })
   }
 
   const getStakeholder = (stakeholder) =>
     stakeholdersFields.find((field) => field.stakeholderType === stakeholder)
-
-  const stakeholdersChecked = useMemo(
-    () => form.getValues('stakeholders')?.map((d) => d?.stakeholderType),
-    [form]
-  )
 
   return (
     <ContentWrapper>
@@ -106,7 +111,7 @@ const SiteBackgroundForm = () => {
       <QuestionNav
         isFormSaving={isSubmitting}
         isFormSaveError={isError}
-        onFormSave={form.handleSubmit(handleSubmit)}
+        onFormSave={() => handleSubmit(form.getValues())}
         currentSection='site-background'
       />
       <FormValidationMessageIfErrors formErrors={form.errors} />
@@ -118,46 +123,42 @@ const SiteBackgroundForm = () => {
             {siteBackground.stakeholders.question} <RequiredIndicator />
           </StickyFormLabel>
           <List>
-            {siteBackground.stakeholders.options?.map((stakeholder, index) => (
-              <ListItem key={index}>
-                <Box>
+            {siteBackground.stakeholders.options?.map((stakeholder, index) => {
+              return (
+                <ListItem key={index}>
                   <Box>
-                    <Checkbox
-                      value={stakeholder}
-                      checked={stakeholdersChecked?.includes(stakeholder)}
-                      onChange={(event) => {
-                        handleStakeholdersOnChange(event, stakeholder)
-                      }}></Checkbox>
-                    <Typography variant='subtitle'>{stakeholder}</Typography>
+                    <Box>
+                      <Checkbox
+                        value={stakeholder}
+                        checked={stakeholderTypesChecked?.includes(stakeholder)}
+                        onChange={(event) => {
+                          handleStakeholdersOnChange(event, stakeholder)
+                        }}></Checkbox>
+                      <Typography variant='subtitle'>{stakeholder}</Typography>
+                    </Box>
+                    <Box>
+                      {getStakeholder(stakeholder) && stakeholder !== 'Unknown' ? (
+                        <Controller
+                          name={`stakeholders.${stakeholdersFields.findIndex(
+                            (field) => field.stakeholderType === stakeholder
+                          )}.stakeholderName`}
+                          control={form.control}
+                          defaultValue=''
+                          render={({ field }) => (
+                            <TextField
+                              sx={{ marginTop: '1em' }}
+                              label='Name'
+                              variant='outlined'
+                              {...field}
+                            />
+                          )}
+                        />
+                      ) : null}
+                    </Box>
                   </Box>
-                  <Box>
-                    {getStakeholder(stakeholder) && stakeholder !== 'Unknown' ? (
-                      <Controller
-                        name={`stakeholders.${stakeholdersFields.findIndex(
-                          (field) => field.stakeholderType === stakeholder
-                        )}.stakeholderName`}
-                        control={form.control}
-                        defaultValue=''
-                        render={({ field }) => (
-                          <TextField
-                            sx={{ marginTop: '1em' }}
-                            label='Name'
-                            variant='outlined'
-                            {...field}
-                            // onChange={() => {
-                            //   ;`stakeholders.${stakeholdersFields.findIndex(
-                            //     (field) => field.stakeholderType === stakeholder
-                            //   )}.stakeholderName`
-                            // }}
-                            // value={field.value}
-                          />
-                        )}
-                      />
-                    ) : null}
-                  </Box>
-                </Box>
-              </ListItem>
-            ))}
+                </ListItem>
+              )
+            })}
           </List>
           <ErrorText>{form.errors?.stakeholders?.message}</ErrorText>
         </FormQuestionDiv>

--- a/mrtt-ui/src/components/SiteInterventions/SiteInterventionsForm.js
+++ b/mrtt-ui/src/components/SiteInterventions/SiteInterventionsForm.js
@@ -71,7 +71,7 @@ function SiteInterventionsForm() {
     remove: mangroveSpeciesUsedRemove,
     update: mangroveSpeciesUsedUpdate
   } = useFieldArray({ name: 'mangroveSpeciesUsed', control })
-
+  console.log(mangroveSpeciesUsedFields, 'mangrove species used fields')
   const {
     fields: mangroveAssociatedSpeciesFields,
     append: mangroveAssociatedSpeciesAppend,
@@ -88,7 +88,7 @@ function SiteInterventionsForm() {
   const { siteId } = useParams()
   const apiAnswersUrl = `${process.env.REACT_APP_API_URL}/sites/${siteId}/registration_intervention_answers`
   const [isSubmitting, setIsSubmitting] = useState(false)
-  const [isSubmitError, setIsSubmitError] = useState(false)
+  const [isError, setIsError] = useState(false)
   const [mangroveSpeciesForCountriesSelected, setMangroveSpeciesForCountriesSelected] = useState([])
   const [mangroveSpeciesUsedChecked, setMangroveSpeciesUsedChecked] = useState([])
   const [whichStakeholdersInvolvedTypesChecked, setWhichStakeholdersInvolvedTypesChecked] =
@@ -129,10 +129,16 @@ function SiteInterventionsForm() {
     successCallback: loadServerData
   })
 
-  const handleSubmit = (formData) => {
+  const handleSubmit = async (formData) => {
+    const fields = Object.keys(questionMapping['siteInterventions'])
+    const ok = await form.trigger(fields, { shouldFocus: true })
+    if (!ok) {
+      setIsError(true)
+      toast.error(language.error.validation)
+      return
+    }
     setIsSubmitting(true)
-    setIsSubmitError(false)
-
+    setIsError(false)
     if (!formData) return
 
     axios
@@ -143,7 +149,7 @@ function SiteInterventionsForm() {
       })
       .catch(() => {
         setIsSubmitting(false)
-        setIsSubmitError(true)
+        setIsError(true)
         toast.error(language.error.submit)
       })
   }
@@ -254,8 +260,8 @@ function SiteInterventionsForm() {
       </FormPageHeader>
       <QuestionNav
         isFormSaving={isSubmitting}
-        isFormSaveError={isSubmitError}
-        onFormSave={validateInputs(handleSubmit)}
+        isFormSaveError={isError}
+        onFormSave={() => handleSubmit(form.getValues())}
         currentSection='site-interventions'
       />
       <FormValidationMessageIfErrors formErrors={errors} />

--- a/mrtt-ui/src/components/SiteInterventions/SiteInterventionsForm.js
+++ b/mrtt-ui/src/components/SiteInterventions/SiteInterventionsForm.js
@@ -71,7 +71,7 @@ function SiteInterventionsForm() {
     remove: mangroveSpeciesUsedRemove,
     update: mangroveSpeciesUsedUpdate
   } = useFieldArray({ name: 'mangroveSpeciesUsed', control })
-  console.log(mangroveSpeciesUsedFields, 'mangrove species used fields')
+
   const {
     fields: mangroveAssociatedSpeciesFields,
     append: mangroveAssociatedSpeciesAppend,

--- a/mrtt-ui/src/constants/sectionNames.js
+++ b/mrtt-ui/src/constants/sectionNames.js
@@ -13,5 +13,18 @@ const SECTION_NAMES = [
   'ecological-status-and-outcomes'
 ]
 
+export const SECTION_NAMES_DICTIONARY = {
+  'project-details': 'projectDetails',
+  'site-background': 'siteBackground',
+  'restoration-aims': 'restorationAims',
+  'causes-of-decline': 'causesOfDecline',
+  'pre-restoration-assessment': 'preRestorationAssessment',
+  'site-interventions': 'siteInterventions',
+  costs: 'costs',
+  'management-status-and-effectiveness': 'managementStatusAndEffectiveness',
+  'socioeconomic-and-governance-status': 'socioeconomicAndGovernanceStatusAndOutcomes',
+  'ecological-status-and-outcomes': 'ecologicalStatusAndOutcomes'
+}
+
 Object.freeze(SECTION_NAMES)
 export default SECTION_NAMES

--- a/mrtt-ui/src/hooks/registrationInterventionAnswers.ts
+++ b/mrtt-ui/src/hooks/registrationInterventionAnswers.ts
@@ -1,49 +1,13 @@
-import { useEffect, useState } from 'react'
 import axios from 'axios'
-import { UseFormReturn } from 'react-hook-form'
 
-type Options = {
-  enabled?: boolean
-}
-
-export function useRegistrationAnswers(
-  form: UseFormReturn<any>,
-  apiUrl: string,
-  options: Options = {}
-) {
-  const { reset } = form
-  const { enabled = true } = options
-
-  const [isLoading, setIsLoading] = useState(false)
-  const [isError, setIsError] = useState(false)
-
-  useEffect(() => {
-    if (!enabled) return
-
-    let cancelled = false
-
-    const fetchAnswers = async () => {
-      setIsLoading(true)
-      setIsError(false)
-
-      try {
-        const { data } = await axios.get(apiUrl)
-        if (cancelled) return
-
-        reset(data)
-      } catch (e) {
-        if (!cancelled) setIsError(true)
-      } finally {
-        if (!cancelled) setIsLoading(false)
-      }
-    }
-
-    fetchAnswers()
-
-    return () => {
-      cancelled = true
-    }
-  }, [apiUrl, enabled, reset])
-
-  return { isLoading, isError }
+export function useRegistrationAnswers(apiUrl: string) {
+  return axios
+    .get(apiUrl)
+    .then((data) => {
+      console.info('Section saved successfully', data)
+      return data.data
+    })
+    .catch(() => {
+      console.error('Error fetching registration intervention answers')
+    })
 }

--- a/mrtt-ui/src/hooks/registrationInterventionAnswers.ts
+++ b/mrtt-ui/src/hooks/registrationInterventionAnswers.ts
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react'
+import axios from 'axios'
+import { UseFormReturn } from 'react-hook-form'
+
+type Options = {
+  enabled?: boolean
+}
+
+export function useRegistrationAnswers(
+  form: UseFormReturn<any>,
+  apiUrl: string,
+  options: Options = {}
+) {
+  const { reset } = form
+  const { enabled = true } = options
+
+  const [isLoading, setIsLoading] = useState(false)
+  const [isError, setIsError] = useState(false)
+
+  useEffect(() => {
+    if (!enabled) return
+
+    let cancelled = false
+
+    const fetchAnswers = async () => {
+      console.log('fetch', apiUrl)
+      setIsLoading(true)
+      setIsError(false)
+
+      try {
+        const { data } = await axios.get(apiUrl)
+        if (cancelled) return
+
+        reset(data)
+      } catch (e) {
+        if (!cancelled) setIsError(true)
+      } finally {
+        if (!cancelled) setIsLoading(false)
+      }
+    }
+
+    fetchAnswers()
+
+    return () => {
+      cancelled = true
+    }
+  }, [apiUrl, enabled, reset])
+
+  return { isLoading, isError }
+}

--- a/mrtt-ui/src/hooks/registrationInterventionAnswers.ts
+++ b/mrtt-ui/src/hooks/registrationInterventionAnswers.ts
@@ -23,7 +23,6 @@ export function useRegistrationAnswers(
     let cancelled = false
 
     const fetchAnswers = async () => {
-      console.log('fetch', apiUrl)
       setIsLoading(true)
       setIsError(false)
 

--- a/mrtt-ui/src/views/SiteForm.js
+++ b/mrtt-ui/src/views/SiteForm.js
@@ -40,7 +40,7 @@ const SiteForm = ({ isNewSite }) => {
 
   const siteForm = useFormContext()
   const { reset: resetSiteForm, getValues: siteFormValues } = siteForm
-  console.log(siteFormValues(), 'site form values')
+
   const {
     control: formControl,
     handleSubmit: validateInputs,
@@ -103,7 +103,6 @@ const SiteForm = ({ isNewSite }) => {
       .then(({ data: { site_name } }) => {
         setIsSubmitting(false)
         toast.success(language.success.getCreateThingSuccessMessage(site_name))
-        console.log(site_name, form)
         resetSiteForm()
         navigate('/sites')
       })

--- a/mrtt-ui/src/views/SiteForm.js
+++ b/mrtt-ui/src/views/SiteForm.js
@@ -1,4 +1,4 @@
-import { Controller, useForm } from 'react-hook-form'
+import { Controller, useForm, useFormContext } from 'react-hook-form'
 import { toast } from 'react-toastify'
 import { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
@@ -38,6 +38,9 @@ const SiteForm = ({ isNewSite }) => {
   const sitesUrl = `${process.env.REACT_APP_API_URL}/sites`
   const siteUrl = `${sitesUrl}/${siteId}`
 
+  const siteForm = useFormContext()
+  const { reset: resetSiteForm, getValues: siteFormValues } = siteForm
+  console.log(siteFormValues(), 'site form values')
   const {
     control: formControl,
     handleSubmit: validateInputs,
@@ -100,6 +103,8 @@ const SiteForm = ({ isNewSite }) => {
       .then(({ data: { site_name } }) => {
         setIsSubmitting(false)
         toast.success(language.success.getCreateThingSuccessMessage(site_name))
+        console.log(site_name, form)
+        resetSiteForm()
         navigate('/sites')
       })
       .catch(() => {

--- a/mrtt-ui/src/views/Sites.js
+++ b/mrtt-ui/src/views/Sites.js
@@ -69,19 +69,21 @@ function Sites() {
 
   const open = Boolean(downloadOptionsAnchorEl)
 
-  const sitesList = sites
-    .sort((siteA, siteB) => {
-      const siteALastUpdatedDate = siteA.section_last_updated
-      const siteBLastUpdatedDate = siteB.section_last_updated
+  const orderedSitesTesting = sites.sort((a, b) => a.site_name.localeCompare(b.site_name)).reverse()
 
-      if (siteALastUpdatedDate > siteBLastUpdatedDate || !siteALastUpdatedDate) {
-        return -1
-      }
-      if (siteALastUpdatedDate < siteBLastUpdatedDate) {
-        return 1
-      }
-      return 0
-    })
+  const sitesList = orderedSitesTesting
+    // .sort((siteA, siteB) => {
+    //   const siteALastUpdatedDate = siteA.section_last_updated
+    //   const siteBLastUpdatedDate = siteB.section_last_updated
+
+    //   if (siteALastUpdatedDate > siteBLastUpdatedDate || !siteALastUpdatedDate) {
+    //     return -1
+    //   }
+    //   if (siteALastUpdatedDate < siteBLastUpdatedDate) {
+    //     return 1
+    //   }
+    //   return 0
+    // })
     .map(({ site_name, landscape_name, id, section_last_updated }) => {
       const anySectionLastEditedString = new Date(section_last_updated).toLocaleDateString(
         undefined,


### PR DESCRIPTION
This pull request introduces several improvements to form validation and error handling across multiple form components in the codebase. The main focus is on ensuring that form validation is explicitly triggered for relevant fields before submission, providing clearer feedback to users about which sections contain errors, and standardizing error state variable naming. Additionally, there are minor code cleanups and debugging additions.

**Form validation and error handling improvements:**

* Added explicit validation before form submission in `ProjectDetailsForm`, `PreRestorationAssessmentForm`, `CausesOfDeclineForm`, `RestorationAimsForm`, and `ManagementStatusAndEffectivenessForm`. Now, only if all required fields pass validation does the form proceed to submit, otherwise, users receive immediate feedback. [[1]](diffhunk://#diff-6155dbfa72018b08407ef10a792736dc5a835a9347c3432f48233e6bf0a7e368R97-R112) [[2]](diffhunk://#diff-b58d7b973b69f3f1166c277ebc3afa49f5b1ae59999b6fb3821ee1ccf2756976L133-R153) [[3]](diffhunk://#diff-68859b676bc8a05bd13e929862ce4c23e85fb12ac70ba9d3a8b3056d6be1e1bfL217-R237) [[4]](diffhunk://#diff-a5a2de75d7f8492114cf9e4f5a617f31fb18573f07b4d88f14652ebca1f92712L56-R66) [[5]](diffhunk://#diff-1d2b59ff2ec93864cf941190e351613d3ade0f42a12421b5a44ab2ca862b9506L85-R106)
* Updated error state variable naming from `isSubmitError`/`setisSubmitting` to `isError`/`setIsSubmitting` for consistency and clarity across forms. [[1]](diffhunk://#diff-a5a2de75d7f8492114cf9e4f5a617f31fb18573f07b4d88f14652ebca1f92712L30-R30) [[2]](diffhunk://#diff-1d2b59ff2ec93864cf941190e351613d3ade0f42a12421b5a44ab2ca862b9506L47-R47) [[3]](diffhunk://#diff-68859b676bc8a05bd13e929862ce4c23e85fb12ac70ba9d3a8b3056d6be1e1bfL54-R54) [[4]](diffhunk://#diff-b58d7b973b69f3f1166c277ebc3afa49f5b1ae59999b6fb3821ee1ccf2756976L86-R86)
* Changed form submission handlers to use `onFormSave={() => handleSubmit(form.getValues())}` instead of relying on react-hook-form’s internal handler, ensuring custom validation logic is executed before submission. [[1]](diffhunk://#diff-6155dbfa72018b08407ef10a792736dc5a835a9347c3432f48233e6bf0a7e368L117-R132) [[2]](diffhunk://#diff-b58d7b973b69f3f1166c277ebc3afa49f5b1ae59999b6fb3821ee1ccf2756976L210-R217) [[3]](diffhunk://#diff-68859b676bc8a05bd13e929862ce4c23e85fb12ac70ba9d3a8b3056d6be1e1bfL253-R260) [[4]](diffhunk://#diff-1d2b59ff2ec93864cf941190e351613d3ade0f42a12421b5a44ab2ca862b9506L135-R144)

**User feedback enhancements:**

* Enhanced the `FormValidationMessageIfErrors` component to display which specific sections have errors, using a new `getSectionsWithErrors` utility function and the `questionMapping` object. [[1]](diffhunk://#diff-40a371907f43cefd339d11642f95015555c1777766eb2d6ff4080fbc5d386988R6-R30) [[2]](diffhunk://#diff-40a371907f43cefd339d11642f95015555c1777766eb2d6ff4080fbc5d386988R43)

**Debugging and minor code cleanups:**

* Added temporary `console.log` statements in several components for debugging purposes. [[1]](diffhunk://#diff-6155dbfa72018b08407ef10a792736dc5a835a9347c3432f48233e6bf0a7e368R54-R58) [[2]](diffhunk://#diff-6155dbfa72018b08407ef10a792736dc5a835a9347c3432f48233e6bf0a7e368L107-R122) [[3]](diffhunk://#diff-18a46ba3d06e1f56c0eeb62b98f7bdd40e25df3f111f6e047260b1a76c9ecd1cL79-R79) [[4]](diffhunk://#diff-18a46ba3d06e1f56c0eeb62b98f7bdd40e25df3f111f6e047260b1a76c9ecd1cL221-R221) [[5]](diffhunk://#diff-6155dbfa72018b08407ef10a792736dc5a835a9347c3432f48233e6bf0a7e368R149)
* Minor import and code organization improvements, such as adding missing imports and cleaning up unused variables. [[1]](diffhunk://#diff-6155dbfa72018b08407ef10a792736dc5a835a9347c3432f48233e6bf0a7e368L3-R3) [[2]](diffhunk://#diff-6155dbfa72018b08407ef10a792736dc5a835a9347c3432f48233e6bf0a7e368L14-R14) [[3]](diffhunk://#diff-6155dbfa72018b08407ef10a792736dc5a835a9347c3432f48233e6bf0a7e368L29-R29) [[4]](diffhunk://#diff-18a46ba3d06e1f56c0eeb62b98f7bdd40e25df3f111f6e047260b1a76c9ecd1cL20-R20)

These changes collectively enhance the reliability and user experience of form submissions throughout the application.
