### PR TITLE
fix countries

### DIFF
--- a/mrtt-ui/src/library/question-mapped-form/useInitializeQuestionMappedForm.tsx
+++ b/mrtt-ui/src/library/question-mapped-form/useInitializeQuestionMappedForm.tsx
@@ -78,10 +78,8 @@ type ParamsMonitors<TSelected = FormattedMonitorsResponse> = Omit<
 }
 
 const queryOptionsDefault = {
-  retry: false,
-  refetchOnWindowFocus: false,
-  refetchOnReconnect: false,
-  refetchOnMount: false
+  refetchOnMount: 'always',
+  staleTime: 0
 } as const
 
 export function useInitializeQuestionMappedForm<TSelected = FormattedResponse>({


### PR DESCRIPTION
This pull request updates the default query options in the `useInitializeQuestionMappedForm` hook to improve data freshness and ensure the form always loads the most recent data.

**Query options update:**

* Changed `refetchOnMount` to `'always'` and set `staleTime` to `0` in the `queryOptionsDefault` object in `useInitializeQuestionMappedForm.tsx` to ensure data is always refetched and never considered fresh. (`[mrtt-ui/src/library/question-mapped-form/useInitializeQuestionMappedForm.tsxL81-R82](diffhunk://#diff-68ae987b79ccf2434be6cd1a0c74e07b2edeb1e0405d56d4813acb30a95c7158L81-R82)`)