### PR TITLE
monitor form id by date

### DIFF
--- a/mrtt-ui/src/components/QuestionNav.js
+++ b/mrtt-ui/src/components/QuestionNav.js
@@ -22,7 +22,7 @@ import { useFormContext } from 'react-hook-form'
 
 import { useSaveRegistrationSection } from '../library/question-mapped-form/useInitializeQuestionMappedForm'
 import { useGetSectionTarget } from '../library/question-mapped-form/sections-hook'
-import { useGetMonitorForm } from '../library/question-mapped-form/monitors'
+import { useGetMonitorsForms } from '../library/question-mapped-form/monitors'
 
 const componentLanguage = language.questionNav
 
@@ -93,7 +93,7 @@ const QuestionNav = ({ isFormSaving, isFormSaveError, currentSection }) => {
   const [isPrivacySaving, setIsPrivacySaving] = useState(false)
   const [sectionPrivacy, setSectionPrivacy] = useState()
   const [siteFromApi, setSiteFromApi] = useState()
-  const { siteId, monitoringFormId } = useParams()
+  const { siteId, monitoringFormId: monitorIdUrl } = useParams()
   const currentSectionNameIndex = SECTION_NAMES.indexOf(currentSection)
   const isFormPrivacyDisabled = currentSection === 'project-details'
   const nextSection = SECTION_NAMES[currentSectionNameIndex + 1]
@@ -106,38 +106,67 @@ const QuestionNav = ({ isFormSaving, isFormSaveError, currentSection }) => {
 
   const pathParts = pathname.split('/').filter(Boolean)
 
-  const sectionFromUrl = monitoringFormId
+  const sectionFromUrl = monitorIdUrl
     ? pathParts[pathParts.length - 2]
     : pathParts[pathParts.length - 1]
-  const sectionTarget = useGetSectionTarget(sectionFromUrl, monitoringFormId)
+  const sectionTarget = useGetSectionTarget(sectionFromUrl, monitorIdUrl)
   const sectionPayload =
     sectionTarget === 'interventions'
       ? SECTION_NAMES_DICTIONARY_INTERVENTIONS[sectionFromUrl]
       : SECTION_NAMES_DICTIONARY_MONITORS[sectionFromUrl]
+
   const { save } = useSaveRegistrationSection({
     siteId,
     currentSection,
     form,
     section: sectionPayload,
     sectionTarget,
-    monitorId: monitoringFormId
+    monitorId: monitorIdUrl
   })
 
-  const { data } = useGetMonitorForm({
+  const { data: monitorForms } = useGetMonitorsForms({
     siteId,
     key: sectionFromUrl,
     queryOptions: {
-      enabled: !!monitoringFormId && sectionTarget === 'monitors'
+      enabled: sectionTarget === 'monitors'
     }
   })
 
-  const monitorId = useMemo(
-    () =>
-      data?.find(
-        (monitor) => monitor?.form_type === SECTION_NAMES_DICTIONARY_MONITORS[sectionFromUrl]
-      )?.id || monitoringFormId,
-    [monitoringFormId, data, sectionFromUrl]
-  )
+  const monitorType = SECTION_NAMES_DICTIONARY_MONITORS[sectionFromUrl]
+
+  const { lastMonitoringFormId, currentMonitorId } = useMemo(() => {
+    if (!monitorForms?.length) {
+      return {
+        lastMonitoringFormId: undefined,
+        currentMonitorId: undefined
+      }
+    }
+
+    const formsOfType = monitorForms.filter((monitor) => monitor.form_type === monitorType)
+
+    const lastMonitoringForm = formsOfType.reduce((latest, monitor) => {
+      if (!latest) return monitor
+
+      return new Date(monitor.monitoring_date) > new Date(latest.monitoring_date) ? monitor : latest
+    }, undefined)
+
+    const monitorFromUrl = monitorForms.find((monitor) => monitor.id === monitorIdUrl)
+
+    const currentMonitor =
+      monitorFromUrl &&
+      monitorForms.find(
+        (monitor) =>
+          monitor.form_type === monitorType &&
+          monitor.monitoring_date === monitorFromUrl.monitoring_date
+      )
+
+    return {
+      lastMonitoringFormId: lastMonitoringForm?.id,
+      currentMonitorId: currentMonitor?.id
+    }
+  }, [monitorForms, monitorIdUrl, monitorType])
+
+  const monitorId = currentMonitorId ?? lastMonitoringFormId
 
   useEffect(
     function getSiteInfoToUseWithAPutRequestToUpdateSitePrivacySincePatchDoesntWork() {

--- a/mrtt-ui/src/library/question-mapped-form/monitors.ts
+++ b/mrtt-ui/src/library/question-mapped-form/monitors.ts
@@ -6,17 +6,17 @@ type MonitorFormKey =
   | 'ecologicalStatusAndOutcomes'
   | 'socioeconomicGovernanceStatusAndOutcomes'
 
-type ApiAnswerMonitorsItem = {
+type MonitorsItem = {
   id: string
   form_type: MonitorFormKey
   monitoring_date: string
 }
 
-type Params<TSelected = ApiAnswerMonitorsItem[]> = {
+type Params<TSelected = MonitorsItem[]> = {
   key: MonitorFormKey
   siteId: string
   queryOptions?: Omit<
-    UseQueryOptions<ApiAnswerMonitorsItem[], Error, TSelected, readonly unknown[]>,
+    UseQueryOptions<MonitorsItem[], Error, TSelected, readonly unknown[]>,
     'queryKey' | 'queryFn' | 'enabled'
   >
 }
@@ -28,15 +28,15 @@ const queryOptionsDefault = {
   refetchOnMount: false
 } as const
 
-export function useGetMonitorForm<TSelected = ApiAnswerMonitorsItem[]>({
+export function useGetMonitorsForms<TSelected = MonitorsItem[]>({
   key,
   siteId,
   queryOptions
 }: Params<TSelected>): UseQueryResult<TSelected, Error> {
-  return useQuery<ApiAnswerMonitorsItem[], Error, TSelected>({
+  return useQuery<MonitorsItem[], Error, TSelected>({
     queryKey: ['question-mapped-form-monitors', key, siteId],
-    queryFn: async (): Promise<ApiAnswerMonitorsItem[]> => {
-      const response = await axios.get<ApiAnswerMonitorsItem[]>(
+    queryFn: async (): Promise<MonitorsItem[]> => {
+      const response = await axios.get<MonitorsItem[]>(
         `${process.env.REACT_APP_API_URL}/sites/${siteId}/monitoring_answers`
       )
 


### PR DESCRIPTION
This pull request refactors how monitoring forms are fetched and handled in the `QuestionNav` component, improving clarity and correctness in monitor form selection. The changes mainly rename and update the hook for fetching monitor forms, clarify variable naming, and enhance the logic to select the correct monitor form based on type and date.

**Refactoring and API Consistency:**

* Renamed the hook from `useGetMonitorForm` to `useGetMonitorsForms` and updated related types from `ApiAnswerMonitorsItem` to `MonitorsItem` for clearer intent and consistency. [[1]](diffhunk://#diff-2b0f3c9972fcfd11cf6c1dabb6f281ba482989a805942a2242ab6a3735018222L25-R25) [[2]](diffhunk://#diff-6705c4ad847dad23f2d245a88781c329841e929bb3d8bda8f117ffe30542dc10L9-R19) [[3]](diffhunk://#diff-6705c4ad847dad23f2d245a88781c329841e929bb3d8bda8f117ffe30542dc10L31-R39)

**Improved Monitor Form Selection Logic:**

* Enhanced the logic in `QuestionNav` to determine the relevant monitor form by:
  * Filtering forms by type,
  * Selecting the most recent form by date,
  * Matching the current form from the URL,
  * Falling back to the latest form if no direct match is found.

**Variable Naming and Parameter Updates:**

* Renamed `monitoringFormId` to `monitorIdUrl` throughout `QuestionNav.js` for clarity and updated all usages accordingly, ensuring parameters passed to hooks and functions are accurate. [[1]](diffhunk://#diff-2b0f3c9972fcfd11cf6c1dabb6f281ba482989a805942a2242ab6a3735018222L96-R96) [[2]](diffhunk://#diff-2b0f3c9972fcfd11cf6c1dabb6f281ba482989a805942a2242ab6a3735018222L109-R170)

**Hook Usage and Query Options:**

* Updated the query options for fetching monitor forms to enable the query only when the section target is 'monitors', removing reliance on a specific form ID.

These changes make the codebase more maintainable and ensure the correct monitor form is selected in all scenarios.