### PR TITLE
Fix/form staged

### DIFF
--- a/mrtt-ui/pnpm-lock.yaml
+++ b/mrtt-ui/pnpm-lock.yaml
@@ -12390,7 +12390,7 @@ snapshots:
       case-sensitive-paths-webpack-plugin: 2.4.0
       core-js: 3.41.0
       css-loader: 3.6.0(webpack@4.47.0)
-      file-loader: 6.2.0(webpack@5.99.7(esbuild@0.25.3))
+      file-loader: 6.2.0(webpack@4.47.0)
       find-up: 5.0.0
       fork-ts-checker-webpack-plugin: 4.1.6(eslint@8.57.1)(typescript@5.8.3)(webpack@4.47.0)
       glob: 7.2.3
@@ -12866,7 +12866,7 @@ snapshots:
       core-js: 3.41.0
       css-loader: 3.6.0(webpack@4.47.0)
       express: 4.21.2
-      file-loader: 6.2.0(webpack@4.47.0)
+      file-loader: 6.2.0(webpack@5.99.7(esbuild@0.25.3))
       find-up: 5.0.0
       fs-extra: 9.1.0
       html-webpack-plugin: 4.5.2(webpack@4.47.0)

--- a/mrtt-ui/src/App.js
+++ b/mrtt-ui/src/App.js
@@ -141,7 +141,7 @@ function App() {
                     element={<EcologicalStatusAndOutcomesForm />}
                   />
                   <Route
-                    path='/sites/:siteId/form/project-details/'
+                    path='/sites/:siteId/form/project-details'
                     element={<ProjectDetailsForm />}
                   />
                   <Route

--- a/mrtt-ui/src/components/ButtonSave.js
+++ b/mrtt-ui/src/components/ButtonSave.js
@@ -3,10 +3,10 @@ import PropTypes from 'prop-types'
 import { ButtonPrimary } from '../styles/buttons'
 import language from '../language'
 
-const ButtonSave = ({ isSaving, component, hasErrors, ...restOfProps }) => {
+const ButtonSave = ({ isSaving, component, ...restOfProps }) => {
   const ComponentToUse = component ? component : ButtonPrimary
   return (
-    <ComponentToUse disabled={isSaving || hasErrors} {...restOfProps}>
+    <ComponentToUse disabled={isSaving} {...restOfProps}>
       {isSaving ? language.buttons.saving : language.buttons.save}
     </ComponentToUse>
   )
@@ -14,8 +14,7 @@ const ButtonSave = ({ isSaving, component, hasErrors, ...restOfProps }) => {
 
 ButtonSave.propTypes = {
   isSaving: PropTypes.bool.isRequired,
-  component: PropTypes.any,
-  hasErrors: PropTypes.bool.isRequired
+  component: PropTypes.any
 }
 
 ButtonSave.defaultProps = {

--- a/mrtt-ui/src/components/CausesOfDeclineForm.js
+++ b/mrtt-ui/src/components/CausesOfDeclineForm.js
@@ -93,10 +93,12 @@ function CausesOfDeclineForm() {
     setCausesOfDeclineTypesChecked(initialCausesOfDeclineTypesChecked)
   }, [])
 
-  useInitializeQuestionMappedForm({
+  const { data, isLoading } = useInitializeQuestionMappedForm({
+    key: 'causesOfDecline',
     apiUrl: apiAnswersUrl,
-    questionMapping: questionMapping.causesOfDecline,
-    successCallback: setInitialCausesOfDeclineTypesFromServerData
+    resetForm: form.reset,
+    questionMapping
+    // successCallback: setInitialCausesOfDeclineTypesFromServerData
   })
 
   // big function with many different cases for Q4.2 due to the nesting involved in this question type
@@ -121,7 +123,7 @@ function CausesOfDeclineForm() {
     if (event.target.checked && !subCauseLabel && mainCauseIndex === -1) {
       causesOfDeclineAppend({
         mainCauseLabel,
-        mainCauseAnswers: [{ mainCauseAnswer: childOption, levelOfDegredation: '' }]
+        mainCauseAnswers: [{ mainCauseAnswer: childOption, levelOfDegradation: '' }]
       })
       causesOfDeclineTypesCheckedCopy.push(`${mainCauseLabel}-${childOption}`)
     }
@@ -129,7 +131,7 @@ function CausesOfDeclineForm() {
     else if (event.target.checked && !subCauseLabel && mainCauseIndex > -1) {
       currentMainCause.mainCauseAnswers.push({
         mainCauseAnswer: childOption,
-        levelOfDegredation: ''
+        levelOfDegradation: ''
       })
       causesOfDeclineUpdate(currentMainCause)
       causesOfDeclineTypesCheckedCopy.push(`${mainCauseLabel}-${childOption}`)
@@ -141,7 +143,7 @@ function CausesOfDeclineForm() {
         subCauses: [
           {
             subCauseLabel,
-            subCauseAnswers: [{ subCauseAnswer: secondaryChildOption, levelOfDegredation: '' }]
+            subCauseAnswers: [{ subCauseAnswer: secondaryChildOption, levelOfDegradation: '' }]
           }
         ]
       })
@@ -153,7 +155,7 @@ function CausesOfDeclineForm() {
       if (subCauseIndex === -1) {
         currentMainCause.subCauses.push({
           subCauseLabel,
-          subCauseAnswers: [{ subCauseAnswer: secondaryChildOption, levelOfDegredation: '' }]
+          subCauseAnswers: [{ subCauseAnswer: secondaryChildOption, levelOfDegradation: '' }]
         })
         causesOfDeclineUpdate(currentMainCause)
       }
@@ -161,7 +163,7 @@ function CausesOfDeclineForm() {
       else {
         currentSubCause.subCauseAnswers.push({
           subCauseAnswer: secondaryChildOption,
-          levelOfDegredation: ''
+          levelOfDegradation: ''
         })
         causesOfDeclineUpdate(currentMainCause)
       }
@@ -213,31 +215,31 @@ function CausesOfDeclineForm() {
     setCausesOfDeclineTypesChecked(causesOfDeclineTypesCheckedCopy)
   }
 
-  const onSubmit = async (data) => {
-    const fields = Object.keys(questionMapping['causesOfDecline'])
-    const ok = await form.trigger(fields, { shouldFocus: true })
+  // const onSubmit = async (data) => {
+  //   const fields = Object.keys(questionMapping['causesOfDecline'])
+  //   const ok = await form.trigger(fields, { shouldFocus: true })
 
-    if (!ok) {
-      setIsError(true)
-      toast.error(language.error.validation)
-      return
-    }
-    setIsSubmitting(true)
-    setIsError(false)
-    if (!data) return
+  //   if (!ok) {
+  //     setIsError(true)
+  //     toast.error(language.error.validation)
+  //     return
+  //   }
+  //   setIsSubmitting(true)
+  //   setIsError(false)
+  //   if (!data) return
 
-    axios
-      .patch(apiAnswersUrl, mapDataForApi('causesOfDecline', data))
-      .then(() => {
-        setIsSubmitting(false)
-        toast.success(language.success.submit)
-      })
-      .catch(() => {
-        setIsError(true)
-        setIsSubmitting(false)
-        toast.error(language.error.apiLoad)
-      })
-  }
+  //   axios
+  //     .patch(apiAnswersUrl, mapDataForApi('causesOfDecline', data))
+  //     .then(() => {
+  //       setIsSubmitting(false)
+  //       toast.success(language.success.submit)
+  //     })
+  //     .catch(() => {
+  //       setIsError(true)
+  //       setIsSubmitting(false)
+  //       toast.error(language.error.apiLoad)
+  //     })
+  // }
 
   const causesOfDeclineChecked = useMemo(() => {
     const causes = form.getValues('causesOfDecline') ?? []
@@ -257,197 +259,196 @@ function CausesOfDeclineForm() {
       <QuestionNav
         isFormSaving={isSubmitting}
         isFormSaveError={isError}
-        onFormSave={handleSubmit(onSubmit)}
         currentSection='causes-of-decline'
       />
       <FormValidationMessageIfErrors formErrors={errors} />
-      <FormProvider>
-        <FormLayout>
+      {/* <FormProvider> */}
+      <FormLayout>
+        <FormQuestionDiv>
+          <StickyFormLabel>{causesOfDecline.lossKnown.question}</StickyFormLabel>
+          <Controller
+            name='lossKnown'
+            control={control}
+            defaultValue={false}
+            render={({ field }) => {
+              return (
+                <RadioGroup
+                  {...field}
+                  aria-labelledby='demo-radio-buttons-group-label'
+                  name='radio-buttons-group'>
+                  {/* Mui converts values to strings, even for booleans */}
+                  <FormControlLabel value={true} control={<Radio />} label='Yes' />
+                  <FormControlLabel value={false} control={<Radio />} label='No' />
+                </RadioGroup>
+              )
+            }}
+          />
+        </FormQuestionDiv>
+        {lossKnownWatcher === 'true' ? (
           <FormQuestionDiv>
-            <StickyFormLabel>{causesOfDecline.lossKnown.question}</StickyFormLabel>
-            <Controller
-              name='lossKnown'
-              control={control}
-              defaultValue={false}
-              render={({ field }) => {
-                return (
-                  <RadioGroup
-                    {...field}
-                    aria-labelledby='demo-radio-buttons-group-label'
-                    name='radio-buttons-group'>
-                    {/* Mui converts values to strings, even for booleans */}
-                    <FormControlLabel value={true} control={<Radio />} label='Yes' />
-                    <FormControlLabel value={false} control={<Radio />} label='No' />
-                  </RadioGroup>
-                )
-              }}
-            />
-          </FormQuestionDiv>
-          {lossKnownWatcher === 'true' ? (
-            <FormQuestionDiv>
-              <StickyFormLabel>
-                {causesOfDecline.causesOfDecline.question} <RequiredIndicator />
-              </StickyFormLabel>
-              {causesOfDeclineOptions.map((mainCause, mainCauseIndex) => {
-                return (
-                  <Box key={mainCauseIndex} sx={{ marginTop: '0.75em', marginBottom: '1.5em' }}>
-                    <NestedLabel1>{mainCause.label}</NestedLabel1>
-                    {typeof mainCause.children[0] === 'string'
-                      ? mainCause.children.map((childOption, childIndex) => (
-                          <Box key={childIndex}>
-                            <Box>
-                              <ListItem>
-                                <Checkbox
-                                  value={childOption}
-                                  checked={causesOfDeclineChecked.includes(
-                                    `${mainCause.label}-${childOption}`
-                                  )}
-                                  onChange={(event) =>
-                                    handleCausesOfDeclineOnChange({
-                                      event,
-                                      mainCauseLabel: mainCause.label,
-                                      childOption
-                                    })
-                                  }></Checkbox>
-                                <Typography variant='subtitle2'>{childOption}</Typography>
-                              </ListItem>
-                            </Box>
-                          </Box>
-                        ))
-                      : mainCause.children.map((subCause, subCauseIndex) => (
-                          <Box
-                            key={subCauseIndex}
-                            variant='subtitle2'
-                            sx={{ marginLeft: '1em', marginTop: '0.75em' }}>
-                            <NestedLabel2>{subCause.secondaryLabel}</NestedLabel2>
-                            {subCause.secondaryChildren.map(
-                              (secondaryChildOption, secondaryChildIndex) => {
-                                return (
-                                  <ListItem key={secondaryChildIndex}>
-                                    <Checkbox
-                                      value={secondaryChildOption}
-                                      checked={causesOfDeclineTypesChecked.includes(
-                                        `${subCause.secondaryLabel}-${secondaryChildOption}`
-                                      )}
-                                      onChange={(event) =>
-                                        handleCausesOfDeclineOnChange({
-                                          event,
-                                          mainCauseLabel: mainCause.label,
-                                          subCauseLabel: subCause.secondaryLabel,
-                                          secondaryChildOption
-                                        })
-                                      }></Checkbox>
-                                    <Typography variant='subtitle2'>
-                                      {secondaryChildOption}
-                                    </Typography>
-                                  </ListItem>
-                                )
-                              }
-                            )}
-                          </Box>
-                        ))}
-                  </Box>
-                )
-              })}
-              <ErrorText>{errors?.causesOfDecline?.message}</ErrorText>
-            </FormQuestionDiv>
-          ) : null}
-          {causesOfDeclineFields.length ? (
-            <FormQuestionDiv>
-              <StickyFormLabel>{causesOfDecline.levelsOfDegredation.question}</StickyFormLabel>
-              {causesOfDeclineFields?.map((mainCause, mainCauseIndex) => (
-                <Box key={mainCauseIndex}>
-                  <NestedLabel1>{mainCause.mainCauseLabel}</NestedLabel1>
-                  {mainCause.mainCauseAnswers?.map((answer, answerIndex) => {
-                    return (
-                      <Box key={answerIndex}>
-                        <Typography sx={{ marginLeft: '0.75em' }} variant='subtitle2'>
-                          {answer.mainCauseAnswer}
-                        </Typography>
-                        <Controller
-                          name={`causesOfDecline.${mainCauseIndex}.mainCauseAnswers.${answerIndex}.levelOfDegredation`}
-                          control={control}
-                          defaultValue=''
-                          required
-                          render={({ field }) => (
-                            <TextField
-                              {...field}
-                              select
-                              required
-                              value={field.value}
-                              label='Magnitude of impact *'
-                              sx={{
-                                width: '13em',
-                                marginLeft: '0.5em',
-                                marginTop: '0.5em',
-                                marginBottom: '1.5em'
-                              }}>
-                              {causesOfDecline.levelsOfDegredation.options.map((item, index) => (
-                                <MenuItem key={index} value={item} sx={{ fontSize: '1.8rem' }}>
-                                  {item}
-                                </MenuItem>
-                              ))}
-                            </TextField>
-                          )}
-                        />
-                      </Box>
-                    )
-                  })}
-                  {mainCause.subCauses?.map((subCause, subCauseIndex) => {
-                    return (
-                      <Box key={subCauseIndex}>
-                        <NestedLabel2>{subCause.subCauseLabel}</NestedLabel2>
-                        {subCause.subCauseAnswers?.map((subCauseAnswer, subCauseAnswerIndex) => {
-                          return (
-                            <Box key={subCauseAnswerIndex}>
-                              <Typography sx={{ marginLeft: '0.75em' }} variant='subtitle2'>
-                                {subCauseAnswer.subCauseAnswer}
-                              </Typography>
-                              <Controller
-                                name={`causesOfDecline.${mainCauseIndex}.subCauses.${subCauseIndex}.subCauseAnswers.${subCauseAnswerIndex}.levelOfDegredation`}
-                                control={control}
-                                defaultValue=''
-                                required
-                                render={({ field }) => (
-                                  <TextField
-                                    {...field}
-                                    select
-                                    value={field.value}
-                                    label='Magnitude of impact *'
-                                    sx={{
-                                      width: '13em',
-                                      marginLeft: '0.5em',
-                                      marginTop: '0.5em',
-                                      marginBottom: '1em'
-                                    }}>
-                                    {causesOfDecline?.levelsOfDegredation.options?.map(
-                                      (item, index) => (
-                                        <MenuItem key={index} value={item}>
-                                          {item}
-                                        </MenuItem>
-                                      )
-                                    )}
-                                  </TextField>
+            <StickyFormLabel>
+              {causesOfDecline.causesOfDecline.question} <RequiredIndicator />
+            </StickyFormLabel>
+            {causesOfDeclineOptions.map((mainCause, mainCauseIndex) => {
+              return (
+                <Box key={mainCauseIndex} sx={{ marginTop: '0.75em', marginBottom: '1.5em' }}>
+                  <NestedLabel1>{mainCause.label}</NestedLabel1>
+                  {typeof mainCause.children[0] === 'string'
+                    ? mainCause.children.map((childOption, childIndex) => (
+                        <Box key={childIndex}>
+                          <Box>
+                            <ListItem>
+                              <Checkbox
+                                value={childOption}
+                                checked={causesOfDeclineChecked.includes(
+                                  `${mainCause.label}-${childOption}`
                                 )}
-                              />
-                            </Box>
-                          )
-                        })}
-                      </Box>
-                    )
-                  })}
+                                onChange={(event) =>
+                                  handleCausesOfDeclineOnChange({
+                                    event,
+                                    mainCauseLabel: mainCause.label,
+                                    childOption
+                                  })
+                                }></Checkbox>
+                              <Typography variant='subtitle2'>{childOption}</Typography>
+                            </ListItem>
+                          </Box>
+                        </Box>
+                      ))
+                    : mainCause.children.map((subCause, subCauseIndex) => (
+                        <Box
+                          key={subCauseIndex}
+                          variant='subtitle2'
+                          sx={{ marginLeft: '1em', marginTop: '0.75em' }}>
+                          <NestedLabel2>{subCause.secondaryLabel}</NestedLabel2>
+                          {subCause.secondaryChildren.map(
+                            (secondaryChildOption, secondaryChildIndex) => {
+                              return (
+                                <ListItem key={secondaryChildIndex}>
+                                  <Checkbox
+                                    value={secondaryChildOption}
+                                    checked={causesOfDeclineTypesChecked.includes(
+                                      `${subCause.secondaryLabel}-${secondaryChildOption}`
+                                    )}
+                                    onChange={(event) =>
+                                      handleCausesOfDeclineOnChange({
+                                        event,
+                                        mainCauseLabel: mainCause.label,
+                                        subCauseLabel: subCause.secondaryLabel,
+                                        secondaryChildOption
+                                      })
+                                    }></Checkbox>
+                                  <Typography variant='subtitle2'>
+                                    {secondaryChildOption}
+                                  </Typography>
+                                </ListItem>
+                              )
+                            }
+                          )}
+                        </Box>
+                      ))}
                 </Box>
-              ))}
-              <ErrorText>
-                {/* if error msg exists, this has to do with MOI. Reduces complexity in flitering */}
-                {errors?.causesOfDecline?.length
-                  ? `Please select magnitude of impact for each item`
-                  : null}
-              </ErrorText>
-            </FormQuestionDiv>
-          ) : null}
-        </FormLayout>
-      </FormProvider>
+              )
+            })}
+            <ErrorText>{errors?.causesOfDecline?.message}</ErrorText>
+          </FormQuestionDiv>
+        ) : null}
+        {causesOfDeclineFields.length ? (
+          <FormQuestionDiv>
+            <StickyFormLabel>{causesOfDecline.levelsOfDegredation.question}</StickyFormLabel>
+            {causesOfDeclineFields?.map((mainCause, mainCauseIndex) => (
+              <Box key={mainCauseIndex}>
+                <NestedLabel1>{mainCause.mainCauseLabel}</NestedLabel1>
+                {mainCause.mainCauseAnswers?.map((answer, answerIndex) => {
+                  return (
+                    <Box key={answerIndex}>
+                      <Typography sx={{ marginLeft: '0.75em' }} variant='subtitle2'>
+                        {answer.mainCauseAnswer}
+                      </Typography>
+                      <Controller
+                        name={`causesOfDecline.${mainCauseIndex}.mainCauseAnswers.${answerIndex}.levelOfDegradation`}
+                        control={control}
+                        defaultValue=''
+                        required
+                        render={({ field }) => (
+                          <TextField
+                            {...field}
+                            select
+                            required
+                            value={field.value}
+                            label='Magnitude of impact *'
+                            sx={{
+                              width: '13em',
+                              marginLeft: '0.5em',
+                              marginTop: '0.5em',
+                              marginBottom: '1.5em'
+                            }}>
+                            {causesOfDecline.levelsOfDegredation.options.map((item, index) => (
+                              <MenuItem key={index} value={item} sx={{ fontSize: '1.8rem' }}>
+                                {item}
+                              </MenuItem>
+                            ))}
+                          </TextField>
+                        )}
+                      />
+                    </Box>
+                  )
+                })}
+                {mainCause.subCauses?.map((subCause, subCauseIndex) => {
+                  return (
+                    <Box key={subCauseIndex}>
+                      <NestedLabel2>{subCause.subCauseLabel}</NestedLabel2>
+                      {subCause.subCauseAnswers?.map((subCauseAnswer, subCauseAnswerIndex) => {
+                        return (
+                          <Box key={subCauseAnswerIndex}>
+                            <Typography sx={{ marginLeft: '0.75em' }} variant='subtitle2'>
+                              {subCauseAnswer.subCauseAnswer}
+                            </Typography>
+                            <Controller
+                              name={`causesOfDecline.${mainCauseIndex}.subCauses.${subCauseIndex}.subCauseAnswers.${subCauseAnswerIndex}.levelOfDegradation`}
+                              control={control}
+                              defaultValue=''
+                              required
+                              render={({ field }) => (
+                                <TextField
+                                  {...field}
+                                  select
+                                  value={field.value}
+                                  label='Magnitude of impact *'
+                                  sx={{
+                                    width: '13em',
+                                    marginLeft: '0.5em',
+                                    marginTop: '0.5em',
+                                    marginBottom: '1em'
+                                  }}>
+                                  {causesOfDecline?.levelsOfDegredation.options?.map(
+                                    (item, index) => (
+                                      <MenuItem key={index} value={item}>
+                                        {item}
+                                      </MenuItem>
+                                    )
+                                  )}
+                                </TextField>
+                              )}
+                            />
+                          </Box>
+                        )
+                      })}
+                    </Box>
+                  )
+                })}
+              </Box>
+            ))}
+            <ErrorText>
+              {/* if error msg exists, this has to do with MOI. Reduces complexity in flitering */}
+              {errors?.causesOfDecline?.length
+                ? `Please select magnitude of impact for each item`
+                : null}
+            </ErrorText>
+          </FormQuestionDiv>
+        ) : null}
+      </FormLayout>
+      {/* </FormProvider> */}
     </ContentWrapper>
   )
 }

--- a/mrtt-ui/src/components/Costs/CostsForm.js
+++ b/mrtt-ui/src/components/Costs/CostsForm.js
@@ -50,9 +50,19 @@ const CostsForm = () => {
   const { site_name } = useSiteInfo()
 
   const form = useFormContext()
+  const { siteId } = useParams()
+  const apiAnswersUrl = `${process.env.REACT_APP_API_URL}/sites/${siteId}/registration_intervention_answers`
+
+  const { data, isLoading } = useInitializeQuestionMappedForm({
+    key: 'costs',
+    apiUrl: apiAnswersUrl,
+    resetForm: form.reset,
+    questionMapping
+    // successCallback: loadServerData
+  })
 
   const {
-    handleSubmit: validateInputs,
+    // handleSubmit: validateInputs,
     formState: { errors },
     control,
     watch: watchForm
@@ -77,8 +87,6 @@ const CostsForm = () => {
     update: percentageSplitOfActivitiesUpdate
   } = useFieldArray({ name: 'percentageSplitOfActivities', control })
 
-  const { siteId } = useParams()
-  const apiAnswersUrl = `${process.env.REACT_APP_API_URL}/sites/${siteId}/registration_intervention_answers`
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [isSubmitError, setIsSubmitError] = useState(false)
   const projectInterventionFundingWatcher = watchForm('projectInterventionFunding')
@@ -145,12 +153,6 @@ const CostsForm = () => {
     },
     [breakdownOfCostReplace, percentageSplitOfActivitiesReplace]
   )
-
-  useInitializeQuestionMappedForm({
-    apiUrl: apiAnswersUrl,
-    questionMapping: questionMapping.costs,
-    successCallback: loadServerData
-  })
 
   const handleSubmit = (formData) => {
     setIsSubmitting(true)
@@ -228,7 +230,6 @@ const CostsForm = () => {
       <QuestionNav
         isFormSaving={isSubmitting}
         isFormSaveError={isSubmitError}
-        onFormSave={validateInputs(handleSubmit)}
         currentSection='costs'
       />
       <FormValidationMessageIfErrors formErrors={errors} />

--- a/mrtt-ui/src/components/DatePickerUtcMui.js
+++ b/mrtt-ui/src/components/DatePickerUtcMui.js
@@ -10,7 +10,7 @@ import { TextSmall } from '../styles/typography'
 import language from '../language'
 
 const DatePickerUtcMui = (props) => {
-  const value = props.field?.value ? DateTime.fromISO(props.field?.value).setZone('UTC+0') : null
+  const value = DateTime.fromISO(props.field?.value)
   return (
     <LocalizationProvider dateAdapter={AdapterLuxon}>
       <Stack spacing={3}>
@@ -30,7 +30,7 @@ const DatePickerUtcMui = (props) => {
 }
 
 DatePickerUtcMui.propTypes = {
-  field: PropTypes.shape({ onChange: PropTypes.func, value: PropTypes.string })
+  field: PropTypes.shape({ onChange: PropTypes.func, value: PropTypes.instanceOf(DateTime) })
 }
 
 export default DatePickerUtcMui

--- a/mrtt-ui/src/components/EcologicalStatusAndOutcomes/EcologicalStatusAndOutcomesForm.js
+++ b/mrtt-ui/src/components/EcologicalStatusAndOutcomes/EcologicalStatusAndOutcomesForm.js
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import axios from 'axios'
 import { toast } from 'react-toastify'
-import { Controller, useFormContext, useFieldArray } from 'react-hook-form'
+import { Controller, useFormContext, useFieldArray, useWatch } from 'react-hook-form'
 import {
   Box,
   Checkbox,
@@ -47,6 +47,9 @@ import DatePickerUtcMui from '../DatePickerUtcMui'
 import { unitOptions } from '../../data/ecologicalOptions'
 import RequiredIndicator from '../RequiredIndicator'
 
+import { useInitializeQuestionMappedForm } from '../../library/question-mapped-form/useInitializeQuestionMappedForm'
+import LoadingIndicator from '../LoadingIndicator'
+
 const getEcologicalAims = (registrationAnswersFromServer) =>
   findRegistationDataItem(registrationAnswersFromServer, '3.1') ?? []
 
@@ -79,13 +82,15 @@ const EcologicalStatusAndOutcomesForm = () => {
     fields: monitoringIndicatorsFields,
     append: monitoringIndicatorsAppend,
     remove: monitoringIndicatorsRemove,
-    update: monitoringIndicatorsUpdate
+    update: monitoringIndicatorsUpdate,
+    replace: monitoringIndicatorsReplace
   } = useFieldArray({ name: 'monitoringIndicators', control })
 
   const {
     fields: ecologicalMonitoringStakeholdersFields,
     append: ecologicalMonitoringStakeholdersAppend,
-    remove: ecologicalMonitoringStakeholdersRemove
+    remove: ecologicalMonitoringStakeholdersRemove,
+    replace: ecologicalMonitoringStakeholdersReplace
   } = useFieldArray({ name: 'ecologicalMonitoringStakeholders', control })
 
   const { siteId } = useParams()
@@ -95,12 +100,16 @@ const EcologicalStatusAndOutcomesForm = () => {
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [isSubmitError, setIsSubmitError] = useState(false)
   const [biophysicalInterventions, setBiophysicalInterventions] = useState([])
-  const mangroveAreaIncreaseWatcher = watchForm('mangroveAreaIncrease')
+
+  const mangroveAreaIncreaseWatcher = useWatch({ control, name: 'mangroveAreaIncrease' })
   const [isDeleting, setIsDeleting] = useState(false)
   const [isDeleteConfirmPromptOpen, setIsDeleteConfirmPromptOpen] = useState(false)
-  const monitoringIndicatorsWatcher = watchForm('monitoringIndicators')
+  const monitoringIndicatorsWatcher = useWatch({ name: 'monitoringIndicators', control })
   const [ecologicalAims, setEcologicalAims] = useState([])
-  const preAndPostRestorationActivitiesWatcher = watchForm('preAndPostRestorationActivities')
+  const preAndPostRestorationActivitiesWatcher = useWatch({
+    name: 'preAndPostRestorationActivities',
+    control
+  })
   const [
     ecologicalMonitoringStakeholdersTypesChecked,
     setEcologicalMonitoringStakeholdersTypesChecked
@@ -166,11 +175,28 @@ const EcologicalStatusAndOutcomesForm = () => {
     [monitoringFormSingularUrl, isEditMode]
   )
 
-  useInitializeMonitoringForm({
-    apiUrl: monitoringFormSingularUrl,
-    formType,
-    isEditMode,
-    questionMapping: questionMapping.ecologicalStatusAndOutcomes
+  const onLoaded = () => {
+    const v = form.getValues()
+    monitoringIndicatorsReplace(v.monitoringIndicators ?? [])
+    ecologicalMonitoringStakeholdersReplace(v.ecologicalMonitoringStakeholders ?? [])
+    setEcologicalMonitoringStakeholdersTypesChecked(
+      (v.ecologicalMonitoringStakeholders ?? []).map((s) => s?.stakeholder).filter(Boolean)
+    )
+  }
+
+  // useInitializeMonitoringForm({
+  //   apiUrl: monitoringFormSingularUrl,
+  //   formType,
+  //   isEditMode,
+  //   questionMapping: questionMapping.ecologicalStatusAndOutcomes
+  // })
+
+  const { data, isLoading } = useInitializeQuestionMappedForm({
+    key: 'ecologicalStatusAndOutcomes',
+    apiUrl: registrationInterventionFormsUrl,
+    resetForm: form.reset,
+    questionMapping,
+    successCallback: onLoaded
   })
 
   const createNewMonitoringForm = (payload) => {
@@ -203,45 +229,45 @@ const EcologicalStatusAndOutcomesForm = () => {
       })
   }
 
-  const handleSubmit = (formData) => {
-    setIsSubmitting(true)
-    setIsSubmitError(false)
+  // const handleSubmit = (formData) => {
+  //   setIsSubmitting(true)
+  //   setIsSubmitError(false)
 
-    const payload = {
-      form_type: formType,
-      answers: mapDataForApi('ecologicalStatusAndOutcomes', formData)
-      // answers: mapAllDataForApi({
-      //   projectDetails: { ...formData },
-      //   siteBackground: { ...formData },
-      //   restorationAims: { ...formData },
-      //   causesOfDecline: { ...formData },
-      //   preRestorationAssessment: { ...formData },
-      //   siteInterventions: { ...formData },
-      //   costs: { ...formData },
-      //   managementStatusAndEffectiveness: { ...formData },
-      //   socioeconomicAndGovernanceStatusAndOutcomes: { ...formData },
-      //   ecologicalStatusAndOutcomes: { ...formData }
-      // })
-    }
-    if (isEditMode) {
-      editMonitoringForm(payload)
-    } else {
-      createNewMonitoringForm(payload)
-      axios
-        .post(registrationInterventionFormsUrl, payload)
-        .then(({ data }) => {
-          setIsSubmitting(false)
-          toast.success(language.success.getCreateThingSuccessMessage('This form'))
-          resetForm()
-          navigate(data.id)
-        })
-        .catch(() => {
-          setIsSubmitting(false)
-          setIsSubmitError(true)
-          toast.error(language.error.submit)
-        })
-    }
-  }
+  //   const payload = {
+  //     form_type: formType,
+  //     answers: mapDataForApi('ecologicalStatusAndOutcomes', formData)
+  //     // answers: mapAllDataForApi({
+  //     //   projectDetails: { ...formData },
+  //     //   siteBackground: { ...formData },
+  //     //   restorationAims: { ...formData },
+  //     //   causesOfDecline: { ...formData },
+  //     //   preRestorationAssessment: { ...formData },
+  //     //   siteInterventions: { ...formData },
+  //     //   costs: { ...formData },
+  //     //   managementStatusAndEffectiveness: { ...formData },
+  //     //   socioeconomicAndGovernanceStatusAndOutcomes: { ...formData },
+  //     //   ecologicalStatusAndOutcomes: { ...formData }
+  //     // })
+  //   }
+  //   if (isEditMode) {
+  //     editMonitoringForm(payload)
+  //   } else {
+  //     createNewMonitoringForm(payload)
+  //     axios
+  //       .post(registrationInterventionFormsUrl, payload)
+  //       .then(({ data }) => {
+  //         setIsSubmitting(false)
+  //         toast.success(language.success.getCreateThingSuccessMessage('This form'))
+  //         resetForm()
+  //         navigate(data.id)
+  //       })
+  //       .catch(() => {
+  //         setIsSubmitting(false)
+  //         setIsSubmitError(true)
+  //         toast.error(language.error.submit)
+  //       })
+  //   }
+  // }
 
   const handleDeleteConfirm = () => {
     setIsDeleting(true)
@@ -338,7 +364,9 @@ const EcologicalStatusAndOutcomesForm = () => {
   const getWhichStakeholderInvolved = (stakeholder) =>
     ecologicalMonitoringStakeholdersFields.find((field) => field.stakeholder === stakeholder)
 
-  return (
+  return isLoading ? (
+    <LoadingIndicator />
+  ) : (
     <ContentWrapper>
       <FormPageHeader>
         <PageTitle>
@@ -349,7 +377,6 @@ const EcologicalStatusAndOutcomesForm = () => {
       <QuestionNav
         isFormSaving={isSubmitting}
         isFormSaveError={isSubmitError}
-        onFormSave={validateInputs(handleSubmit)}
         currentSection='ecological-status-and-outcomes'
       />
       <FormValidationMessageIfErrors formErrors={errors} />
@@ -363,10 +390,9 @@ const EcologicalStatusAndOutcomesForm = () => {
           <Controller
             name='monitoringStartDate'
             control={control}
-            defaultValue={null}
             render={({ field }) => (
               <DatePickerUtcMui
-                id='monitoring-start-date'
+                id='monitoringStartDate'
                 label='Monitoring start date'
                 field={field}
               />
@@ -377,10 +403,9 @@ const EcologicalStatusAndOutcomesForm = () => {
             <Controller
               name='monitoringEndDate'
               control={control}
-              defaultValue={null}
               render={({ field }) => (
                 <DatePickerUtcMui
-                  id='monitoring-end-date'
+                  id='monitoringEndDate'
                   label='Monitoring end date'
                   field={field}
                 />
@@ -413,7 +438,6 @@ const EcologicalStatusAndOutcomesForm = () => {
                               (field) => field.stakeholder === stakeholder
                             )}.stakeholderType`}
                             control={control}
-                            defaultValue=''
                             render={({ field }) => (
                               <TextField
                                 {...field}

--- a/mrtt-ui/src/components/FormWrapper/FormSchemaValidation.js
+++ b/mrtt-ui/src/components/FormWrapper/FormSchemaValidation.js
@@ -11,6 +11,14 @@ import language from '../../language'
 
 const siteAreaError = 'Please provide a site area'
 
+import { DateTime } from 'luxon'
+
+const toDate = (value, originalValue) => {
+  if (originalValue == null || originalValue === '') return null
+  const d = new Date(originalValue)
+  return Number.isNaN(d.getTime()) ? null : d
+}
+
 export const validationSchema = yup.object().shape({
   // project details
   projectStartDate: yup.date().required('Select a start date'),
@@ -84,7 +92,7 @@ export const validationSchema = yup.object().shape({
         mainCauseAnswers: yup.array().of(
           yup.object().shape({
             mainCauseAnswer: yup.string(),
-            levelOfDegredation: yup.string().required()
+            levelOfDegradation: yup.string().required()
           })
         ),
         subCauses: yup.array().of(
@@ -93,7 +101,7 @@ export const validationSchema = yup.object().shape({
             subCauseAnswers: yup.array().of(
               yup.object().shape({
                 subCauseAnswer: yup.string(),
-                levelOfDegredation: yup.string().required()
+                levelOfDegradation: yup.string().required()
               })
             )
           })
@@ -164,10 +172,11 @@ export const validationSchema = yup.object().shape({
     .default([]),
   biophysicalInterventionsUsed: multiselectWithOtherValidation,
   biophysicalInterventionDuration: yup.object().shape({
-    startDate: yup.string().nullable(),
+    startDate: yup.date().nullable().transform(toDate),
     endDate: yup
-      .string()
+      .date()
       .nullable()
+      .transform(toDate)
       .min(yup.ref('startDate'), "End date can't be before start date")
   }),
   mangroveSpeciesUsed: yup
@@ -335,9 +344,9 @@ export const validationSchema = yup.object().shape({
 
 export const defaultValues = {
   // project details - Site Details and Location
-  projectStartDate: null,
+  projectStartDate: DateTime.now(),
   hasProjectEndDate: false,
-  projectEndDate: null,
+  projectEndDate: DateTime.now(),
   countries: undefined,
   siteArea: emptyFeatureCollection,
 

--- a/mrtt-ui/src/components/FormWrapper/FormWrapperProvider.js
+++ b/mrtt-ui/src/components/FormWrapper/FormWrapperProvider.js
@@ -5,8 +5,14 @@ import { yupResolver } from '@hookform/resolvers/yup'
 import { FormProvider, useForm } from 'react-hook-form'
 
 import { defaultValues, validationSchema } from './FormSchemaValidation'
+import { useInitializeQuestionMappedForm } from '../../library/question-mapped-form/useInitializeQuestionMappedForm'
 
 function FormWrapperProvider({ children }) {
+  // fetch api data, merge defaultValues
+  // fix date
+  // initialize form with data
+  // remove save from steps use just navigation buttons
+  // validate by step
   const form = useForm({
     resolver: yupResolver(validationSchema),
     defaultValues

--- a/mrtt-ui/src/components/ManagementStatusAndEffectiveness/ManagementStatusAndEffectivenessForm.js
+++ b/mrtt-ui/src/components/ManagementStatusAndEffectiveness/ManagementStatusAndEffectivenessForm.js
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import axios from 'axios'
 import { toast } from 'react-toastify'
-import { Controller, useFormContext } from 'react-hook-form'
+import { Controller, useFormContext, useWatch } from 'react-hook-form'
 import { Box, MenuItem, TextField } from '@mui/material'
 
 import { FormLayout, FormPageHeader, FormQuestionDiv, StickyFormLabel } from '../../styles/forms'
@@ -23,10 +23,14 @@ import ConfirmPrompt from '../ConfirmPrompt/ConfirmPrompt'
 import DatePickerUtcMui from '../DatePickerUtcMui'
 import RequiredIndicator from '../RequiredIndicator'
 
+import { useInitializeQuestionMappedForm } from '../../library/question-mapped-form/useInitializeQuestionMappedForm'
+import LoadingIndicator from '../LoadingIndicator'
+
 const formType = MONITORING_FORM_CONSTANTS.managementStatusAndEffectiveness.payloadType
 
 const ManagementStatusAndEffectivenessForm = () => {
-  const { monitoringFormId } = useParams()
+  const { monitoringFormId, siteId } = useParams()
+  const apiAnswersUrl = `${process.env.REACT_APP_API_URL}/sites/${siteId}/registration_intervention_answers`
   const isEditMode = !!monitoringFormId
   const navigate = useNavigate()
   const { site_name } = useSiteInfo()
@@ -34,28 +38,31 @@ const ManagementStatusAndEffectivenessForm = () => {
   const form = useFormContext()
 
   const {
-    handleSubmit: validateInputs,
+    // handleSubmit: validateInputs,
     formState: { errors },
-    control,
-    watch: watchForm
+    control
   } = form
 
-  const { siteId } = useParams()
   const monitoringFormsUrl = `${process.env.REACT_APP_API_URL}/sites/${siteId}/monitoring_answers`
   const monitoringFormSingularUrl = `${monitoringFormsUrl}/${monitoringFormId}`
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [isError, setIsError] = useState(false)
-  const managementStatusChangesWatcher = watchForm('managementStatusChanges')
-  const projectStatusChangeWatcher = watchForm('projectStatusChange')
-  const financeForCiteManagementWatcher = watchForm('financeForCiteManagement')
+  const managementStatusChangesWatcher = useWatch({ control, name: 'managementStatusChanges' })
+  const projectStatusChangeWatcher = useWatch({ control, name: 'projectStatusChange' })
+  const financeForCiteManagementWatcher = useWatch({ control, name: 'financeForCiteManagement' })
   const [isDeleting, setIsDeleting] = useState(false)
   const [isDeleteConfirmPromptOpen, setIsDeleteConfirmPromptOpen] = useState(false)
 
-  useInitializeMonitoringForm({
-    apiUrl: monitoringFormSingularUrl,
-    formType,
-    isEditMode,
-    questionMapping: questionMapping.managementStatusAndEffectiveness
+  const { data, isLoading } = useInitializeQuestionMappedForm({
+    key: 'managementStatusAndEffectiveness',
+    apiUrl: apiAnswersUrl,
+    resetForm: form.reset,
+    questionMapping,
+    queryOptions: {
+      refetchOnMount: 'always',
+      staleTime: 0,
+      refetchOnWindowFocus: false
+    }
   })
 
   const createNewMonitoringForm = (payload) => {
@@ -87,29 +94,29 @@ const ManagementStatusAndEffectivenessForm = () => {
       })
   }
 
-  const handleSubmit = async (formData) => {
-    const fields = Object.keys(questionMapping['managementStatusAndEffectiveness'])
-    const ok = await form.trigger(fields, { shouldFocus: true })
-    if (!ok) {
-      setIsError(true)
-      toast.error(language.error.validation)
-      return
-    }
-    setIsSubmitting(true)
-    setIsError(false)
-    if (!formData) return
+  // const handleSubmit = async (formData) => {
+  //   const fields = Object.keys(questionMapping['managementStatusAndEffectiveness'])
+  //   const ok = await form.trigger(fields, { shouldFocus: true })
+  //   if (!ok) {
+  //     setIsError(true)
+  //     toast.error(language.error.validation)
+  //     return
+  //   }
+  //   setIsSubmitting(true)
+  //   setIsError(false)
+  //   if (!formData) return
 
-    const payload = {
-      form_type: formType,
-      answers: mapDataForApi('managementStatusAndEffectiveness', formData)
-    }
+  //   const payload = {
+  //     form_type: formType,
+  //     answers: mapDataForApi('managementStatusAndEffectiveness', formData)
+  //   }
 
-    if (isEditMode) {
-      editMonitoringForm(payload)
-    } else {
-      createNewMonitoringForm(payload)
-    }
-  }
+  //   if (isEditMode) {
+  //     editMonitoringForm(payload)
+  //   } else {
+  //     createNewMonitoringForm(payload)
+  //   }
+  // }
 
   const handleDeleteConfirm = () => {
     setIsDeleting(true)
@@ -130,7 +137,9 @@ const ManagementStatusAndEffectivenessForm = () => {
     setIsDeleteConfirmPromptOpen(true)
   }
 
-  return (
+  return isLoading ? (
+    <LoadingIndicator />
+  ) : (
     <ContentWrapper>
       <FormPageHeader>
         <PageTitle>
@@ -141,7 +150,6 @@ const ManagementStatusAndEffectivenessForm = () => {
       <QuestionNav
         isFormSaving={isSubmitting}
         isFormSaveError={isError}
-        onFormSave={() => handleSubmit(form.getValues())}
         currentSection='management-status-and-effectiveness'
       />
       <FormValidationMessageIfErrors formErrors={errors} />
@@ -155,9 +163,8 @@ const ManagementStatusAndEffectivenessForm = () => {
           <Controller
             name='dateOfAssessment'
             control={control}
-            defaultValue={''}
             render={({ field }) => (
-              <DatePickerUtcMui id='date-of-assessment' label='date' field={field} />
+              <DatePickerUtcMui id='dateOfAssessment' label='date' field={field} />
             )}
           />
           <ErrorText>{errors.dateOfAssessment?.message}</ErrorText>

--- a/mrtt-ui/src/components/PreRestorationAssessment/PreRestorationAssessmentForm.js
+++ b/mrtt-ui/src/components/PreRestorationAssessment/PreRestorationAssessmentForm.js
@@ -85,7 +85,6 @@ function PreRestorationAssessmentForm() {
   const speciesCompositionWatcher = watchForm('speciesComposition')
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [isError, setIsError] = useState(false)
-  const [isLoading, setIsLoading] = useState(false)
   const [mangroveSpeciesList, setMangroveSpeciesList] = useState([])
   const [mangroveSpeciesTypesChecked, setMangroveSpeciesTypesChecked] = useState([])
   const [showAddTabularInputRow, setShowAddTabularInputRow] = useState(false)
@@ -121,11 +120,11 @@ function PreRestorationAssessmentForm() {
     [physicalMeasurementsTakenReplace]
   )
 
-  useInitializeQuestionMappedForm({
+  const { data, isLoading } = useInitializeQuestionMappedForm({
+    key: 'preRestorationAssessment',
     apiUrl: apiAnswersUrl,
-    questionMapping: questionMapping.preRestorationAssessment,
+    questionMapping: questionMapping,
     resetForm,
-    setIsLoading,
     successCallback: loadServerData
   })
 
@@ -214,7 +213,6 @@ function PreRestorationAssessmentForm() {
       <QuestionNav
         isFormSaving={isSubmitting}
         isFormSaveError={isError}
-        onFormSave={() => handleSubmit(form.getValues())}
         currentSection='pre-restoration-assessment'
       />
       <FormValidationMessageIfErrors formErrors={errors} />

--- a/mrtt-ui/src/components/ProjectDetailsForm.js
+++ b/mrtt-ui/src/components/ProjectDetailsForm.js
@@ -3,18 +3,18 @@ import { Controller, useFormContext } from 'react-hook-form'
 import { useState } from 'react'
 
 import Autocomplete from '@mui/material/Autocomplete'
-import axios from 'axios'
+// import axios from 'axios'
 import turfBbox from '@turf/bbox'
 import turfBboxPolygon from '@turf/bbox-polygon'
 import turfConvex from '@turf/convex'
 
 import { ContentWrapper } from '../styles/containers'
 import { ErrorText, PageSubtitle, PageTitle } from '../styles/typography'
-import { mapDataForApi, mapAllDataForApi } from '../library/mapDataForApi'
+// import { mapDataForApi } from '../library/mapDataForApi'
 import { projectDetails as questions } from '../data/questions'
 import { questionMapping } from '../data/questionMapping'
 import { StickyFormLabel, FormPageHeader, FormQuestionDiv, FormLayout } from '../styles/forms'
-import { toast } from 'react-toastify'
+// import { toast } from 'react-toastify'
 import { useParams } from 'react-router-dom'
 import FormValidationMessageIfErrors from './FormValidationMessageIfErrors'
 import language from '../language'
@@ -26,6 +26,7 @@ import RequiredIndicator from './RequiredIndicator'
 import { useInitializeQuestionMappedForm } from '../library/question-mapped-form/useInitializeQuestionMappedForm'
 import useSiteInfo from '../library/useSiteInfo'
 import DatePickerUtcMui from './DatePickerUtcMui'
+import { useSectionQuestions } from '../library/question-mapped-form/sections-hook'
 
 export const siteAreaError = 'Please provide a site area'
 
@@ -39,26 +40,28 @@ const countriesGeojson = mangroveCountries.features.sort(sortCountries)
 
 function ProjectDetailsForm() {
   const form = useFormContext()
-  const [isLoading, setIsLoading] = useState(false)
-  const errors = form.errors
+  const errors = form.formState.errors
 
   const [mapExtent, setMapExtent] = useState()
   const [isError, setIsError] = useState(false)
+  // const [isLoading, setIsLoading] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const { site_name } = useSiteInfo()
 
+  // const { errors } = form.formState
   const { siteId } = useParams()
   const apiAnswersUrl = `${process.env.REACT_APP_API_URL}/sites/${siteId}/registration_intervention_answers`
-
   let watchHasProjectEndDate = form.watch('hasProjectEndDate', false)
   /* showEndDateInput is a hack because MUI follows native html and casts values to strings.
    The api casts them to boolean so we support both */
   const showEndDateInput = watchHasProjectEndDate === 'true' || watchHasProjectEndDate === true
 
-  useInitializeQuestionMappedForm({
+  const { data, isLoading } = useInitializeQuestionMappedForm({
+    key: 'projectDetails',
     apiUrl: apiAnswersUrl,
     resetForm: form.reset,
-    questionMapping: questionMapping.projectDetails
+    questionMapping,
+    setIsLoading: () => {}
   })
 
   const onCountriesChange = (field, features) => {
@@ -87,62 +90,24 @@ function ProjectDetailsForm() {
     }
   }
 
-  const handleSubmit = async (formData) => {
-    const fields = Object.keys(questionMapping['projectDetails'])
+  // const handleSubmit = async (formData) => {
+  //   setIsSubmitting(true)
+  //   setIsError(false)
 
-    const ok = await form.trigger(fields, { shouldFocus: true })
-    if (!ok) {
-      setIsError(true)
-      toast.error(language.error.validation)
-      return
-    }
-    setIsSubmitting(true)
-    setIsError(false)
+  //   axios
+  //     .patch(apiAnswersUrl, mapDataForApi('projectDetails', formData))
+  //     .then(() => {
+  //       setIsSubmitting(false)
+  //       toast.success(language.success.submit)
+  //     })
+  //     .catch(() => {
+  //       setIsError(true)
+  //       setIsSubmitting(false)
+  //       toast.error(language.error.submit)
+  //     })
+  // }
 
-    if (!formData) return
-
-    const payload = {
-      // answers: mapDataForApi('ecologicalStatusAndOutcomes', formData)
-      answers: mapAllDataForApi({
-        projectDetails: { ...formData },
-        siteBackground: { ...formData },
-        restorationAims: { ...formData },
-        causesOfDecline: { ...formData },
-        preRestorationAssessment: { ...formData },
-        siteInterventions: { ...formData },
-        costs: { ...formData },
-        managementStatusAndEffectiveness: { ...formData },
-        socioeconomicAndGovernanceStatusAndOutcomes: { ...formData },
-        ecologicalStatusAndOutcomes: { ...formData }
-      })
-    }
-
-    axios
-      .get(apiAnswersUrl, mapDataForApi(payload))
-      .then(() => {
-        setIsError(false)
-        setIsSubmitting(false)
-        toast.success(language.success.submit)
-      })
-      .catch(() => {
-        setIsError(true)
-        setIsSubmitting(false)
-        toast.error(language.error.submit)
-      })
-
-    axios
-      .patch(apiAnswersUrl, mapDataForApi('projectDetails', formData))
-      .then(() => {
-        setIsError(false)
-        setIsSubmitting(false)
-        toast.success(language.success.submit)
-      })
-      .catch(() => {
-        setIsError(true)
-        setIsSubmitting(false)
-        toast.error(language.error.submit)
-      })
-  }
+  const { sectionKeys } = useSectionQuestions('project-details')
 
   return (
     <ContentWrapper>
@@ -153,7 +118,6 @@ function ProjectDetailsForm() {
       <QuestionNav
         isFormSaving={isSubmitting}
         isFormSaveError={isError}
-        onFormSave={() => handleSubmit(form.getValues())}
         currentSection='project-details'
       />
       <FormValidationMessageIfErrors formErrors={errors} />
@@ -169,9 +133,7 @@ function ProjectDetailsForm() {
           <Controller
             name='projectStartDate'
             control={form.control}
-            render={({ field }) => {
-              return <DatePickerUtcMui id='start-date' label='date' field={field} />
-            }}
+            render={({ field }) => <DatePickerUtcMui id='start-date' label='date' field={field} />}
           />
           <ErrorText>{errors?.projectStartDate?.message}</ErrorText>
         </FormQuestionDiv>

--- a/mrtt-ui/src/components/QuestionNav.js
+++ b/mrtt-ui/src/components/QuestionNav.js
@@ -2,19 +2,24 @@ import { ArrowBack, ArrowBackIosNew, ArrowForwardIos } from '@mui/icons-material
 import { css, styled } from '@mui/system'
 import { Stack } from '@mui/material'
 import { toast } from 'react-toastify'
-import { useParams } from 'react-router-dom'
+import { useParams, useNavigate, useLocation } from 'react-router-dom'
 import axios from 'axios'
 import PropTypes from 'prop-types'
-import React, { useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
+
+import { mapDataForApi } from '../library/mapDataForApi'
 
 import { ErrorText, LinkLooksLikeButtonSecondary } from '../styles/typography'
 import ButtonSave from './ButtonSave'
 import language from '../language'
 import LoadingIndicatorOverlay from './LoadingIndicatorOverlay'
-import SECTION_NAMES from '../constants/sectionNames'
+import SECTION_NAMES, { SECTION_NAMES_DICTIONARY } from '../constants/sectionNames'
 import theme from '../styles/theme'
 import themeMui from '../styles/themeMui'
 import PRIVACY_VALUES from '../constants/privacyValues'
+import { useFormContext } from 'react-hook-form'
+
+import { useSaveRegistrationSection } from '../library/question-mapped-form/useInitializeQuestionMappedForm'
 
 const componentLanguage = language.questionNav
 
@@ -80,7 +85,7 @@ const NavSubWrapper = styled('div')`
   gap: ${themeMui.spacing(2)};
 `
 
-const QuestionNav = ({ isFormSaving, isFormSaveError, onFormSave, currentSection }) => {
+const QuestionNav = ({ isFormSaving, isFormSaveError, currentSection }) => {
   const [isPrivacySaveError, setIsPrivacySaveError] = useState(false)
   const [isPrivacySaving, setIsPrivacySaving] = useState(false)
   const [sectionPrivacy, setSectionPrivacy] = useState()
@@ -92,6 +97,18 @@ const QuestionNav = ({ isFormSaving, isFormSaveError, onFormSave, currentSection
   const previousSection = SECTION_NAMES[currentSectionNameIndex - 1]
   const sectionIdForApi = currentSectionNameIndex + 1
   const siteUrl = `${process.env.REACT_APP_API_URL}/sites/${siteId}`
+  const form = useFormContext()
+
+  const navigate = useNavigate()
+  const { pathname } = useLocation()
+  const sectionFromUrl = pathname.split('/').pop()
+
+  const { save, query, mutation } = useSaveRegistrationSection({
+    siteId,
+    currentSection,
+    form,
+    section: SECTION_NAMES_DICTIONARY[sectionFromUrl]
+  })
 
   useEffect(
     function getSiteInfoToUseWithAPutRequestToUpdateSitePrivacySincePatchDoesntWork() {
@@ -135,24 +152,62 @@ const QuestionNav = ({ isFormSaving, isFormSaveError, onFormSave, currentSection
     }
   }
 
+  const { handleSubmit: validateInputs } = form
+
+  const handleInterventionFormSave = async (e) => {
+    e?.preventDefault?.()
+    const saved = await save(SECTION_NAMES_DICTIONARY[sectionFromUrl])
+    if (saved && sectionFromUrl === 'ecological-status-and-outcomes') navigate('/sites')
+  }
+
+  const handleNavigateWithSave = useCallback(
+    (to, direction) => async (e) => {
+      e.preventDefault()
+
+      if (direction === 'previous') {
+        navigate(to)
+        return
+      }
+
+      const saved = await save(SECTION_NAMES_DICTIONARY[sectionFromUrl])
+
+      if (saved) navigate(to)
+    },
+    [sectionFromUrl, navigate, save]
+  )
+
   return (
     <>
       <LoadingIndicatorOverlay isVisible={isPrivacySaving} />
       <StickyStack>
         <NavWrapper>
           <NavSubWrapper>
+            {/* back to sites overview */}
             <LinkLooksLikeButtonSecondary to={`/sites/${siteId}/overview`}>
               <ArrowBack /> <NavButtonText>{componentLanguage.returnToSite}</NavButtonText>
             </LinkLooksLikeButtonSecondary>
+            {/* previous and next section buttons */}
+            {/* previous  */}
             <LinkLooksLikeButtonSecondary
               to={!previousSection ? '#' : `/sites/${siteId}/form/${previousSection}`}
-              disabled={!previousSection}>
+              disabled={!previousSection}
+              onClick={
+                !previousSection
+                  ? undefined
+                  : handleNavigateWithSave(`/sites/${siteId}/form/${previousSection}`, 'previous')
+              }>
               <ArrowBackIosNew />
               <NavButtonText>{componentLanguage.previousSection}</NavButtonText>
             </LinkLooksLikeButtonSecondary>
+            {/* next */}
             <LinkLooksLikeButtonSecondary
               to={!nextSection ? '#' : `/sites/${siteId}/form/${nextSection}`}
-              disabled={!nextSection}>
+              disabled={!nextSection}
+              onClick={
+                !nextSection
+                  ? undefined
+                  : handleNavigateWithSave(`/sites/${siteId}/form/${nextSection}`, 'next')
+              }>
               <NavButtonText>{componentLanguage.nextSection}</NavButtonText>
               <ArrowForwardIos />
             </LinkLooksLikeButtonSecondary>
@@ -170,7 +225,7 @@ const QuestionNav = ({ isFormSaving, isFormSaveError, onFormSave, currentSection
               <option value={PRIVACY_VALUES.private}>{language.sectionPrivacy.private}</option>
               <option value={PRIVACY_VALUES.public}>{language.sectionPrivacy.public}</option>
             </PrivacySelect>
-            <ButtonSave isSaving={isFormSaving} onClick={onFormSave} />
+            <ButtonSave isSaving={isFormSaving} onClick={handleInterventionFormSave} />
           </NavSubWrapper>
         </NavWrapper>
         {isFormSaveError ? <ErrorText>{language.error.submit}</ErrorText> : null}
@@ -183,8 +238,7 @@ const QuestionNav = ({ isFormSaving, isFormSaveError, onFormSave, currentSection
 QuestionNav.propTypes = {
   currentSection: PropTypes.string.isRequired,
   isFormSaving: PropTypes.bool.isRequired,
-  isFormSaveError: PropTypes.bool.isRequired,
-  onFormSave: PropTypes.func.isRequired
+  isFormSaveError: PropTypes.bool.isRequired
 }
 
 export default QuestionNav

--- a/mrtt-ui/src/components/RestorationAimsForm/RestorationAimsForm.js
+++ b/mrtt-ui/src/components/RestorationAimsForm/RestorationAimsForm.js
@@ -1,16 +1,12 @@
-import { useCallback, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useFormContext } from 'react-hook-form'
 import { useParams } from 'react-router-dom'
-
-import axios from 'axios'
 
 import { ContentWrapper } from '../../styles/containers'
 import { ErrorText, PageSubtitle, PageTitle } from '../../styles/typography'
 import { FormLayout, FormPageHeader, FormQuestionDiv } from '../../styles/forms'
-import { mapDataForApi } from '../../library/mapDataForApi'
 import { questionMapping } from '../../data/questionMapping'
 import { restorationAims as questions } from '../../data/questions'
-import { toast } from 'react-toastify'
 import FormValidationMessageIfErrors from '../FormValidationMessageIfErrors'
 import language from '../../language'
 import LoadingIndicator from '../LoadingIndicator'
@@ -20,70 +16,96 @@ import { useInitializeQuestionMappedForm } from '../../library/question-mapped-f
 import useSiteInfo from '../../library/useSiteInfo'
 import { Alert } from '@mui/material'
 
-const getStakeholders = (registrationAnswersFromServer) =>
-  registrationAnswersFromServer?.data.find((dataItem) => dataItem.question_id === '2.1')
-    ?.answer_value ?? []
-
 const RestorationAimsForm = () => {
   const form = useFormContext()
-  const [isLoading, setIsLoading] = useState(false)
-  const [isError, setIsError] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [stakeholders, setStakeholders] = useState(form.getValues('stakeholders') || [])
   const { site_name } = useSiteInfo()
   const { siteId } = useParams()
   const apiAnswersUrl = `${process.env.REACT_APP_API_URL}/sites/${siteId}/registration_intervention_answers`
-  const areThereStakeholders = !!stakeholders.length
 
-  const {
-    handleSubmit: validateInputs,
-    formState: { errors },
-    reset: resetForm
-  } = form
+  const errors = form.errors
 
-  const loadStakeholdersFromServerData = useCallback((serverResponse) => {
-    setStakeholders(getStakeholders(serverResponse))
-  }, [])
-
-  useInitializeQuestionMappedForm({
+  const { data, isLoading } = useInitializeQuestionMappedForm({
+    key: 'restorationAims',
     apiUrl: apiAnswersUrl,
-    questionMapping: questionMapping.restorationAims,
-    resetForm,
-    setIsLoading,
-    successCallback: loadStakeholdersFromServerData
+    resetForm: form.reset,
+    questionMapping
   })
 
-  const handleSubmit = async (formData) => {
-    const fields = Object.keys(questionMapping['restorationAims'])
-    const ok = await form.trigger(fields, { shouldFocus: true })
-    if (!ok) {
-      setIsError(true)
-      toast.error(language.error.validation)
-      return
-    }
-    setIsSubmitting(true)
-    setIsError(false)
-    if (!formData) return
+  // const getStakeholders = useMemo(
+  //   () => (registrationAnswersFromServer) =>
+  //     registrationAnswersFromServer?.data.find((dataItem) => dataItem.question_id === '2.1')
+  //       ?.answer_value ?? [],
+  //   []
+  // )
 
-    axios
-      .patch(apiAnswersUrl, mapDataForApi('restorationAims', formData))
-      .then(() => {
-        setIsSubmitting(false)
-        toast.success(language.success.submit)
-      })
-      .catch(() => {
-        setIsSubmitting(false)
-        setIsError(true)
-        toast.error(language.error.submit)
-      })
-  }
+  // const loadStakeholdersFromServerData = useCallback(
+  //   (serverResponse) => {
+  //     return setStakeholders(getStakeholders(serverResponse))
+  //   },
+  //   [getStakeholders]
+  // )
+  // const { data, isError, error } = useInitializeQuestionMappedForm({
+  //   apiUrl: apiAnswersUrl,
+  //   resetForm: form.reset,
+  //   questionMapping: questionMapping.restorationAims,
+  //   successCallback: loadStakeholdersFromServerData,
+  //   queryOptions: {
+  //     select: ({ response, formattedData }) => {
+  //       const stakeholders =
+  //         response.data.find((item) => item.question_id === '2.1')?.answer_value ?? []
 
+  //       return {
+  //         response,
+  //         formattedData,
+  //         stakeholders
+  //       }
+  //     }
+  //   }
+  // })
+
+  // const areThereStakeholders = !!data?.stakeholders.length
+
+  // const handleSubmit = async (values: any) => {
+  //   const fields = Object.keys(questionMapping.restorationAims)
+  //   const ok = await form.trigger(fields, { shouldFocus: true })
+  //   if (!ok) {
+  //     setIsSubmitError(true)
+  //     toast.error(language.error.validation)
+  //     return
+  //   }
+  //   setIsSubmitting(true)
+  //   setIsSubmitError(false)
+
+  //   if (!values) return
+
+  //   const payload = mapDataForApi('restorationAims', values)
+
+  //   axios
+  //     .patch(apiAnswersUrl, payload)
+  //     .then(() => {
+  //       setIsSubmitError(false)
+  //       setIsSubmitting(false)
+  //       toast.success(language.success.submit)
+  //     })
+  //     .catch(() => {
+  //       setIsSubmitting(false)
+  //       setIsSubmitError(true)
+  //       toast.error(language.error.submit)
+  //     })
+  // }
+
+  // TO DO
+  // helper to get sections, if any, with errors questions, answers, errors
   const noStakeholdersWarning = (
     <Alert severity='info'>{language.pages.restorationAims.missingStakeholdersWarning}</Alert>
   )
-
-  const fields = Object.keys(questionMapping['restorationAims'])
-  const restorationAmisErrors = fields.filter((field) => errors[field])
+  const areThereStakeholders = useMemo(() => {
+    const currentStakeholders =
+      form.getValues('stakeholders') || data?.formattedData.siteBackground.stakeholders || []
+    return !!(currentStakeholders && currentStakeholders.length)
+  }, [form, data])
 
   return isLoading ? (
     <LoadingIndicator />
@@ -95,23 +117,22 @@ const RestorationAimsForm = () => {
       </FormPageHeader>
       <QuestionNav
         isFormSaving={isSubmitting}
-        isFormSaveError={isError}
-        onFormSave={() => handleSubmit(form.getValues())}
+        isFormSaveError={form.formState.errors['restorationAims']}
         currentSection='restoration-aims'
       />
       <FormValidationMessageIfErrors formErrors={errors} />
-      <FormLayout onSubmit={() => handleSubmit(form.getValues())}>
+      <FormLayout>
         <FormQuestionDiv>
           {!areThereStakeholders ? noStakeholdersWarning : null}
           <RestorationAimsCheckboxGroupWithLabel
             stakeholders={stakeholders}
             fieldName='ecologicalAims'
             form={form}
-            options={questions.ecologicalAims.options}
+            options={questions.ecologicalAims?.options}
             question={questions.ecologicalAims.question}
             showAsterisk
           />
-          <ErrorText>{errors.ecologicalAims?.selectedValues?.message}</ErrorText>
+          <ErrorText>{errors?.ecologicalAims?.selectedValues?.message}</ErrorText>
         </FormQuestionDiv>
         <FormQuestionDiv>
           {!areThereStakeholders ? noStakeholdersWarning : null}
@@ -123,7 +144,7 @@ const RestorationAimsForm = () => {
             question={questions.socioEconomicAims.question}
             showAsterisk
           />
-          <ErrorText>{errors.socioEconomicAims?.selectedValues?.message}</ErrorText>
+          <ErrorText>{errors?.socioEconomicAims?.selectedValues?.message}</ErrorText>
         </FormQuestionDiv>
         <FormQuestionDiv>
           {!areThereStakeholders ? noStakeholdersWarning : null}
@@ -134,7 +155,7 @@ const RestorationAimsForm = () => {
             options={questions.otherAims.options}
             question={questions.otherAims.question}
           />
-          <ErrorText>{errors.otherAims?.selectedValues?.message}</ErrorText>
+          <ErrorText>{errors?.otherAims?.selectedValues?.message}</ErrorText>
         </FormQuestionDiv>
       </FormLayout>
     </ContentWrapper>

--- a/mrtt-ui/src/components/SiteBackgroundForm.js
+++ b/mrtt-ui/src/components/SiteBackgroundForm.js
@@ -18,16 +18,22 @@ import FormValidationMessageIfErrors from './FormValidationMessageIfErrors'
 import language from '../language'
 import QuestionNav from './QuestionNav'
 import RequiredIndicator from './RequiredIndicator'
-import { useInitializeQuestionMappedForm } from '../library/question-mapped-form/useInitializeQuestionMappedForm'
+import {
+  useInitializeQuestionMappedForm,
+  useSaveRegistrationSection
+} from '../library/question-mapped-form/useInitializeQuestionMappedForm'
 import useSiteInfo from '../library/useSiteInfo'
+
+import { useWatch } from 'react-hook-form'
 
 const SiteBackgroundForm = () => {
   const form = useFormContext()
   const [isError, setIsError] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
-  const [stakeholderTypesChecked, setStakeholderTypesChecked] = useState(
-    form.getValues('stakeholders')?.map((s) => s.stakeholderType) || []
-  )
+
+  // const [stakeholderTypesChecked, setStakeholderTypesChecked] = useState(
+  //   form.getValues('stakeholders')?.map((s) => s.stakeholderType) || []
+  // )
   const { site_name } = useSiteInfo()
   const { siteId } = useParams()
   const apiAnswersUrl = `${process.env.REACT_APP_API_URL}/sites/${siteId}/registration_intervention_answers`
@@ -38,69 +44,90 @@ const SiteBackgroundForm = () => {
     remove: stakeholdersRemove
   } = useFieldArray({ name: 'stakeholders', control: form.control })
 
-  const setInitialStakeholderTypesFromServerData = useCallback((serverResponse) => {
-    const initialStakeholders =
-      serverResponse?.data.find((dataItem) => dataItem.question_id === '2.1')?.answer_value ?? []
+  // const setInitialStakeholderTypesFromServerData = useCallback((serverResponse) => {
+  //   const initialStakeholders =
+  //     serverResponse?.data.find((dataItem) => dataItem.question_id === '2.1')?.answer_value ?? []
 
-    const initialStakeholderTypesChecked = initialStakeholders?.map(
-      (stakeholder) => stakeholder.stakeholderType
-    )
-    setStakeholderTypesChecked(initialStakeholderTypesChecked)
-  }, [])
+  //   const initialStakeholderTypesChecked = initialStakeholders?.map(
+  //     (stakeholder) => stakeholder.stakeholderType
+  //   )
+  //   setStakeholderTypesChecked(initialStakeholderTypesChecked)
+  // }, [])
 
-  useInitializeQuestionMappedForm({
+  const { data, isLoading } = useInitializeQuestionMappedForm({
+    key: 'siteBackground',
     apiUrl: apiAnswersUrl,
-    questionMapping: questionMapping.siteBackground,
     resetForm: form.reset,
-    successCallback: setInitialStakeholderTypesFromServerData
+    questionMapping
+    // successCallback: setInitialStakeholderTypesFromServerData
   })
 
-  const handleSubmit = async (formData) => {
-    const fields = Object.keys(questionMapping['siteBackground'])
-    const ok = await form.trigger(fields, { shouldFocus: true })
-    if (!ok) {
-      setIsError(true)
-      toast.error(language.error.validation)
-      return
-    }
-    setIsSubmitting(true)
-    setIsError(false)
-    if (!formData) return
+  // const saveMutation = useSaveRegistrationSection(siteId)
 
-    axios
-      .patch(apiAnswersUrl, mapDataForApi('siteBackground', formData))
-      .then(() => {
-        setIsSubmitting(false)
-        toast.success(language.success.submit)
-      })
-      .catch(() => {
-        setIsError(true)
-        setIsSubmitting(false)
-        toast.error(language.error.submit)
-      })
-  }
+  // const handleSubmit = async (formData) => {
+  //   const fields = Object.keys(questionMapping['siteBackground'])
+
+  //   const ok = await form.trigger(fields, { shouldFocus: true })
+  //   if (!ok) {
+  //     setIsError(true)
+  //     toast.error(language.error.validation)
+  //     return
+  //   }
+  //   setIsSubmitting(true)
+  //   setIsError(false)
+
+  //   if (!formData) return
+
+  //   axios
+  //     .patch(apiAnswersUrl, mapDataForApi('siteBackground', formData))
+  //     .then(() => {
+  //       setIsError(false)
+  //       setIsSubmitting(false)
+  //       toast.success(language.success.submit)
+  //     })
+  //     .catch(() => {
+  //       setIsError(true)
+  //       setIsSubmitting(false)
+  //       toast.error(language.error.submit)
+  //     })
+  // }
+
+  // const handleStakeholdersOnChange = (_event, stakeholder) => {
+  //   setStakeholderTypesChecked((prev) => {
+  //     const isChecked = prev.includes(stakeholder)
+  //     const next = isChecked ? prev.filter((t) => t !== stakeholder) : [...prev, stakeholder]
+
+  //     if (isChecked) {
+  //       const fieldIndex = stakeholdersFields.findIndex(
+  //         (field) => field.stakeholderType === stakeholder
+  //       )
+  //       if (fieldIndex !== -1) stakeholdersRemove(fieldIndex)
+  //     } else {
+  //       const exists = stakeholdersFields.some((f) => f.stakeholderType === stakeholder)
+  //       if (!exists) stakeholdersAppend({ stakeholderType: stakeholder })
+  //     }
+
+  //     return next
+  //   })
+  // }
 
   const handleStakeholdersOnChange = (_event, stakeholder) => {
-    setStakeholderTypesChecked((prev) => {
-      const isChecked = prev.includes(stakeholder)
-      const next = isChecked ? prev.filter((t) => t !== stakeholder) : [...prev, stakeholder]
+    const isChecked = stakeholderTypesChecked.includes(stakeholder)
 
-      if (isChecked) {
-        const fieldIndex = stakeholdersFields.findIndex(
-          (field) => field.stakeholderType === stakeholder
-        )
-        if (fieldIndex !== -1) stakeholdersRemove(fieldIndex)
-      } else {
-        const exists = stakeholdersFields.some((f) => f.stakeholderType === stakeholder)
-        if (!exists) stakeholdersAppend({ stakeholderType: stakeholder })
-      }
-
-      return next
-    })
+    if (isChecked) {
+      const idx = stakeholdersFields.findIndex((f) => f.stakeholderType === stakeholder)
+      if (idx !== -1) stakeholdersRemove(idx)
+    } else {
+      const exists = stakeholdersFields.some((f) => f.stakeholderType === stakeholder)
+      if (!exists) stakeholdersAppend({ stakeholderType: stakeholder })
+    }
   }
 
+  const watchedStakeholders = useWatch({ control: form.control, name: 'stakeholders' }) ?? []
+  const stakeholderTypesChecked = watchedStakeholders.map((s) => s.stakeholderType)
+
   const getStakeholder = (stakeholder) =>
-    stakeholdersFields.find((field) => field.stakeholderType === stakeholder)
+    watchedStakeholders.find((s) => s.stakeholderType === stakeholder)
 
   return (
     <ContentWrapper>
@@ -111,7 +138,6 @@ const SiteBackgroundForm = () => {
       <QuestionNav
         isFormSaving={isSubmitting}
         isFormSaveError={isError}
-        onFormSave={() => handleSubmit(form.getValues())}
         currentSection='site-background'
       />
       <FormValidationMessageIfErrors formErrors={form.errors} />
@@ -124,24 +150,26 @@ const SiteBackgroundForm = () => {
           </StickyFormLabel>
           <List>
             {siteBackground.stakeholders.options?.map((stakeholder, index) => {
+              const stakeholderIndex = watchedStakeholders.findIndex(
+                (s) => s.stakeholderType === stakeholder
+              )
+
               return (
                 <ListItem key={index}>
                   <Box>
                     <Box>
                       <Checkbox
                         value={stakeholder}
-                        checked={stakeholderTypesChecked?.includes(stakeholder)}
+                        checked={stakeholderTypesChecked.includes(stakeholder)}
                         onChange={(event) => {
                           handleStakeholdersOnChange(event, stakeholder)
                         }}></Checkbox>
                       <Typography variant='subtitle'>{stakeholder}</Typography>
                     </Box>
                     <Box>
-                      {getStakeholder(stakeholder) && stakeholder !== 'Unknown' ? (
+                      {stakeholderIndex !== -1 && stakeholder !== 'Unknown' ? (
                         <Controller
-                          name={`stakeholders.${stakeholdersFields.findIndex(
-                            (field) => field.stakeholderType === stakeholder
-                          )}.stakeholderName`}
+                          name={`stakeholders.${stakeholderIndex}.stakeholderName`}
                           control={form.control}
                           defaultValue=''
                           render={({ field }) => (

--- a/mrtt-ui/src/components/SiteInterventions/SiteInterventionsForm.js
+++ b/mrtt-ui/src/components/SiteInterventions/SiteInterventionsForm.js
@@ -11,16 +11,13 @@ import {
   TextField,
   Typography
 } from '@mui/material'
-import { Controller, useFieldArray, useFormContext } from 'react-hook-form'
+import { Controller, useFieldArray, useFormContext, useWatch } from 'react-hook-form'
 import { styled } from '@mui/material/styles'
-import { toast } from 'react-toastify'
 import { useParams } from 'react-router-dom'
-import { useState, useCallback } from 'react'
-import axios from 'axios'
+import { useState, useCallback, useMemo, useEffect } from 'react'
 
 import { ContentWrapper } from '../../styles/containers'
 import { ErrorText, PageSubtitle, PageTitle } from '../../styles/typography'
-import { findRegistationDataItem } from '../../library/findDataItems'
 import {
   FormLayout,
   FormPageHeader,
@@ -28,279 +25,265 @@ import {
   InnerFormDiv,
   StickyFormLabel
 } from '../../styles/forms'
-import { mapDataForApi } from '../../library/mapDataForApi'
 
-import { propaguleOptions, seedlingOptions } from '../../data/siteInterventionOptions'
 import { questionMapping } from '../../data/questionMapping'
+import { propaguleOptions, seedlingOptions } from '../../data/siteInterventionOptions'
 import { siteInterventions as questions } from '../../data/questions'
+import language from '../../language'
+
 import AddMangroveAssociatedSpeciesRow from './AddMangroveAssociatedSpeciesRow'
+import MangroveAssociatedSpeciesRow from './MangroveAssociatedSpeciesRow'
 import CheckboxGroupWithLabelAndController from '../CheckboxGroupWithLabelAndController'
 import FormValidationMessageIfErrors from '../FormValidationMessageIfErrors'
-import language from '../../language'
-import MangroveAssociatedSpeciesRow from './MangroveAssociatedSpeciesRow'
 import QuestionNav from '../QuestionNav'
+import DatePickerUtcMui from '../DatePickerUtcMui'
+
 import { useInitializeQuestionMappedForm } from '../../library/question-mapped-form/useInitializeQuestionMappedForm'
 import useSiteInfo from '../../library/useSiteInfo'
 import organizeMangroveSpeciesList from '../../library/organizeMangroveSpeciesList'
-import DatePickerUtcMui from '../DatePickerUtcMui'
 
-const getWhichStakeholdersInvolved = (registrationAnswersFromServer) =>
-  findRegistationDataItem(registrationAnswersFromServer, '6.1') ?? []
-
-const getSiteCountries = (registrationAnswersFromServer) =>
-  findRegistationDataItem(registrationAnswersFromServer, '1.2') ?? []
-
-const getMangroveSpeciesUsed = (registrationAnswersFromServer) =>
-  findRegistationDataItem(registrationAnswersFromServer, '6.2b') ?? []
+import LoadingIndicator from '../LoadingIndicator'
 
 function SiteInterventionsForm() {
   const { site_name } = useSiteInfo()
-
   const form = useFormContext()
-
   const {
-    handleSubmit: validateInputs,
     formState: { errors },
-    watch: watchForm,
     control
   } = form
 
+  const { siteId } = useParams()
+  const apiAnswersUrl = `${process.env.REACT_APP_API_URL}/sites/${siteId}/registration_intervention_answers`
+
+  const [isSubmitting] = useState(false)
+  const [isError] = useState(false)
+
+  const [mangroveSpeciesForCountriesSelected, setMangroveSpeciesForCountriesSelected] = useState([])
+  const [showAddTabularInputRow, setShowAddTabularInputRow] = useState(false)
+
+  // ---------- Field arrays ----------
   const {
     fields: mangroveSpeciesUsedFields,
     append: mangroveSpeciesUsedAppend,
     remove: mangroveSpeciesUsedRemove,
-    update: mangroveSpeciesUsedUpdate
+    update: mangroveSpeciesUsedUpdate,
+    replace: mangroveSpeciesUsedReplace
   } = useFieldArray({ name: 'mangroveSpeciesUsed', control })
 
   const {
     fields: mangroveAssociatedSpeciesFields,
     append: mangroveAssociatedSpeciesAppend,
     remove: mangroveAssociatedSpeciesRemove,
-    update: mangroveAssociatedSpeciesUpdate
+    update: mangroveAssociatedSpeciesUpdate,
+    replace: mangroveAssociatedSpeciesReplace
   } = useFieldArray({ name: 'mangroveAssociatedSpecies', control })
 
   const {
-    fields: whichStakeholdersInvolvedFields,
     append: whichStakeholdersInvolvedAppend,
-    remove: whichStakeholdersInvolvedRemove
+    remove: whichStakeholdersInvolvedRemove,
+    replace: whichStakeholdersInvolvedReplace
   } = useFieldArray({ name: 'whichStakeholdersInvolved', control })
 
-  const { siteId } = useParams()
-  const apiAnswersUrl = `${process.env.REACT_APP_API_URL}/sites/${siteId}/registration_intervention_answers`
-  const [isSubmitting, setIsSubmitting] = useState(false)
-  const [isError, setIsError] = useState(false)
-  const [mangroveSpeciesForCountriesSelected, setMangroveSpeciesForCountriesSelected] = useState([])
-  const [mangroveSpeciesUsedChecked, setMangroveSpeciesUsedChecked] = useState([])
-  const [whichStakeholdersInvolvedTypesChecked, setWhichStakeholdersInvolvedTypesChecked] =
-    useState([])
-  const [showAddTabularInputRow, setShowAddTabularInputRow] = useState(false)
-  const localParticipantTrainingWatcher = watchForm('localParticipantTraining')
-  const biophysicalInterventionsUsedWatcher = watchForm('biophysicalInterventionsUsed')
+  // ---------- Read from form ----------
+  const whichStakeholdersInvolvedWatch = useWatch({ control, name: 'whichStakeholdersInvolved' })
+  const biophysicalInterventionsUsedWatch = useWatch({
+    control,
+    name: 'biophysicalInterventionsUsed'
+  })
+  const mangroveSpeciesUsedWatch = useWatch({ control, name: 'mangroveSpeciesUsed' })
+  const localParticipantTraining = useWatch({ control, name: 'localParticipantTraining' })
+  const countriesSelected = useWatch({ control, name: 'countries' })
 
-  const loadServerData = useCallback((serverResponse) => {
-    // set whichStakeholdersInvolved
-    const whichStakeholdersInvolvedInitialVal = getWhichStakeholdersInvolved(serverResponse)
+  const whichStakeholdersInvolvedTypesChecked = useMemo(() => {
+    const arr = whichStakeholdersInvolvedWatch ?? []
+    return arr.map((s) => s?.stakeholder).filter(Boolean)
+  }, [whichStakeholdersInvolvedWatch])
 
-    const initialWhichStakeholdersInvolvedTypesChecked = whichStakeholdersInvolvedInitialVal?.map(
-      (stakeholder) => stakeholder.stakeholder
-    )
-    setWhichStakeholdersInvolvedTypesChecked(initialWhichStakeholdersInvolvedTypesChecked)
+  const biophysicalSelected = useMemo(() => {
+    return biophysicalInterventionsUsedWatch?.selectedValues ?? []
+  }, [biophysicalInterventionsUsedWatch])
 
-    // set countries list for countries selected in 1.2
-    const siteCountriesResponse = getSiteCountries(serverResponse)
+  const mangroveSpeciesUsedChecked = useMemo(() => {
+    const arr = mangroveSpeciesUsedWatch ?? []
+    return arr.map((s) => s?.type).filter(Boolean)
+  }, [mangroveSpeciesUsedWatch])
 
-    if (siteCountriesResponse.length) {
-      const organizedSpecies = organizeMangroveSpeciesList(siteCountriesResponse)
+  const getWhichStakeholderInvolved = useCallback(
+    (stakeholder) =>
+      (whichStakeholdersInvolvedWatch ?? []).find((i) => i?.stakeholder === stakeholder),
+    [whichStakeholdersInvolvedWatch]
+  )
 
-      setMangroveSpeciesForCountriesSelected(organizedSpecies)
-    }
+  const getWhichStakeholdersIndex = useCallback(
+    (stakeholder) =>
+      (whichStakeholdersInvolvedWatch ?? []).findIndex((i) => i?.stakeholder === stakeholder),
+    [whichStakeholdersInvolvedWatch]
+  )
 
-    const getMangroveSpeciesUsedFrom6_2b = getMangroveSpeciesUsed(serverResponse)
-    let mangroveSpeciesList = []
-    if (getMangroveSpeciesUsedFrom6_2b.length) {
-      mangroveSpeciesList = getMangroveSpeciesUsedFrom6_2b.map((specie) => specie.type)
-    }
-    setMangroveSpeciesUsedChecked(mangroveSpeciesList)
-  }, [])
+  const getMangroveSpeciesUsedIndex = useCallback(
+    (specie) => (mangroveSpeciesUsedWatch ?? []).findIndex((i) => i?.type === specie),
+    [mangroveSpeciesUsedWatch]
+  )
 
-  useInitializeQuestionMappedForm({
+  const isMangroveSpeciesUsedShowing = useCallback(() => {
+    const optionsUsed = [
+      'Planting',
+      'Broadcast collected propagules onto an incoming tide',
+      'Large scale broadcasting of propagules from the air or boats'
+    ]
+    return optionsUsed.some((item) => biophysicalSelected.includes(item))
+  }, [biophysicalSelected])
+
+  const updateTabularInputDisplay = (boolean) => setShowAddTabularInputRow(boolean)
+
+  const onLoaded = useCallback(
+    (_response, sectionValues) => {
+      const v = sectionValues ?? {}
+
+      queueMicrotask(() => {
+        whichStakeholdersInvolvedReplace(v.whichStakeholdersInvolved ?? [])
+        mangroveSpeciesUsedReplace(v.mangroveSpeciesUsed ?? [])
+        mangroveAssociatedSpeciesReplace(v.mangroveAssociatedSpecies ?? [])
+      })
+
+      const countries = v.countries ?? []
+      setMangroveSpeciesForCountriesSelected(
+        countries.length ? organizeMangroveSpeciesList(countries) : []
+      )
+    },
+    [whichStakeholdersInvolvedReplace, mangroveSpeciesUsedReplace, mangroveAssociatedSpeciesReplace]
+  )
+
+  const { isLoading } = useInitializeQuestionMappedForm({
+    key: 'siteInterventions',
     apiUrl: apiAnswersUrl,
-    questionMapping: questionMapping.siteInterventions,
-    successCallback: loadServerData
+    resetForm: form.reset,
+    questionMapping,
+    successCallback: onLoaded,
+    queryOptions: {
+      refetchOnMount: 'always',
+      staleTime: 0
+    }
   })
 
-  const handleSubmit = async (formData) => {
-    const fields = Object.keys(questionMapping['siteInterventions'])
-    const ok = await form.trigger(fields, { shouldFocus: true })
-    if (!ok) {
-      setIsError(true)
-      toast.error(language.error.validation)
-      return
-    }
-    setIsSubmitting(true)
-    setIsError(false)
-    if (!formData) return
+  useEffect(() => {
+    const countries = countriesSelected ?? []
+    setMangroveSpeciesForCountriesSelected(
+      countries.length ? organizeMangroveSpeciesList(countries) : []
+    )
+  }, [countriesSelected])
 
-    axios
-      .patch(apiAnswersUrl, mapDataForApi('siteInterventions', formData))
-      .then(() => {
-        setIsSubmitting(false)
-        toast.success(language.success.submit)
-      })
-      .catch(() => {
-        setIsSubmitting(false)
-        setIsError(true)
-        toast.error(language.error.submit)
-      })
-  }
-
+  // ---------- Handlers ----------
   const handleWhichStakeholdersInvolvedOnChange = (event, stakeholder) => {
-    const whichStakeholdersInvolvedTypesCheckedCopy = [...whichStakeholdersInvolvedTypesChecked]
-
     if (event.target.checked) {
-      whichStakeholdersInvolvedAppend({
-        stakeholder: stakeholder,
-        stakeholderType: ''
-      })
-      whichStakeholdersInvolvedTypesCheckedCopy.push(stakeholder)
+      whichStakeholdersInvolvedAppend({ stakeholder, stakeholderType: '' })
     } else {
-      const fieldIndex = whichStakeholdersInvolvedFields.findIndex(
-        (field) => field.stakeholder === stakeholder
-      )
-      const typeIndex = whichStakeholdersInvolvedTypesCheckedCopy.findIndex(
-        (type) => type === stakeholder
-      )
-      whichStakeholdersInvolvedTypesCheckedCopy.splice(typeIndex, 1)
-      whichStakeholdersInvolvedRemove(fieldIndex)
+      const idx = getWhichStakeholdersIndex(stakeholder)
+      if (idx >= 0) whichStakeholdersInvolvedRemove(idx)
     }
-    setWhichStakeholdersInvolvedTypesChecked(whichStakeholdersInvolvedTypesCheckedCopy)
   }
-
-  const getWhichStakeholderInvolved = (stakeholder) =>
-    whichStakeholdersInvolvedFields.find((field) => field.stakeholder === stakeholder)
 
   const handleMangroveSpeciesUsedOnChange = (event, specie) => {
-    const mangroveSpeciesUsedCheckedCopy = [...mangroveSpeciesUsedChecked]
-
     if (event.target.checked) {
       mangroveSpeciesUsedAppend({
         type: specie,
         seed: { checked: false, source: [], count: 0 },
         propagule: { checked: false, source: [], count: 0 }
       })
-      mangroveSpeciesUsedCheckedCopy.push(specie)
     } else {
-      const fieldIndex = mangroveSpeciesUsedFields.findIndex((field) => field.type === specie)
-      const typeIndex = mangroveSpeciesUsedCheckedCopy.findIndex((type) => type === specie)
-      mangroveSpeciesUsedCheckedCopy.splice(typeIndex, 1)
-      mangroveSpeciesUsedRemove(fieldIndex)
+      const idx = getMangroveSpeciesUsedIndex(specie)
+      if (idx >= 0) mangroveSpeciesUsedRemove(idx)
     }
-    setMangroveSpeciesUsedChecked(mangroveSpeciesUsedCheckedCopy)
-  }
-  const getMangroveSpeciesUsedIndex = (specie) => {
-    return mangroveSpeciesUsedFields.findIndex((item) => item.type === specie)
   }
 
   const handleSourceOfSeedlingsOnChange = (event, specie, seedlingType) => {
-    const index = getMangroveSpeciesUsedIndex(specie)
-    const item = mangroveSpeciesUsedFields[index]
-    if (seedlingType === 'seedling') {
-      event.target.checked ? (item.seed.checked = true) : (item.seed.checked = false)
-    } else if (seedlingType === 'propagule') {
-      event.target.checked ? (item.propagule.checked = true) : (item.propagule.checked = false)
-    }
-    mangroveSpeciesUsedUpdate(item)
+    const idx = getMangroveSpeciesUsedIndex(specie)
+    if (idx < 0) return
+
+    const current = mangroveSpeciesUsedWatch?.[idx]
+    if (!current) return
+
+    const item = { ...current }
+    if (seedlingType === 'seedling') item.seed = { ...item.seed, checked: event.target.checked }
+    if (seedlingType === 'propagule')
+      item.propagule = { ...item.propagule, checked: event.target.checked }
+
+    mangroveSpeciesUsedUpdate(idx, item)
   }
 
-  const isMangroveSpeciesUsedShowing = () => {
-    const optionsUsed = [
-      'Planting',
-      'Broadcast collected propagules onto an incoming tide',
-      'Large scale broadcasting of propagules from the air or boats'
-    ]
-
-    const matchingItems = optionsUsed.filter((item) =>
-      biophysicalInterventionsUsedWatcher?.selectedValues?.includes(item)
-    )
-
-    return matchingItems.length ? true : false
-  }
-
-  const updateTabularInputDisplay = (boolean) => {
-    return setShowAddTabularInputRow(boolean)
-  }
-
-  const saveItem = ({ type, count, source, purpose }) => {
-    mangroveAssociatedSpeciesAppend({
-      type,
-      count,
-      source,
-      purpose
-    })
-  }
-
-  const deleteMeasurementItem = (measurementIndex) => {
+  const saveItem = ({ type, count, source, purpose }) =>
+    mangroveAssociatedSpeciesAppend({ type, count, source, purpose })
+  const deleteMeasurementItem = (measurementIndex) =>
     mangroveAssociatedSpeciesRemove(measurementIndex)
-  }
 
   const updateMeasurementItem = (measurementIndex, count, source, purpose, otherPurpose) => {
-    const currentItem = mangroveAssociatedSpeciesFields[measurementIndex]
+    const currentItem = { ...mangroveAssociatedSpeciesFields[measurementIndex] }
     if (count) currentItem.count = count
     if (source) currentItem.source = source
-    if (purpose) currentItem.purpose.purpose = purpose
-    if (otherPurpose) currentItem.purpose.other = otherPurpose
+    if (purpose) currentItem.purpose = { ...currentItem.purpose, purpose }
+    if (otherPurpose) currentItem.purpose = { ...currentItem.purpose, other: otherPurpose }
     mangroveAssociatedSpeciesUpdate(measurementIndex, currentItem)
   }
 
-  return (
+  const showDuration = !biophysicalSelected.includes('None')
+
+  return isLoading ? (
+    <LoadingIndicator />
+  ) : (
     <ContentWrapper>
       <FormPageHeader>
         <PageTitle>{language.pages.siteQuestionsOverview.formName.siteInterventions}</PageTitle>
         <PageSubtitle>{site_name}</PageSubtitle>
       </FormPageHeader>
+
       <QuestionNav
         isFormSaving={isSubmitting}
         isFormSaveError={isError}
-        onFormSave={() => handleSubmit(form.getValues())}
         currentSection='site-interventions'
       />
+
       <FormValidationMessageIfErrors formErrors={errors} />
 
       <FormLayout>
+        {/* 6.1 Which stakeholders involved */}
         <FormQuestionDiv>
           <StickyFormLabel>{questions.whichStakeholdersInvolved.question}</StickyFormLabel>
+
           <List>
-            {questions.whichStakeholdersInvolved.options.map((stakeholder, index) => (
-              <ListItem key={index}>
-                <Box>
+            {questions.whichStakeholdersInvolved.options.map((stakeholder, index) => {
+              const idx = getWhichStakeholdersIndex(stakeholder)
+              const showType = idx >= 0 && !!getWhichStakeholderInvolved(stakeholder)
+
+              return (
+                <ListItem key={index}>
                   <Box>
-                    <Checkbox
-                      value={stakeholder}
-                      checked={whichStakeholdersInvolvedTypesChecked.includes(stakeholder)}
-                      onChange={(event) =>
-                        handleWhichStakeholdersInvolvedOnChange(event, stakeholder)
-                      }></Checkbox>
-                    <Typography variant='subtitle'>{stakeholder}</Typography>
-                  </Box>
-                  <Box>
-                    {getWhichStakeholderInvolved(stakeholder) && (
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                      <Checkbox
+                        value={stakeholder}
+                        checked={whichStakeholdersInvolvedTypesChecked.includes(stakeholder)}
+                        onChange={(event) =>
+                          handleWhichStakeholdersInvolvedOnChange(event, stakeholder)
+                        }
+                      />
+                      <Typography variant='subtitle'>{stakeholder}</Typography>
+                    </Box>
+
+                    {showType ? (
                       <Box>
                         <InnerFormDiv>
                           <Controller
-                            name={`whichStakeholdersInvolved.${whichStakeholdersInvolvedFields.findIndex(
-                              (field) => field.stakeholder === stakeholder
-                            )}.stakeholderType`}
+                            name={`whichStakeholdersInvolved.${idx}.stakeholderType`}
                             control={control}
                             defaultValue=''
                             render={({ field }) => (
                               <TextField
                                 {...field}
                                 select
-                                value={field.value}
+                                value={field.value ?? ''}
                                 label='select'
                                 sx={{ width: '10em' }}>
-                                {['Paid', 'Voluntary'].map((item, index) => (
-                                  <MenuItem key={index} value={item}>
+                                {['Paid', 'Voluntary'].map((item, i) => (
+                                  <MenuItem key={i} value={item}>
                                     {item}
                                   </MenuItem>
                                 ))}
@@ -309,14 +292,17 @@ function SiteInterventionsForm() {
                           />
                         </InnerFormDiv>
                       </Box>
-                    )}
+                    ) : null}
                   </Box>
-                </Box>
-              </ListItem>
-            ))}
+                </ListItem>
+              )
+            })}
           </List>
-          <ErrorText>{errors.whichStakeholdersInvolved?.selectedValues?.message}</ErrorText>
+
+          <ErrorText>{errors.whichStakeholdersInvolved?.message}</ErrorText>
         </FormQuestionDiv>
+
+        {/* 6.2 Biophysical interventions used */}
         <FormQuestionDiv>
           <CheckboxGroupWithLabelAndController
             fieldName='biophysicalInterventionsUsed'
@@ -328,192 +314,223 @@ function SiteInterventionsForm() {
           />
           <ErrorText>{errors.biophysicalInterventionsUsed?.selectedValues?.message}</ErrorText>
         </FormQuestionDiv>
-        {!biophysicalInterventionsUsedWatcher?.selectedValues?.includes('None') ? (
+
+        {/* 6.2a Duration */}
+        {showDuration ? (
           <FormQuestionDiv>
             <StickyFormLabel>{questions.biophysicalInterventionDuration.question}</StickyFormLabel>
             <Box>
               <InnerFormDiv>
                 <Controller
-                  name={`biophysicalInterventionDuration.startDate`}
+                  name='biophysicalInterventionDuration.startDate'
                   control={control}
-                  defaultValue={null}
                   render={({ field }) => (
                     <DatePickerUtcMui
-                      id='start-date'
+                      id='biophysicalInterventionDuration.startDate'
                       label='Intervention start date'
                       field={field}
                     />
                   )}
                 />
               </InnerFormDiv>
+
               <InnerFormDiv>
                 <Controller
-                  name={`biophysicalInterventionDuration.endDate`}
+                  name='biophysicalInterventionDuration.endDate'
                   control={control}
-                  defaultValue={null}
                   render={({ field }) => (
-                    <DatePickerUtcMui id='end-date' label='Intervention end date' field={field} />
+                    <DatePickerUtcMui
+                      id='biophysicalInterventionDuration.endDate'
+                      label='Intervention end date'
+                      field={field}
+                    />
                   )}
                 />
               </InnerFormDiv>
-              <ErrorText>{errors.biophysicalInterventionDuration?.endDate.message}</ErrorText>
+
+              <ErrorText>{errors.biophysicalInterventionDuration?.endDate?.message}</ErrorText>
             </Box>
           </FormQuestionDiv>
         ) : null}
 
+        {/* Mangrove species used */}
         {isMangroveSpeciesUsedShowing() ? (
           <FormQuestionDiv>
             <StickyFormLabel>{questions.mangroveSpeciesUsed.question}</StickyFormLabel>
+
             <List>
               {mangroveSpeciesForCountriesSelected.length ? (
-                mangroveSpeciesForCountriesSelected.map((specie, specieSelectedIndex) => (
-                  <ListItem key={specieSelectedIndex}>
-                    <Box>
+                mangroveSpeciesForCountriesSelected.map((specie, specieSelectedIndex) => {
+                  const idx = getMangroveSpeciesUsedIndex(specie)
+                  const selected = mangroveSpeciesUsedChecked.includes(specie)
+
+                  const seedChecked =
+                    idx >= 0 ? mangroveSpeciesUsedWatch?.[idx]?.seed?.checked : false
+                  const propaguleChecked =
+                    idx >= 0 ? mangroveSpeciesUsedWatch?.[idx]?.propagule?.checked : false
+
+                  return (
+                    <ListItem key={specieSelectedIndex}>
                       <Box>
-                        <Checkbox
-                          value={specie}
-                          checked={mangroveSpeciesUsedChecked.includes(specie)}
-                          onChange={(event) =>
-                            handleMangroveSpeciesUsedOnChange(event, specie)
-                          }></Checkbox>
-                        <Typography variant='subtitle'>{specie}</Typography>
+                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                          <Checkbox
+                            value={specie}
+                            checked={selected}
+                            onChange={(event) => handleMangroveSpeciesUsedOnChange(event, specie)}
+                          />
+                          <Typography variant='subtitle'>{specie}</Typography>
+                        </Box>
+
+                        {selected ? (
+                          <SubgroupDiv>
+                            <Typography>{questions.sourceOfMangroves.question}</Typography>
+
+                            {/* Seedling */}
+                            <Box>
+                              <Checkbox
+                                value={specie}
+                                checked={!!seedChecked}
+                                onChange={(event) =>
+                                  handleSourceOfSeedlingsOnChange(event, specie, 'seedling')
+                                }
+                              />
+                              <Typography variant='subtitle'>Seedling</Typography>
+
+                              {/* ✅ no montes controllers con idx < 0 */}
+                              {idx >= 0 ? (
+                                <>
+                                  <SubgroupDiv>
+                                    <Controller
+                                      name={`mangroveSpeciesUsed.${idx}.seed.source`}
+                                      control={control}
+                                      defaultValue={[]}
+                                      render={({ field }) => (
+                                        <Select
+                                          {...field}
+                                          multiple
+                                          value={field.value ?? []}
+                                          label='Source'
+                                          renderValue={(selected) => (
+                                            <Box
+                                              sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+                                              {(selected ?? []).map((value) => (
+                                                <Chip key={value} label={value} />
+                                              ))}
+                                            </Box>
+                                          )}
+                                          sx={{ minWidth: '10em' }}>
+                                          {seedlingOptions.map((item, i) => (
+                                            <MenuItem key={i} value={item}>
+                                              {item}
+                                            </MenuItem>
+                                          ))}
+                                        </Select>
+                                      )}
+                                    />
+                                  </SubgroupDiv>
+
+                                  <SubgroupDiv>
+                                    <Controller
+                                      name={`mangroveSpeciesUsed.${idx}.seed.count`}
+                                      control={control}
+                                      defaultValue=''
+                                      render={({ field }) => (
+                                        <TextField
+                                          {...field}
+                                          value={field.value ?? ''}
+                                          label='Count'
+                                          sx={{ width: '10em', marginTop: '1em' }}
+                                        />
+                                      )}
+                                    />
+                                  </SubgroupDiv>
+                                </>
+                              ) : null}
+                            </Box>
+
+                            {/* Propagule */}
+                            <Box>
+                              <Checkbox
+                                value={specie}
+                                checked={!!propaguleChecked}
+                                onChange={(event) =>
+                                  handleSourceOfSeedlingsOnChange(event, specie, 'propagule')
+                                }
+                              />
+                              <Typography variant='subtitle'>Propagule</Typography>
+
+                              {idx >= 0 ? (
+                                <>
+                                  <SubgroupDiv>
+                                    <Controller
+                                      name={`mangroveSpeciesUsed.${idx}.propagule.source`}
+                                      control={control}
+                                      defaultValue={[]}
+                                      render={({ field }) => (
+                                        <Select
+                                          {...field}
+                                          multiple
+                                          value={field.value ?? []}
+                                          label='Source'
+                                          renderValue={(selected) => (
+                                            <Box
+                                              sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+                                              {(selected ?? []).map((value) => (
+                                                <Chip key={value} label={value} />
+                                              ))}
+                                            </Box>
+                                          )}
+                                          sx={{ minWidth: '10em' }}>
+                                          {propaguleOptions.map((item, i) => (
+                                            <MenuItem key={i} value={item}>
+                                              <ListItemText>{item}</ListItemText>
+                                            </MenuItem>
+                                          ))}
+                                        </Select>
+                                      )}
+                                    />
+                                  </SubgroupDiv>
+
+                                  <SubgroupDiv>
+                                    <Controller
+                                      name={`mangroveSpeciesUsed.${idx}.propagule.count`}
+                                      control={control}
+                                      defaultValue=''
+                                      render={({ field }) => (
+                                        <TextField
+                                          {...field}
+                                          value={field.value ?? ''}
+                                          label='Count'
+                                          sx={{ width: '10em', marginTop: '1em' }}
+                                        />
+                                      )}
+                                    />
+                                  </SubgroupDiv>
+                                </>
+                              ) : null}
+                            </Box>
+                          </SubgroupDiv>
+                        ) : null}
                       </Box>
-                      {mangroveSpeciesUsedChecked.includes(specie) ? (
-                        <SubgroupDiv>
-                          <Typography>{questions.sourceOfMangroves.question}</Typography>
-                          <Box>
-                            <Checkbox
-                              value={specie}
-                              checked={
-                                mangroveSpeciesUsedFields[getMangroveSpeciesUsedIndex(specie)].seed
-                                  .checked
-                              }
-                              onChange={(event) =>
-                                handleSourceOfSeedlingsOnChange(event, specie, 'seedling')
-                              }></Checkbox>
-                            <Typography variant='subtitle'>Seedling</Typography>
-                            <SubgroupDiv>
-                              <Controller
-                                name={`mangroveSpeciesUsed.${getMangroveSpeciesUsedIndex(
-                                  specie
-                                )}.seed.source`}
-                                control={control}
-                                defaultValue={[]}
-                                render={({ field }) => (
-                                  <Select
-                                    {...field}
-                                    multiple
-                                    value={field.value}
-                                    label='Source'
-                                    renderValue={(selected) => (
-                                      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
-                                        {selected.map((value) => (
-                                          <Chip key={value} label={value} />
-                                        ))}
-                                      </Box>
-                                    )}
-                                    sx={{ minWidth: '10em' }}>
-                                    {seedlingOptions.map((item, index) => (
-                                      <MenuItem key={index} value={item}>
-                                        {item}
-                                      </MenuItem>
-                                    ))}
-                                  </Select>
-                                )}
-                              />
-                            </SubgroupDiv>
-                            <SubgroupDiv>
-                              <Controller
-                                name={`mangroveSpeciesUsed.${getMangroveSpeciesUsedIndex(
-                                  specie
-                                )}.seed.count`}
-                                control={control}
-                                defaultValue=''
-                                render={({ field }) => (
-                                  <TextField
-                                    {...field}
-                                    value={field.value}
-                                    label='Count'
-                                    sx={{ width: '10em', marginTop: '1em' }}></TextField>
-                                )}
-                              />
-                            </SubgroupDiv>
-                          </Box>
-                          <Box>
-                            <Checkbox
-                              value={specie}
-                              checked={
-                                mangroveSpeciesUsedFields[getMangroveSpeciesUsedIndex(specie)]
-                                  .propagule.checked
-                              }
-                              onChange={(event) =>
-                                handleSourceOfSeedlingsOnChange(event, specie, 'propagule')
-                              }></Checkbox>
-                            <Typography variant='subtitle'>Propagule</Typography>
-                            <SubgroupDiv>
-                              <Controller
-                                name={`mangroveSpeciesUsed.${getMangroveSpeciesUsedIndex(
-                                  specie
-                                )}.propagule.source`}
-                                control={control}
-                                defaultValue={[]}
-                                render={({ field }) => (
-                                  <Select
-                                    {...field}
-                                    multiple
-                                    value={field.value}
-                                    label='Source'
-                                    renderValue={(selected) => (
-                                      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
-                                        {selected.map((value) => (
-                                          <Chip key={value} label={value} />
-                                        ))}
-                                      </Box>
-                                    )}
-                                    sx={{ minWidth: '10em' }}>
-                                    {propaguleOptions.map((item, index) => (
-                                      <MenuItem key={index} value={item}>
-                                        <ListItemText>{item}</ListItemText>
-                                      </MenuItem>
-                                    ))}
-                                  </Select>
-                                )}
-                              />
-                            </SubgroupDiv>
-                            <SubgroupDiv>
-                              <Controller
-                                name={`mangroveSpeciesUsed.${getMangroveSpeciesUsedIndex(
-                                  specie
-                                )}.propagule.count`}
-                                control={control}
-                                defaultValue=''
-                                render={({ field }) => (
-                                  <TextField
-                                    {...field}
-                                    value={field.value}
-                                    label='Count'
-                                    sx={{ width: '10em', marginTop: '1em' }}></TextField>
-                                )}
-                              />
-                            </SubgroupDiv>
-                          </Box>
-                        </SubgroupDiv>
-                      ) : null}
-                    </Box>
-                  </ListItem>
-                ))
+                    </ListItem>
+                  )
+                })
               ) : (
                 <ErrorText>
                   No items to display. Please select countries in Site Details and Location (1.2).
                 </ErrorText>
               )}
             </List>
+
             <ErrorText>{errors.mangroveSpeciesUsed?.message}</ErrorText>
           </FormQuestionDiv>
         ) : null}
-        {isMangroveSpeciesUsedShowing ? (
+
+        {/* Mangrove associated species */}
+        {isMangroveSpeciesUsedShowing() ? (
           <FormQuestionDiv>
             <StickyFormLabel>{questions.mangroveAssociatedSpecies.question}</StickyFormLabel>
+
             {mangroveAssociatedSpeciesFields.length > 0
               ? mangroveAssociatedSpeciesFields.map((item, itemIndex) => (
                   <MangroveAssociatedSpeciesRow
@@ -521,21 +538,24 @@ function SiteInterventionsForm() {
                     type={item.type}
                     count={item.count}
                     source={item.source}
-                    purpose={item.purpose.purpose}
-                    other={item.purpose.other}
+                    purpose={item.purpose?.purpose}
+                    other={item.purpose?.other}
                     index={itemIndex}
                     deleteItem={deleteMeasurementItem}
-                    updateItem={updateMeasurementItem}></MangroveAssociatedSpeciesRow>
+                    updateItem={updateMeasurementItem}
+                  />
                 ))
               : null}
+
             <ErrorText>{errors.mangroveAssociatedSpecies?.message}</ErrorText>
+
             {showAddTabularInputRow ? (
               <AddMangroveAssociatedSpeciesRow
                 saveItem={saveItem}
-                updateTabularInputDisplay={
-                  updateTabularInputDisplay
-                }></AddMangroveAssociatedSpeciesRow>
+                updateTabularInputDisplay={updateTabularInputDisplay}
+              />
             ) : null}
+
             {!showAddTabularInputRow ? (
               <Button sx={{ marginTop: '1.5em' }} onClick={() => setShowAddTabularInputRow(true)}>
                 + Add measurement row
@@ -543,14 +563,15 @@ function SiteInterventionsForm() {
             ) : null}
           </FormQuestionDiv>
         ) : null}
+
+        {/* Local participant training */}
         <FormQuestionDiv>
           <StickyFormLabel>{questions.localParticipantTraining.question}</StickyFormLabel>
           <Controller
             name='localParticipantTraining'
             control={control}
-            defaultValue=''
             render={({ field }) => (
-              <TextField {...field} select value={field.value} label='select'>
+              <TextField {...field} select value={field.value ?? ''} label='select'>
                 {questions.localParticipantTraining.options.map((item, index) => (
                   <MenuItem key={index} value={item}>
                     {item}
@@ -562,7 +583,8 @@ function SiteInterventionsForm() {
           <ErrorText>{errors.localParticipantTraining?.message}</ErrorText>
         </FormQuestionDiv>
 
-        {localParticipantTrainingWatcher === 'Yes' ? (
+        {/* Organizations providing training */}
+        {localParticipantTraining === 'Yes' ? (
           <FormQuestionDiv>
             <CheckboxGroupWithLabelAndController
               fieldName='organizationsProvidingTraining'
@@ -574,6 +596,8 @@ function SiteInterventionsForm() {
             <ErrorText>{errors.organizationsProvidingTraining?.selectedValues?.message}</ErrorText>
           </FormQuestionDiv>
         ) : null}
+
+        {/* Other activities implemented */}
         <FormQuestionDiv>
           <CheckboxGroupWithLabelAndController
             fieldName='otherActivitiesImplemented'

--- a/mrtt-ui/src/components/SocioeconomicAndGovernance/SocioeconomicAndGovernanceStatusAndOutcomesForm.js
+++ b/mrtt-ui/src/components/SocioeconomicAndGovernance/SocioeconomicAndGovernanceStatusAndOutcomesForm.js
@@ -35,6 +35,8 @@ import ConfirmPrompt from '../ConfirmPrompt/ConfirmPrompt'
 import DatePickerUtcMui from '../DatePickerUtcMui'
 import RequiredIndicator from '../RequiredIndicator'
 
+import { useInitializeQuestionMappedForm } from '../../library/question-mapped-form/useInitializeQuestionMappedForm'
+
 const getSocioeconomicAims = (registrationAnswersFromServer) =>
   findRegistationDataItem(registrationAnswersFromServer, '3.2') ?? []
 
@@ -103,12 +105,12 @@ const SocioeconomicAndGovernanceStatusAndOutcomesForm = () => {
     [registrationInterventionFormsUrl]
   )
 
-  useInitializeMonitoringForm({
-    apiUrl: monitoringFormSingularUrl,
-    formType,
-    isEditMode,
-    questionMapping: questionMapping.socioeconomicAndGovernanceStatusAndOutcomes,
-    setIsLoading: setIsMainFormDataLoading
+  const { data, isLoading } = useInitializeQuestionMappedForm({
+    key: 'socioeconomicAndGovernanceStatusAndOutcomes',
+    apiUrl: registrationInterventionFormsUrl,
+    resetForm: form.reset,
+    questionMapping,
+    setIsLoading: () => {}
   })
 
   const createNewMonitoringForm = (payload) => {
@@ -235,7 +237,6 @@ const SocioeconomicAndGovernanceStatusAndOutcomesForm = () => {
       <QuestionNav
         isFormSaving={isSubmitting}
         isFormSaveError={isSubmitError}
-        onFormSave={validateInputs(handleSubmit)}
         currentSection='socioeconomic-and-governance-status'
       />
       <FormValidationMessageIfErrors formErrors={errors} />
@@ -249,9 +250,8 @@ const SocioeconomicAndGovernanceStatusAndOutcomesForm = () => {
           <Controller
             name='dateOfOutcomesAssessment'
             control={control}
-            defaultValue={null}
             render={({ field }) => (
-              <DatePickerUtcMui id='date-of-outcomes-assessment' label='date' field={field} />
+              <DatePickerUtcMui id='dateOfOutcomesAssessment' label='date' field={field} />
             )}
           />
           <ErrorText>{errors.dateOfOutcomesAssessment?.message}</ErrorText>

--- a/mrtt-ui/src/library/formatApiAnswersForForm.js
+++ b/mrtt-ui/src/library/formatApiAnswersForForm.js
@@ -1,4 +1,5 @@
-const formatApiAnswersForForm = ({ apiAnswers, questionMapping }) => {
+import { defaultValues } from '../components/FormWrapper/FormSchemaValidation'
+export const formatApiAnswersForForm = ({ apiAnswers, questionMapping }) => {
   // questionMapping type is an object with one level of properties with string values
 
   const questionIdEntries = Object.entries(questionMapping)
@@ -7,10 +8,36 @@ const formatApiAnswersForForm = ({ apiAnswers, questionMapping }) => {
     const [frontEndAnswerId, apiAnswerId] = question
     const apiAnswer = apiAnswers.find((apiAnswer) => apiAnswer.question_id === apiAnswerId)
 
-    return [frontEndAnswerId, apiAnswer?.answer_value]
+    return [frontEndAnswerId, apiAnswer?.answer_value || defaultValues[frontEndAnswerId]]
   })
 
-  return Object.fromEntries(answersForUiFormEntries)
+  return Object.fromEntries(answersForUiFormEntries, defaultValues)
+}
+
+export const formatApiAnswersForFormByKey = ({ apiAnswers, questionMapping }) => {
+  const answersById = Object.fromEntries(apiAnswers.map((a) => [a.question_id, a.answer_value]))
+
+  const result = {}
+
+  Object.entries(questionMapping).forEach(([sectionKey, sectionMapping]) => {
+    result[sectionKey] = {}
+
+    Object.entries(sectionMapping).forEach(([fieldKey, questionId]) => {
+      let apiValue = answersById[questionId]
+
+      // MUI specific: cast 'true'/'false' strings to boolean
+      if (apiValue === 'true') apiValue = true
+      if (apiValue === 'false') apiValue = false
+
+      const hasValue =
+        apiValue !== undefined &&
+        apiValue !== null &&
+        !(typeof apiValue === 'string' && apiValue.trim() === '')
+
+      result[sectionKey][fieldKey] = hasValue ? apiValue : defaultValues[fieldKey]
+    })
+  })
+  return result
 }
 
 export default formatApiAnswersForForm

--- a/mrtt-ui/src/library/mapDataForApi.js
+++ b/mrtt-ui/src/library/mapDataForApi.js
@@ -7,6 +7,7 @@ export const mapDataForApi = (formTitle, data) => {
 
   for (const [fieldName, uiAnswer] of Object.entries(data)) {
     const apiQuestionId = questionMapping[formTitle]?.[fieldName]
+
     if (apiQuestionId) {
       preppedData.push({
         question_id: apiQuestionId,
@@ -14,6 +15,7 @@ export const mapDataForApi = (formTitle, data) => {
       })
     }
   }
+
   return preppedData
 }
 

--- a/mrtt-ui/src/library/question-mapped-form/sections-hook.ts
+++ b/mrtt-ui/src/library/question-mapped-form/sections-hook.ts
@@ -1,0 +1,30 @@
+import { useMemo } from 'react'
+import { sectionsRegistry, SectionKey } from './sections'
+import { SECTION_NAMES_DICTIONARY } from '../../constants/sectionNames'
+
+export function useSectionQuestions(section: SectionKey) {
+  return useMemo(() => {
+    const config = sectionsRegistry[section] || sectionsRegistry[SECTION_NAMES_DICTIONARY[section]]
+
+    if (!config) {
+      throw new Error(`Unknown section: ${section}`)
+    }
+    const { mapping, questions } = config
+
+    const sectionKeys = Object.keys(mapping)
+
+    const orderedQuestions = Object.entries(mapping).map(([fieldKey, questionId]) => ({
+      fieldKey,
+      questionId,
+      ...questions[fieldKey]
+    }))
+
+    return {
+      section,
+      mapping,
+      questions,
+      sectionKeys,
+      orderedQuestions
+    }
+  }, [section])
+}

--- a/mrtt-ui/src/library/question-mapped-form/sections.ts
+++ b/mrtt-ui/src/library/question-mapped-form/sections.ts
@@ -1,0 +1,59 @@
+import {
+  projectDetails,
+  siteBackground,
+  restorationAims,
+  causesOfDecline,
+  preRestorationAssessment,
+  siteInterventions,
+  costs,
+  managementStatusAndEffectiveness,
+  socioeconomicGovernanceStatusOutcomes,
+  ecologicalStatusOutcomes
+} from '../../data/questions'
+
+import { questionMapping } from '../../data/questionMapping'
+
+export const sectionsRegistry = {
+  projectDetails: {
+    mapping: questionMapping.projectDetails,
+    questions: projectDetails
+  },
+  siteBackground: {
+    mapping: questionMapping.siteBackground,
+    questions: siteBackground
+  },
+  restorationAims: {
+    mapping: questionMapping.restorationAims,
+    questions: restorationAims
+  },
+  causesOfDecline: {
+    mapping: questionMapping.causesOfDecline,
+    questions: causesOfDecline
+  },
+  preRestorationAssessment: {
+    mapping: questionMapping.preRestorationAssessment,
+    questions: preRestorationAssessment
+  },
+  siteInterventions: {
+    mapping: questionMapping.siteInterventions,
+    questions: siteInterventions
+  },
+  costs: {
+    mapping: questionMapping.costs,
+    questions: costs
+  },
+  managementStatusAndEffectiveness: {
+    mapping: questionMapping.managementStatusAndEffectiveness,
+    questions: managementStatusAndEffectiveness
+  },
+  socioeconomicGovernanceStatusOutcomes: {
+    mapping: questionMapping.socioeconomicAndGovernanceStatusAndOutcomes,
+    questions: socioeconomicGovernanceStatusOutcomes
+  },
+  ecologicalStatusOutcomes: {
+    mapping: questionMapping.ecologicalStatusAndOutcomes,
+    questions: ecologicalStatusOutcomes
+  }
+} as const
+
+export type SectionKey = keyof typeof sectionsRegistry

--- a/mrtt-ui/src/library/question-mapped-form/useInitializeQuestionMappedForm.tsx
+++ b/mrtt-ui/src/library/question-mapped-form/useInitializeQuestionMappedForm.tsx
@@ -1,54 +1,116 @@
-import { useQuery, UseQueryResult } from '@tanstack/react-query'
+import { useQuery, UseQueryResult, UseQueryOptions } from '@tanstack/react-query'
 import axios, { AxiosResponse } from 'axios'
-import { toast } from 'react-toastify'
 
-import formatApiAnswersForForm from '../formatApiAnswersForForm'
-import language from '../../language'
+import { useMutation } from '@tanstack/react-query'
 
-type FormattedResponse = {
-  response: AxiosResponse
+import { mapDataForApi } from '../../library/mapDataForApi'
+
+import { formatApiAnswersForFormByKey } from '../formatApiAnswersForForm'
+import { questionMapping } from '../../data/questionMapping'
+import { useParams } from 'react-router-dom'
+import { defaultValues } from '../../components/FormWrapper/FormSchemaValidation'
+import { SECTION_NAMES_DICTIONARY } from '../../constants/sectionNames'
+
+type ApiAnswerItem = {
+  question_id: string
+  answer_value: unknown
+}
+
+export type FormattedResponse = {
+  response: AxiosResponse<ApiAnswerItem[]>
   formattedData: unknown
 }
 
-type Params = {
+type Params<TSelected = FormattedResponse> = {
+  key: 'projectDetails' | 'siteBackground'
   apiUrl: string
   questionMapping: unknown
   resetForm: (values: unknown) => void
-  successCallback?: (response: AxiosResponse) => void
+  successCallback?: (response: AxiosResponse<ApiAnswerItem[]>) => void
   enabled?: boolean
+  queryOptions?: Omit<
+    UseQueryOptions<FormattedResponse, Error, TSelected, readonly unknown[]>,
+    'queryKey' | 'queryFn' | 'enabled'
+  >
 }
 
-const queryOptions = {
+type ApiAnswer = { question_id: string; answer_value: any }
+
+const queryOptionsDefault = {
   retry: false,
   refetchOnWindowFocus: false,
   refetchOnReconnect: false,
   refetchOnMount: false
-}
+} as const
 
-export function useInitializeQuestionMappedForm({
+export function useInitializeQuestionMappedForm<TSelected = FormattedResponse>({
+  key,
   apiUrl,
+  resetForm,
   questionMapping,
   successCallback,
-  enabled = true
-}: Params): UseQueryResult<FormattedResponse, Error> {
-  return useQuery<FormattedResponse, Error>({
-    queryKey: ['question-mapped-form', apiUrl],
-    queryFn: async () => {
-      const response = await axios.get(apiUrl)
-      try {
-        const formattedData = await formatApiAnswersForForm({
-          apiAnswers: response.data,
-          questionMapping
-        })
-        successCallback?.(response)
-        return { response: response.data, formattedData }
-      } catch (error) {
-        toast.error(language.error.apiLoad)
-        console.error('Error formatting API answers:', error)
-        throw error
-      }
+  enabled = true,
+  queryOptions = queryOptionsDefault
+}: Params<TSelected>): UseQueryResult<TSelected, Error> {
+  return useQuery<FormattedResponse, Error, TSelected>({
+    queryKey: ['question-mapped-form', key, apiUrl],
+    enabled: Boolean(enabled && key && apiUrl && !apiUrl.includes('undefined')),
+    ...(queryOptionsDefault as any),
+    ...(queryOptions ?? {}),
+    queryFn: async (): Promise<FormattedResponse> => {
+      const response = await axios.get<ApiAnswerItem[]>(apiUrl)
+
+      const formattedData = await formatApiAnswersForFormByKey({
+        apiAnswers: response.data,
+        questionMapping
+      })
+      resetForm({
+        ...defaultValues,
+        ...formattedData[key]
+      })
+
+      successCallback?.(response)
+
+      return { response, formattedData }
     },
-    ...queryOptions,
-    enabled: !!apiUrl && enabled
+
+    ...(queryOptionsDefault as Omit<
+      UseQueryOptions<FormattedResponse, Error, TSelected, readonly unknown[]>,
+      'queryKey' | 'queryFn' | 'enabled'
+    >),
+    ...(queryOptions ?? {})
   })
+}
+
+export function useSaveRegistrationSection({
+  siteId,
+  form,
+  section
+}: {
+  siteId: string
+  form: any
+  section: string
+}) {
+  const apiUrl = `${process.env.REACT_APP_API_URL}/sites/${siteId}/registration_intervention_answers`
+
+  const mutation = useMutation({
+    mutationKey: ['save-registration-section', siteId, section],
+    mutationFn: async ({ formData }: { formData: any }) => {
+      if (!siteId) throw new Error('Missing siteId')
+      return axios.patch(apiUrl, mapDataForApi(section, formData))
+    }
+  })
+
+  const save = async (section: string) => {
+    const fields = Object.keys(questionMapping[section] ?? {})
+    const ok = await form.trigger(fields, { shouldFocus: true })
+    if (!ok) return false
+
+    const all = form.getValues()
+    const sectionValues = Object.fromEntries(fields.map((k) => [k, all[k]]))
+    await mutation.mutateAsync({ formData: sectionValues })
+    return true
+  }
+
+  return { save, mutation }
 }


### PR DESCRIPTION
This pull request introduces several updates and refactors to the forms and supporting components in the `mrtt-ui` project. The main focus is on improving form initialization, correcting typos, and cleaning up unused or redundant code. Additionally, there are some technical adjustments to dependencies and route paths.

**Form Initialization and Refactoring:**

* Replaced custom form initialization hooks (like `useInitializeMonitoringForm`) with the more general `useInitializeQuestionMappedForm` in `CausesOfDeclineForm`, `CostsForm`, and `EcologicalStatusAndOutcomesForm`. This standardizes how forms are populated with server data and resets, and allows for custom callbacks on load. [[1]](diffhunk://#diff-68859b676bc8a05bd13e929862ce4c23e85fb12ac70ba9d3a8b3056d6be1e1bfL96-R101) [[2]](diffhunk://#diff-68859b676bc8a05bd13e929862ce4c23e85fb12ac70ba9d3a8b3056d6be1e1bfL216-R242) [[3]](diffhunk://#diff-18a46ba3d06e1f56c0eeb62b98f7bdd40e25df3f111f6e047260b1a76c9ecd1cR53-R65) [[4]](diffhunk://#diff-18a46ba3d06e1f56c0eeb62b98f7bdd40e25df3f111f6e047260b1a76c9ecd1cL80-L81) [[5]](diffhunk://#diff-18a46ba3d06e1f56c0eeb62b98f7bdd40e25df3f111f6e047260b1a76c9ecd1cL149-L154) [[6]](diffhunk://#diff-7d9ba7abb5e0dd1419113fe2b0e50186a41e69917fe3830afacd65a21cc26fe9R50-R52) [[7]](diffhunk://#diff-7d9ba7abb5e0dd1419113fe2b0e50186a41e69917fe3830afacd65a21cc26fe9L169-R199)

* Updated usage of `useFieldArray` and `useWatch` in `EcologicalStatusAndOutcomesForm` to improve state management and ensure form arrays are correctly reset and replaced from server data. [[1]](diffhunk://#diff-7d9ba7abb5e0dd1419113fe2b0e50186a41e69917fe3830afacd65a21cc26fe9L82-R93) [[2]](diffhunk://#diff-7d9ba7abb5e0dd1419113fe2b0e50186a41e69917fe3830afacd65a21cc26fe9L98-R112) [[3]](diffhunk://#diff-7d9ba7abb5e0dd1419113fe2b0e50186a41e69917fe3830afacd65a21cc26fe9L169-R199)

**Bug Fixes and Typo Corrections:**

* Fixed a recurring typo by renaming all instances of `levelOfDegredation` to `levelOfDegradation` in `CausesOfDeclineForm.js`. [[1]](diffhunk://#diff-68859b676bc8a05bd13e929862ce4c23e85fb12ac70ba9d3a8b3056d6be1e1bfL124-R134) [[2]](diffhunk://#diff-68859b676bc8a05bd13e929862ce4c23e85fb12ac70ba9d3a8b3056d6be1e1bfL144-R146) [[3]](diffhunk://#diff-68859b676bc8a05bd13e929862ce4c23e85fb12ac70ba9d3a8b3056d6be1e1bfL156-R166) [[4]](diffhunk://#diff-68859b676bc8a05bd13e929862ce4c23e85fb12ac70ba9d3a8b3056d6be1e1bfL368-R369) [[5]](diffhunk://#diff-68859b676bc8a05bd13e929862ce4c23e85fb12ac70ba9d3a8b3056d6be1e1bfL407-R408)

* Updated the prop type for the `field.value` in `DatePickerUtcMui` to expect a `DateTime` instance instead of a string, and adjusted the value parsing accordingly. [[1]](diffhunk://#diff-dbc52f4edf6465689e13848798c3c0d1346aee8794e624d190a4059bfe623f2fL13-R13) [[2]](diffhunk://#diff-dbc52f4edf6465689e13848798c3c0d1346aee8794e624d190a4059bfe623f2fL33-R33)

**Code Cleanup and Simplification:**

* Removed the `hasErrors` prop from `ButtonSave` and its usage, simplifying the component and its prop types.

* Commented out or removed unused form submission handlers and providers in `CausesOfDeclineForm` and `CostsForm`, reflecting a move to new form management approaches. [[1]](diffhunk://#diff-68859b676bc8a05bd13e929862ce4c23e85fb12ac70ba9d3a8b3056d6be1e1bfL216-R242) [[2]](diffhunk://#diff-68859b676bc8a05bd13e929862ce4c23e85fb12ac70ba9d3a8b3056d6be1e1bfL260-R265) [[3]](diffhunk://#diff-68859b676bc8a05bd13e929862ce4c23e85fb12ac70ba9d3a8b3056d6be1e1bfL450-R451) [[4]](diffhunk://#diff-18a46ba3d06e1f56c0eeb62b98f7bdd40e25df3f111f6e047260b1a76c9ecd1cL80-L81) [[5]](diffhunk://#diff-18a46ba3d06e1f56c0eeb62b98f7bdd40e25df3f111f6e047260b1a76c9ecd1cL231)

**Routing and Dependency Adjustments:**

* Fixed the route path for the project details form by removing the trailing slash in `App.js`.

* Updated the `file-loader` dependency versions in `pnpm-lock.yaml` to ensure compatibility with the correct `webpack` versions. [[1]](diffhunk://#diff-2f64b9dc308fd93b6eb79899f82af5200d2ce1292edeaa77a1889232f545cb2fL12393-R12393) [[2]](diffhunk://#diff-2f64b9dc308fd93b6eb79899f82af5200d2ce1292edeaa77a1889232f545cb2fL12869-R12869)
