### PR TITLE
Fix/form state persistence on navigation

### DIFF
--- a/mrtt-ui/src/components/CausesOfDeclineForm.js
+++ b/mrtt-ui/src/components/CausesOfDeclineForm.js
@@ -96,7 +96,7 @@ function CausesOfDeclineForm() {
   const { data, isLoading } = useInitializeQuestionMappedForm({
     key: 'causesOfDecline',
     apiUrl: apiAnswersUrl,
-    resetForm: form.reset,
+    form,
     questionMapping
     // successCallback: setInitialCausesOfDeclineTypesFromServerData
   })

--- a/mrtt-ui/src/components/CheckboxGroup/CheckboxGroup.js
+++ b/mrtt-ui/src/components/CheckboxGroup/CheckboxGroup.js
@@ -1,6 +1,6 @@
 import { Checkbox, FormControlLabel, FormGroup, Stack, TextField } from '@mui/material'
 import PropTypes from 'prop-types'
-import { forwardRef, useState } from 'react'
+import { forwardRef, useEffect, useState } from 'react'
 import language from '../../language'
 import { makeValidClassName } from '../../library/strings/makeValidClassName'
 
@@ -44,6 +44,12 @@ const CheckboxGroup = forwardRef(
       value?.selectedValues ?? []
     )
     const [otherInputValue, setOtherInputValue] = useState(value?.otherValue ?? '')
+
+    useEffect(() => {
+      setNonOtherSelectedValues(value?.selectedValues ?? [])
+      setIsOtherChecked(!!value?.isOtherChecked)
+      setOtherInputValue(value?.otherValue ?? '')
+    }, [value?.selectedValues, value?.isOtherChecked, value?.otherValue])
 
     const handleOtherCheckboxChange = (event) => {
       const isOtherCheckedNewState = !isOtherChecked

--- a/mrtt-ui/src/components/Costs/CostsForm.js
+++ b/mrtt-ui/src/components/Costs/CostsForm.js
@@ -149,7 +149,7 @@ const CostsForm = () => {
   const { data, isLoading } = useInitializeQuestionMappedForm({
     key: 'costs',
     apiUrl: apiAnswersUrl,
-    resetForm: form.reset,
+    form,
     questionMapping,
     successCallback: loadServerData
   })

--- a/mrtt-ui/src/components/EcologicalStatusAndOutcomes/EcologicalStatusAndOutcomesForm.js
+++ b/mrtt-ui/src/components/EcologicalStatusAndOutcomes/EcologicalStatusAndOutcomesForm.js
@@ -74,8 +74,7 @@ const EcologicalStatusAndOutcomesForm = () => {
     handleSubmit: validateInputs,
     formState: { errors },
     control,
-    watch: watchForm,
-    reset: resetForm
+    watch: watchForm
   } = form
 
   const {
@@ -194,7 +193,7 @@ const EcologicalStatusAndOutcomesForm = () => {
   const { data, isLoading } = useInitializeQuestionMappedFormMonitors({
     key: 'ecologicalStatusAndOutcomes',
     apiUrl: isEditMode ? monitoringFormSingularUrl : null,
-    resetForm: form.reset,
+    form,
     questionMapping,
     successCallback: onLoaded,
     queryOptions: {

--- a/mrtt-ui/src/components/ManagementStatusAndEffectiveness/ManagementStatusAndEffectivenessForm.js
+++ b/mrtt-ui/src/components/ManagementStatusAndEffectiveness/ManagementStatusAndEffectivenessForm.js
@@ -56,7 +56,7 @@ const ManagementStatusAndEffectivenessForm = () => {
   const { data, isLoading } = useInitializeQuestionMappedFormMonitors({
     key: 'managementStatusAndEffectiveness',
     apiUrl: isEditMode ? monitoringFormSingularUrl : null,
-    resetForm: form.reset,
+    form,
     questionMapping,
     queryOptions: {
       enabled: isEditMode

--- a/mrtt-ui/src/components/PreRestorationAssessment/PreRestorationAssessmentForm.js
+++ b/mrtt-ui/src/components/PreRestorationAssessment/PreRestorationAssessmentForm.js
@@ -59,7 +59,6 @@ function PreRestorationAssessmentForm() {
     handleSubmit: validateInputs,
     formState: { errors },
     control,
-    reset: resetForm,
     setValue: setFormValue,
     watch: watchForm
   } = form
@@ -124,7 +123,7 @@ function PreRestorationAssessmentForm() {
     key: 'preRestorationAssessment',
     apiUrl: apiAnswersUrl,
     questionMapping: questionMapping,
-    resetForm,
+    form,
     successCallback: loadServerData
   })
 

--- a/mrtt-ui/src/components/ProjectDetailsForm.js
+++ b/mrtt-ui/src/components/ProjectDetailsForm.js
@@ -60,9 +60,8 @@ function ProjectDetailsForm() {
     siteId,
     key: 'projectDetails',
     apiUrl: apiAnswersUrl,
-    resetForm: form.reset,
-    questionMapping,
-    setIsLoading: () => {}
+    form,
+    questionMapping
   })
 
   const onCountriesChange = (field, features) => {

--- a/mrtt-ui/src/components/QuestionNav.js
+++ b/mrtt-ui/src/components/QuestionNav.js
@@ -5,7 +5,7 @@ import { toast } from 'react-toastify'
 import { useParams, useNavigate, useLocation } from 'react-router-dom'
 import axios from 'axios'
 import PropTypes from 'prop-types'
-import React, { useCallback, useEffect, useState, useMemo } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 
 import { ErrorText, LinkLooksLikeButtonSecondary } from '../styles/typography'
 import ButtonSave from './ButtonSave'
@@ -25,6 +25,12 @@ import { useGetSectionTarget } from '../library/question-mapped-form/sections-ho
 import { useGetMonitorsForms } from '../library/question-mapped-form/monitors'
 
 const componentLanguage = language.questionNav
+
+const MONITOR_DATE_FIELDS = {
+  'management-status-and-effectiveness': 'dateOfAssessment',
+  'socioeconomic-and-governance-status': 'dateOfOutcomesAssessment',
+  'ecological-status-and-outcomes': 'dateOfEcologicalMonitoring'
+}
 
 const getMobileNavButtonSecondaryCss = (props) => css`
   align-items: center;
@@ -124,6 +130,8 @@ const QuestionNav = ({ isFormSaving, isFormSaveError, currentSection }) => {
     monitorId: monitorIdUrl
   })
 
+  const monitorId = monitorIdUrl
+
   const { data: monitorForms } = useGetMonitorsForms({
     siteId,
     key: sectionFromUrl,
@@ -132,41 +140,21 @@ const QuestionNav = ({ isFormSaving, isFormSaveError, currentSection }) => {
     }
   })
 
-  const monitorType = SECTION_NAMES_DICTIONARY_MONITORS[sectionFromUrl]
+  useEffect(() => {
+    if (sectionTarget !== 'monitors') return
 
-  const { lastMonitoringFormId, currentMonitorId } = useMemo(() => {
-    if (!monitorForms?.length) {
-      return {
-        lastMonitoringFormId: undefined,
-        currentMonitorId: undefined
+    const dateField = MONITOR_DATE_FIELDS[sectionFromUrl]
+    if (!dateField) return
+
+    if (monitorIdUrl && monitorForms?.length) {
+      const monitor = monitorForms.find((m) => m.id === monitorIdUrl)
+      if (monitor?.monitoring_date) {
+        form.setValue(dateField, monitor.monitoring_date, { shouldDirty: false })
       }
+    } else if (!monitorIdUrl) {
+      form.setValue(dateField, new Date().toISOString(), { shouldDirty: false })
     }
-
-    const formsOfType = monitorForms.filter((monitor) => monitor.form_type === monitorType)
-
-    const lastMonitoringForm = formsOfType.reduce((latest, monitor) => {
-      if (!latest) return monitor
-
-      return new Date(monitor.monitoring_date) > new Date(latest.monitoring_date) ? monitor : latest
-    }, undefined)
-
-    const monitorFromUrl = monitorForms.find((monitor) => monitor.id === monitorIdUrl)
-
-    const currentMonitor =
-      monitorFromUrl &&
-      monitorForms.find(
-        (monitor) =>
-          monitor.form_type === monitorType &&
-          monitor.monitoring_date === monitorFromUrl.monitoring_date
-      )
-
-    return {
-      lastMonitoringFormId: lastMonitoringForm?.id,
-      currentMonitorId: currentMonitor?.id
-    }
-  }, [monitorForms, monitorIdUrl, monitorType])
-
-  const monitorId = currentMonitorId ?? lastMonitoringFormId
+  }, [sectionTarget, sectionFromUrl, monitorIdUrl, monitorForms]) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(
     function getSiteInfoToUseWithAPutRequestToUpdateSitePrivacySincePatchDoesntWork() {

--- a/mrtt-ui/src/components/RestorationAimsForm/RestorationAimsForm.js
+++ b/mrtt-ui/src/components/RestorationAimsForm/RestorationAimsForm.js
@@ -29,7 +29,7 @@ const RestorationAimsForm = () => {
   const { data, isLoading } = useInitializeQuestionMappedForm({
     key: 'restorationAims',
     apiUrl: apiAnswersUrl,
-    resetForm: form.reset,
+    form,
     questionMapping
   })
 

--- a/mrtt-ui/src/components/SiteBackgroundForm.js
+++ b/mrtt-ui/src/components/SiteBackgroundForm.js
@@ -57,7 +57,7 @@ const SiteBackgroundForm = () => {
   const { data, isLoading } = useInitializeQuestionMappedForm({
     key: 'siteBackground',
     apiUrl: apiAnswersUrl,
-    resetForm: form.reset,
+    form,
     questionMapping
     // successCallback: setInitialStakeholderTypesFromServerData
   })

--- a/mrtt-ui/src/components/SiteInterventions/SiteInterventionsForm.js
+++ b/mrtt-ui/src/components/SiteInterventions/SiteInterventionsForm.js
@@ -137,7 +137,7 @@ function SiteInterventionsForm() {
   const updateTabularInputDisplay = (boolean) => setShowAddTabularInputRow(boolean)
 
   const onLoaded = useCallback(
-    (_response, sectionValues) => {
+    (_response, sectionValues, allSections) => {
       const v = sectionValues ?? {}
 
       queueMicrotask(() => {
@@ -146,12 +146,20 @@ function SiteInterventionsForm() {
         mangroveAssociatedSpeciesReplace(v.mangroveAssociatedSpecies ?? [])
       })
 
-      const countries = v.countries ?? []
+      const countries = allSections?.projectDetails?.countries ?? []
+      if (countries.length) {
+        form.setValue('countries', countries, { shouldDirty: false })
+      }
       setMangroveSpeciesForCountriesSelected(
         countries.length ? organizeMangroveSpeciesList(countries) : []
       )
     },
-    [whichStakeholdersInvolvedReplace, mangroveSpeciesUsedReplace, mangroveAssociatedSpeciesReplace]
+    [
+      form,
+      whichStakeholdersInvolvedReplace,
+      mangroveSpeciesUsedReplace,
+      mangroveAssociatedSpeciesReplace
+    ]
   )
 
   const { isLoading } = useInitializeQuestionMappedForm({

--- a/mrtt-ui/src/components/SiteInterventions/SiteInterventionsForm.js
+++ b/mrtt-ui/src/components/SiteInterventions/SiteInterventionsForm.js
@@ -157,13 +157,9 @@ function SiteInterventionsForm() {
   const { isLoading } = useInitializeQuestionMappedForm({
     key: 'siteInterventions',
     apiUrl: apiAnswersUrl,
-    resetForm: form.reset,
+    form,
     questionMapping,
-    successCallback: onLoaded,
-    queryOptions: {
-      refetchOnMount: 'always',
-      staleTime: 0
-    }
+    successCallback: onLoaded
   })
 
   useEffect(() => {

--- a/mrtt-ui/src/components/SocioeconomicAndGovernance/SocioeconomicGovernanceStatusAndOutcomesForm.js
+++ b/mrtt-ui/src/components/SocioeconomicAndGovernance/SocioeconomicGovernanceStatusAndOutcomesForm.js
@@ -106,9 +106,8 @@ const SocioeconomicGovernanceStatusAndOutcomesForm = () => {
   const { data, isLoading } = useInitializeQuestionMappedFormMonitors({
     key: 'socioeconomicGovernanceStatusAndOutcomes',
     apiUrl: isEditMode ? monitoringFormSingularUrl : null,
-    resetForm: form.reset,
+    form,
     questionMapping,
-    setIsLoading: () => {},
     queryOptions: {
       enabled: !!isEditMode
     }

--- a/mrtt-ui/src/library/question-mapped-form/useInitializeQuestionMappedForm.tsx
+++ b/mrtt-ui/src/library/question-mapped-form/useInitializeQuestionMappedForm.tsx
@@ -65,7 +65,8 @@ type Params<TSelected = FormattedResponse> = {
   questionMapping: unknown
   successCallback?: (
     response: AxiosResponse<ApiAnswerItem[]>,
-    sectionData: Record<string, unknown>
+    sectionData: Record<string, unknown>,
+    allSectionsData: Record<string, Record<string, unknown>>
   ) => void
   enabled?: boolean
   queryOptions?: Omit<
@@ -80,7 +81,8 @@ type ParamsMonitors<TSelected = FormattedMonitorsResponse> = Omit<
 > & {
   successCallback?: (
     response: AxiosResponse<ApiMonitorsFormResponse>,
-    sectionData: Record<string, unknown>
+    sectionData: Record<string, unknown>,
+    allSectionsData: Record<string, Record<string, unknown>>
   ) => void
   queryOptions?: Omit<
     UseQueryOptions<FormattedMonitorsResponse, Error, TSelected, readonly unknown[]>,
@@ -132,7 +134,7 @@ export function useInitializeQuestionMappedForm<TSelected = FormattedResponse>({
       form.setValue(fieldKey, value, { shouldDirty: false })
     })
 
-    successCallback?.(data.response, sectionData)
+    successCallback?.(data.response, sectionData, data.formattedData)
   }, [query.data, query.dataUpdatedAt]) // eslint-disable-line react-hooks/exhaustive-deps
 
   return query
@@ -178,7 +180,7 @@ export function useInitializeQuestionMappedFormMonitors<TSelected = FormattedMon
       form.setValue(fieldKey, value, { shouldDirty: false })
     })
 
-    successCallback?.(data.response, sectionData)
+    successCallback?.(data.response, sectionData, data.formattedData)
   }, [query.data, query.dataUpdatedAt]) // eslint-disable-line react-hooks/exhaustive-deps
 
   return query

--- a/mrtt-ui/src/library/question-mapped-form/useInitializeQuestionMappedForm.tsx
+++ b/mrtt-ui/src/library/question-mapped-form/useInitializeQuestionMappedForm.tsx
@@ -1,10 +1,16 @@
-import { useQuery, UseQueryResult, UseQueryOptions, useMutation } from '@tanstack/react-query'
+import {
+  useQuery,
+  useQueryClient,
+  UseQueryResult,
+  UseQueryOptions,
+  useMutation
+} from '@tanstack/react-query'
 import axios, { AxiosResponse } from 'axios'
+import { useEffect, useRef } from 'react'
 
 import { mapDataForApi } from '../../library/mapDataForApi'
 import { formatApiAnswersForFormByKey } from '../formatApiAnswersForForm'
 import { questionMapping } from '../../data/questionMapping'
-import { defaultValues } from '../../components/FormWrapper/FormSchemaValidation'
 import { FORM_NAMES_DICTIONARY_INTERVENTIONS } from '../../constants/sectionNames'
 import { toast } from 'react-toastify'
 
@@ -31,7 +37,7 @@ type ApiAnswerItem = {
 
 export type FormattedResponse = {
   response: AxiosResponse<ApiAnswerItem[]>
-  formattedData: unknown
+  formattedData: Record<string, Record<string, unknown>>
 }
 
 type ApiAnswerMonitorsItem = {
@@ -48,17 +54,19 @@ type ApiMonitorsFormResponse = {
 
 export type FormattedMonitorsResponse = {
   response: AxiosResponse<ApiMonitorsFormResponse>
-  formattedData: unknown
+  formattedData: Record<string, Record<string, unknown>>
 }
 
 type Params<TSelected = FormattedResponse> = {
-  key: 'projectDetails' | 'siteBackground'
+  key: string
   apiUrl: string
-  siteId: string
-  targetKey: 'interventions' | 'monitors'
+  siteId?: string
+  form: UseFormReturn<any>
   questionMapping: unknown
-  resetForm: (values: unknown) => void
-  successCallback?: (response: AxiosResponse<ApiAnswerItem[]>) => void
+  successCallback?: (
+    response: AxiosResponse<ApiAnswerItem[]>,
+    sectionData: Record<string, unknown>
+  ) => void
   enabled?: boolean
   queryOptions?: Omit<
     UseQueryOptions<FormattedResponse, Error, TSelected, readonly unknown[]>,
@@ -70,7 +78,10 @@ type ParamsMonitors<TSelected = FormattedMonitorsResponse> = Omit<
   Params<any>,
   'successCallback' | 'queryOptions'
 > & {
-  successCallback?: (response: AxiosResponse<ApiMonitorsFormResponse>) => void
+  successCallback?: (
+    response: AxiosResponse<ApiMonitorsFormResponse>,
+    sectionData: Record<string, unknown>
+  ) => void
   queryOptions?: Omit<
     UseQueryOptions<FormattedMonitorsResponse, Error, TSelected, readonly unknown[]>,
     'queryKey' | 'queryFn' | 'enabled'
@@ -78,85 +89,105 @@ type ParamsMonitors<TSelected = FormattedMonitorsResponse> = Omit<
 }
 
 const queryOptionsDefault = {
-  refetchOnMount: 'always',
-  staleTime: 0
+  refetchOnMount: false,
+  staleTime: Infinity
 } as const
 
 export function useInitializeQuestionMappedForm<TSelected = FormattedResponse>({
   key,
   apiUrl,
   siteId,
-  resetForm,
+  form,
   questionMapping,
   successCallback,
   enabled = true,
   queryOptions
 }: Params<TSelected>): UseQueryResult<TSelected, Error> {
-  return useQuery<FormattedResponse, Error, TSelected>({
+  const lastPopulatedAt = useRef(0)
+
+  const query = useQuery<FormattedResponse, Error, TSelected>({
     queryKey: ['question-mapped-form', key, apiUrl, siteId],
     enabled: Boolean(enabled && key && apiUrl && !apiUrl.includes('undefined')),
     queryFn: async (): Promise<FormattedResponse> => {
       const response = await axios.get<ApiAnswerItem[]>(apiUrl)
 
-      const formattedData = await formatApiAnswersForFormByKey({
+      const formattedData = formatApiAnswersForFormByKey({
         apiAnswers: response.data,
         questionMapping
-      })
-
-      resetForm({
-        ...defaultValues,
-        ...formattedData[key]
-      })
-
-      successCallback?.(response)
+      }) as Record<string, Record<string, unknown>>
 
       return { response, formattedData }
     },
     ...queryOptionsDefault,
     ...queryOptions
   })
+
+  useEffect(() => {
+    if (!query.data || query.dataUpdatedAt === lastPopulatedAt.current) return
+    lastPopulatedAt.current = query.dataUpdatedAt
+
+    const data = query.data as unknown as FormattedResponse
+    const sectionData = data.formattedData[key] ?? {}
+    Object.entries(sectionData).forEach(([fieldKey, value]) => {
+      form.setValue(fieldKey, value, { shouldDirty: false })
+    })
+
+    successCallback?.(data.response, sectionData)
+  }, [query.data, query.dataUpdatedAt]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  return query
 }
 
 export function useInitializeQuestionMappedFormMonitors<TSelected = FormattedMonitorsResponse>({
   key,
   apiUrl,
   siteId,
-  resetForm,
+  form,
   questionMapping,
   successCallback,
   enabled = true,
   queryOptions
 }: ParamsMonitors<TSelected>): UseQueryResult<TSelected, Error> {
+  const lastPopulatedAt = useRef(0)
   const isQueryEnabled =
     Boolean(enabled) && Boolean(key) && Boolean(apiUrl) && !apiUrl.includes('undefined')
 
-  return useQuery<FormattedMonitorsResponse, Error, TSelected>({
+  const query = useQuery<FormattedMonitorsResponse, Error, TSelected>({
     queryKey: ['question-mapped-form-monitors', key, apiUrl, siteId],
     enabled: isQueryEnabled,
     queryFn: async (): Promise<FormattedMonitorsResponse> => {
       const response = await axios.get<ApiMonitorsFormResponse>(apiUrl)
-      const formattedData = await formatApiAnswersForFormByKey({
+      const formattedData = formatApiAnswersForFormByKey({
         apiAnswers: response.data.answers,
         questionMapping
-      })
-
-      resetForm({
-        ...defaultValues,
-        ...formattedData[key]
-      })
-
-      successCallback?.(response)
+      }) as Record<string, Record<string, unknown>>
 
       return { response, formattedData }
     },
     ...queryOptionsDefault,
     ...queryOptions
   })
+
+  useEffect(() => {
+    if (!query.data || query.dataUpdatedAt === lastPopulatedAt.current) return
+    lastPopulatedAt.current = query.dataUpdatedAt
+
+    const data = query.data as unknown as FormattedMonitorsResponse
+    const sectionData = data.formattedData[key] ?? {}
+    Object.entries(sectionData).forEach(([fieldKey, value]) => {
+      form.setValue(fieldKey, value, { shouldDirty: false })
+    })
+
+    successCallback?.(data.response, sectionData)
+  }, [query.data, query.dataUpdatedAt]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  return query
 }
 
 export function useSaveRegistrationSection<
   TFormValues extends Record<string, unknown> = Record<string, unknown>
 >({ siteId, form, section, sectionTarget, monitorId }: SaveRegistrationSectionParams<TFormValues>) {
+  const queryClient = useQueryClient()
   const apiUrl: Record<SectionTarget, string> = {
     interventions: `${process.env.REACT_APP_API_URL}/sites/${siteId}/registration_intervention_answers`,
     monitors: `${process.env.REACT_APP_API_URL}/sites/${siteId}/monitoring_answers${
@@ -180,6 +211,10 @@ export function useSaveRegistrationSection<
       }
 
       return axios.post(apiUrl.monitors, payload)
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ['question-mapped-form'] })
+      await queryClient.invalidateQueries({ queryKey: ['question-mapped-form-monitors'] })
     }
   })
 


### PR DESCRIPTION
This pull request refactors the way form initialization and data population are handled across multiple forms in the application. The main improvement is the migration from using a `resetForm` callback to directly passing the `form` object into the form initialization hooks. This enables more consistent and granular population of form fields and simplifies the callback signatures. Additionally, the `useInitializeQuestionMappedForm` and related hooks have been enhanced to better handle side effects and callbacks, and caching/query invalidation logic has been improved for better data consistency.

**Form Initialization and Data Population Refactor:**

* Replaced the `resetForm` callback parameter with the `form` object in all usages of `useInitializeQuestionMappedForm` and `useInitializeQuestionMappedFormMonitors` across all forms, enabling direct field population and simplifying the API. [[1]](diffhunk://#diff-68859b676bc8a05bd13e929862ce4c23e85fb12ac70ba9d3a8b3056d6be1e1bfL99-R99) [[2]](diffhunk://#diff-18a46ba3d06e1f56c0eeb62b98f7bdd40e25df3f111f6e047260b1a76c9ecd1cL152-R152) [[3]](diffhunk://#diff-7d9ba7abb5e0dd1419113fe2b0e50186a41e69917fe3830afacd65a21cc26fe9L197-R196) [[4]](diffhunk://#diff-1d2b59ff2ec93864cf941190e351613d3ade0f42a12421b5a44ab2ca862b9506L59-R59) [[5]](diffhunk://#diff-b58d7b973b69f3f1166c277ebc3afa49f5b1ae59999b6fb3821ee1ccf2756976L127-R126) [[6]](diffhunk://#diff-6155dbfa72018b08407ef10a792736dc5a835a9347c3432f48233e6bf0a7e368L63-R64) [[7]](diffhunk://#diff-a5a2de75d7f8492114cf9e4f5a617f31fb18573f07b4d88f14652ebca1f92712L32-R32) [[8]](diffhunk://#diff-32a4bc894fd100286c52dac51edaa15809da28cca7b34c4a181557976fdb23e5L60-R60) [[9]](diffhunk://#diff-d2f7f6e373e83b30beb9fda541bebb556052186763d12b46eeaa0a790b35e360L109-L111) [[10]](diffhunk://#diff-5e977ab780de3d8a0b9f446f0433511ea904f396b09beb25f5a230c059fa29a2L149-R170)

* Updated the hook implementations in `useInitializeQuestionMappedForm.tsx` to use the passed `form` object for setting field values, removed the dependency on `defaultValues`, and restructured the `successCallback` to provide both section and all-sections data. [[1]](diffhunk://#diff-68ae987b79ccf2434be6cd1a0c74e07b2edeb1e0405d56d4813acb30a95c7158L34-R40) [[2]](diffhunk://#diff-68ae987b79ccf2434be6cd1a0c74e07b2edeb1e0405d56d4813acb30a95c7158L51-R70) [[3]](diffhunk://#diff-68ae987b79ccf2434be6cd1a0c74e07b2edeb1e0405d56d4813acb30a95c7158L73-R192)

**Callback and Data Handling Improvements:**

* Enhanced the `successCallback` signature for both hooks to receive the API response, section data, and all-sections data, providing more flexibility for consumers (e.g., for cross-section dependencies like countries in interventions). [[1]](diffhunk://#diff-5e977ab780de3d8a0b9f446f0433511ea904f396b09beb25f5a230c059fa29a2L140-R140) [[2]](diffhunk://#diff-5e977ab780de3d8a0b9f446f0433511ea904f396b09beb25f5a230c059fa29a2L149-R170) [[3]](diffhunk://#diff-68ae987b79ccf2434be6cd1a0c74e07b2edeb1e0405d56d4813acb30a95c7158L34-R40) [[4]](diffhunk://#diff-68ae987b79ccf2434be6cd1a0c74e07b2edeb1e0405d56d4813acb30a95c7158L73-R192)

* Added a `useRef` and `useEffect` in the hooks to ensure form fields are only populated when new data arrives, preventing unnecessary resets and improving performance.

**Query and Caching Enhancements:**

* Adjusted the default query options to use `refetchOnMount: false` and `staleTime: Infinity` for better cache utilization.

* Added query invalidation logic to `useSaveRegistrationSection` to ensure data consistency after saving, by invalidating relevant queries.

**Component-Specific Improvements:**

* Updated the `CheckboxGroup` component to sync its internal state with controlled values using `useEffect`, ensuring UI consistency when the parent value changes. [[1]](diffhunk://#diff-32db97bfd618977a106b0114d7c67cedf8d692fe21886c1163ebdafbd728c822L3-R3) [[2]](diffhunk://#diff-32db97bfd618977a106b0114d7c67cedf8d692fe21886c1163ebdafbd728c822R48-R53)

* Improved monitor form date field handling in `QuestionNav.js` to correctly set form values based on the current monitor and section, removing unnecessary `useMemo` logic. [[1]](diffhunk://#diff-2b0f3c9972fcfd11cf6c1dabb6f281ba482989a805942a2242ab6a3735018222R29-R34) [[2]](diffhunk://#diff-2b0f3c9972fcfd11cf6c1dabb6f281ba482989a805942a2242ab6a3735018222R133-R134) [[3]](diffhunk://#diff-2b0f3c9972fcfd11cf6c1dabb6f281ba482989a805942a2242ab6a3735018222L135-R157)

These changes collectively make form data handling more robust, consistent, and maintainable across the codebase.