### PR TITLE
error handling

### DIFF
--- a/mrtt-ui/src/components/FormValidationMessageIfErrors.js
+++ b/mrtt-ui/src/components/FormValidationMessageIfErrors.js
@@ -7,40 +7,13 @@ import { questionMapping } from '../data/questionMapping'
 
 import language from '../language'
 
-export function getSectionsWithErrors(questionMapping, errors) {
-  const sections = new Set()
-
-  for (const fields of Object.values(questionMapping)) {
-    for (const [fieldName, questionId] of Object.entries(fields)) {
-      if (errors[fieldName]) {
-        sections.add(questionId)
-      }
-    }
-  }
-
-  if (sections.size === 0) return ''
-
-  return `Please note the sections with errors are ${Array.from(sections).join(', ')}.`
-}
-
 const FormValidationMessageIfErrors = ({ formErrors = {} }) => {
   const formHasErrors = !!Object.keys(formErrors).length
-
-  const sectionsWithErrors = getSectionsWithErrors(questionMapping, formErrors)
-
-  useEffect(() => {
-    if (formHasErrors) {
-      toast.warn(
-        `${language.form.validationAlert.title}. ${language.form.validationAlert.description}`
-      )
-    }
-  }, [formHasErrors])
 
   return formHasErrors ? (
     <Alert variant='outlined' severity='error'>
       <AlertTitle>{language.form.validationAlert.title}</AlertTitle>
       <p>{language.form.validationAlert.description}</p>
-      {sectionsWithErrors && <p>{sectionsWithErrors}</p>}
     </Alert>
   ) : null
 }

--- a/mrtt-ui/src/components/QuestionNav.js
+++ b/mrtt-ui/src/components/QuestionNav.js
@@ -164,11 +164,6 @@ const QuestionNav = ({ isFormSaving, isFormSaveError, currentSection }) => {
     (to, direction) => async (e) => {
       e.preventDefault()
 
-      if (direction === 'previous') {
-        navigate(to)
-        return
-      }
-
       const saved = await save(SECTION_NAMES_DICTIONARY[sectionFromUrl])
 
       if (saved) navigate(to)

--- a/mrtt-ui/src/constants/sectionNames.js
+++ b/mrtt-ui/src/constants/sectionNames.js
@@ -26,5 +26,18 @@ export const SECTION_NAMES_DICTIONARY = {
   'ecological-status-and-outcomes': 'ecologicalStatusAndOutcomes'
 }
 
+export const FORM_NAMES_DICTIONARY = {
+  projectDetails: 'Site Details and Location',
+  siteBackground: 'Site Background',
+  restorationAims: 'Restoration Aims',
+  causesOfDecline: 'Causes of Decline',
+  preRestorationAssessment: 'Pre-Restoration Assessment',
+  siteInterventions: 'Site Interventions',
+  costs: 'Costs',
+  managementStatusAndEffectiveness: 'Management Status and Effectiveness',
+  socioeconomicAndGovernanceStatusAndOutcomes: 'Socioeconomic and Governance Status and Outcomes',
+  ecologicalStatusAndOutcomes: 'Ecological Status and Outcomes'
+}
+
 Object.freeze(SECTION_NAMES)
 export default SECTION_NAMES

--- a/mrtt-ui/src/library/question-mapped-form/useInitializeQuestionMappedForm.tsx
+++ b/mrtt-ui/src/library/question-mapped-form/useInitializeQuestionMappedForm.tsx
@@ -7,9 +7,10 @@ import { mapDataForApi } from '../../library/mapDataForApi'
 
 import { formatApiAnswersForFormByKey } from '../formatApiAnswersForForm'
 import { questionMapping } from '../../data/questionMapping'
-import { useParams } from 'react-router-dom'
+
 import { defaultValues } from '../../components/FormWrapper/FormSchemaValidation'
-import { SECTION_NAMES_DICTIONARY } from '../../constants/sectionNames'
+import { FORM_NAMES_DICTIONARY } from '../../constants/sectionNames'
+import { toast } from 'react-toastify'
 
 type ApiAnswerItem = {
   question_id: string
@@ -33,8 +34,6 @@ type Params<TSelected = FormattedResponse> = {
     'queryKey' | 'queryFn' | 'enabled'
   >
 }
-
-type ApiAnswer = { question_id: string; answer_value: any }
 
 const queryOptionsDefault = {
   retry: false,
@@ -104,7 +103,14 @@ export function useSaveRegistrationSection({
   const save = async (section: string) => {
     const fields = Object.keys(questionMapping[section] ?? {})
     const ok = await form.trigger(fields, { shouldFocus: true })
-    if (!ok) return false
+    if (!ok) {
+      toast.error(
+        `Cannot save "${
+          FORM_NAMES_DICTIONARY[section] || section
+        }". Please fix the errors indicated on the form.`
+      )
+      return false
+    }
 
     const all = form.getValues()
     const sectionValues = Object.fromEntries(fields.map((k) => [k, all[k]]))


### PR DESCRIPTION
This pull request primarily improves error handling and user feedback in the form workflow, focusing on making validation messages clearer and more context-specific. The changes also include some code cleanup and the introduction of a new dictionary for section names.

**Error handling and user feedback improvements:**

* When a form section fails validation on save, a toast error is now shown with the specific section name using `FORM_NAMES_DICTIONARY`, making it clearer to users which section needs attention. (`useInitializeQuestionMappedForm.tsx`)
* The logic for displaying a summary of sections with errors in `FormValidationMessageIfErrors.js` has been removed, simplifying the error display and focusing on the main validation alert.

**Codebase improvements and cleanup:**

* The unused `getSectionsWithErrors` function and related code have been removed from `FormValidationMessageIfErrors.js`, reducing complexity.
* The navigation logic in `QuestionNav.js` has been streamlined to always trigger a save before navigating, eliminating the special case for the "previous" direction.
* The new `FORM_NAMES_DICTIONARY` has been added to `sectionNames.js` to provide user-friendly section names for error messages and other UI elements.