### PR TITLE
fix: replace explicit any with precise types in question-mapped-form

### DIFF
--- a/mrtt-ui/src/library/question-mapped-form/sections-hook.ts
+++ b/mrtt-ui/src/library/question-mapped-form/sections-hook.ts
@@ -41,5 +41,9 @@ export function useGetSectionTarget(
 ): SectionTarget {
   if (monitorId) return 'monitors'
 
-  return (SECTION_REGISTRY as any)[sectionFromUrl ?? '']?.target ?? null
+  return (
+    (SECTION_REGISTRY as Record<string, { target: SectionTarget; id: string; label: string }>)[
+      sectionFromUrl ?? ''
+    ]?.target ?? null
+  )
 }

--- a/mrtt-ui/src/library/question-mapped-form/useInitializeQuestionMappedForm.tsx
+++ b/mrtt-ui/src/library/question-mapped-form/useInitializeQuestionMappedForm.tsx
@@ -61,7 +61,7 @@ type Params<TSelected = FormattedResponse> = {
   key: string
   apiUrl: string
   siteId?: string
-  form: UseFormReturn<any>
+  form: UseFormReturn
   questionMapping: unknown
   successCallback?: (
     response: AxiosResponse<ApiAnswerItem[]>,
@@ -76,7 +76,7 @@ type Params<TSelected = FormattedResponse> = {
 }
 
 type ParamsMonitors<TSelected = FormattedMonitorsResponse> = Omit<
-  Params<any>,
+  Params,
   'successCallback' | 'queryOptions'
 > & {
   successCallback?: (


### PR DESCRIPTION
## Summary
Removes `any` usage in the question-mapped-form library, replacing with precise types to satisfy the no-explicit-any eslint rule.

- `sections-hook.ts` — replace `(SECTION_REGISTRY as any)` with a typed `Record<string, { target: SectionTarget; id: string; label: string }>` cast.
- `useInitializeQuestionMappedForm.tsx` — drop `<any>` from `UseFormReturn<any>` and `Params<any>`, falling back to the type defaults.

## Test plan
- [ ] Lint passes (no `no-explicit-any` violations)
- [ ] No TypeScript errors
- [ ] Question-mapped form still initializes and resolves section target correctly