### PR TITLE
fix: reset shared form when active site changes

### DIFF
--- a/mrtt-ui/src/components/FormWrapper/FormWrapperProvider.js
+++ b/mrtt-ui/src/components/FormWrapper/FormWrapperProvider.js
@@ -1,8 +1,9 @@
 import 'react-toastify/dist/ReactToastify.css'
-import React from 'react'
+import React, { useEffect, useRef } from 'react'
 import PropTypes from 'prop-types'
 import { yupResolver } from '@hookform/resolvers/yup'
 import { FormProvider, useForm } from 'react-hook-form'
+import { useLocation } from 'react-router-dom'
 
 import { defaultValues, validationSchema } from './FormSchemaValidation'
 
@@ -16,6 +17,21 @@ function FormWrapperProvider({ children }) {
     resolver: yupResolver(validationSchema),
     defaultValues
   })
+
+  // The form instance is a singleton shared across all routes. Reset it to
+  // defaults whenever the active site changes so one site's answers don't carry
+  // over to the next. Provider sits outside <Routes>, so useParams() is empty
+  // here — derive the site id from the pathname instead.
+  const { pathname } = useLocation()
+  const siteId = pathname.match(/\/sites\/([^/]+)/)?.[1]
+  const prevSiteId = useRef(siteId)
+
+  useEffect(() => {
+    if (prevSiteId.current !== siteId) {
+      form.reset(defaultValues)
+      prevSiteId.current = siteId
+    }
+  }, [siteId]) // eslint-disable-line react-hooks/exhaustive-deps
 
   return <FormProvider {...form}>{children}</FormProvider>
 }


### PR DESCRIPTION
## Problem

A user filled in site information for one site, then went to add a second site, and the first site's answers appeared pre-filled on the second site's forms.

## Root cause

`App.js` mounts a single `<FormWrapperProvider>` **around all routes**, outside `<Routes>`. It creates one `react-hook-form` instance on mount and never resets it. Every detail/registration form (site background, project details, costs, interventions, etc.) consumes this singleton via `useFormContext()`, so values entered for site A persisted into site B. The per-section repopulation uses `setValue` only for fields present in the fetched data, so it never cleared site A's leftovers — and `SiteBackgroundForm` has its init hook commented out, making the carryover total.

Site creation itself (`SiteForm`) uses a separate local form, so the site name/landscape fields were unaffected — the bug was isolated to the shared detail forms.

## Fix

Reset the shared form to defaults whenever the active site changes, centralized in `FormWrapperProvider.js`. The provider sits outside `<Routes>` so `useParams()` is empty there — the site id is derived from the pathname via `useLocation()`.

- Reset fires only on a real site change → in-progress answers preserved while moving between sections of the same site.
- After reset, the existing per-section `useQuery` (keyed by `siteId`) repopulates the current site's saved answers.

Single file changed: `src/components/FormWrapper/FormWrapperProvider.js`.

## Test plan

- [ ] Open site A, fill site-background / project-details answers (no save needed).
- [ ] Open (or create) site B, open the same forms → shows site B's own data or empty defaults, none of site A's values.
- [ ] Within site A, move between sections (overview ↔ site-background) → in-progress answers NOT wiped.
- [ ] Existing-site edit still loads saved answers correctly.
